### PR TITLE
Add `mem0_memory` tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 .mypy_cache
 errors/
 repl_state/
+venv/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Agents Tools is an open-source Python library that provides a unified toolkit fo
 
 - 📁 **File Operations** - Read, write, and edit files with syntax highlighting and intelligent modifications
 - 🖥️ **Shell Integration** - Execute and interact with shell commands securely
-- 🧠 **Mem0 Memory** - Store user and agent memories across agent runs to provide personalized experience
+- 🧠 **Mem0 Memory** - Store user and agent memories across agent runs to provide personalized experience 
 - 🌐 **HTTP Client** - Make API requests with comprehensive authentication support
 - 🐍 **Python Execution** - Run Python code snippets with state persistence, user confirmation for code execution, and safety features
 - 🧮 **Mathematical Tools** - Perform advanced calculations with symbolic math capabilities

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Agents Tools is an open-source Python library that provides a unified toolkit fo
 
 - 📁 **File Operations** - Read, write, and edit files with syntax highlighting and intelligent modifications
 - 🖥️ **Shell Integration** - Execute and interact with shell commands securely
+- 🧠 **Mem0 Memory** - Store user and agent memories across agent runs to provide personalized experience
 - 🌐 **HTTP Client** - Make API requests with comprehensive authentication support
 - 🐍 **Python Execution** - Run Python code snippets with state persistence, user confirmation for code execution, and safety features
 - 🧮 **Mathematical Tools** - Perform advanced calculations with symbolic math capabilities
@@ -74,6 +75,7 @@ Below is a comprehensive table of all available tools, how to use them with an a
 | use_aws | `agent.tool.use_aws(service_name="s3", operation_name="list_buckets", parameters={}, region="us-west-2")` | Interacting with AWS services, cloud resource management |
 | retrieve | `agent.tool.retrieve(text="What is STRANDS?")` | Retrieving information from Amazon Bedrock Knowledge Bases |
 | nova_reels | `agent.tool.nova_reels(action="create", text="A cinematic shot of mountains", s3_bucket="my-bucket")` | Create high-quality videos using Amazon Bedrock Nova Reel with configurable parameters via environment variables |
+| mem0_memory | `agent.tool.mem0_memory(action="store", content="Remember I like to tennis", user_id="alex")` | Store user and agent memories across agent runs to provide personalized experience |
 | memory | `agent.tool.memory(action="retrieve", query="product features")` | Store, retrieve, list, and manage documents in Amazon Bedrock Knowledge Bases with configurable parameters via environment variables |
 | environment | `agent.tool.environment(action="list", prefix="AWS_")` | Managing environment variables, configuration management |
 | generate_image | `agent.tool.generate_image(prompt="A sunset over mountains")` | Creating AI-generated images for various applications |
@@ -233,6 +235,12 @@ These variables affect multiple tools:
 | Environment Variable | Description | Default | 
 |----------------------|-------------|---------|
 | DEFAULT_TIMEZONE | Default timezone for current_time tool | UTC |
+
+#### Mem0 Memory Tool
+
+| Environment Variable | Description | Default |
+|----------------------|-------------|---------|
+| OPENSEARCH_HOST | OpenSearch Host URL | None |
 
 #### Memory Tool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
     "tenacity>=9.1.2,<10.0.0",
     "watchdog>=6.0.0,<7.0.0",
     "slack_bolt>=1.23.0,<2.0.0",
+    "mem0ai>=0.1.99,<1.0.0",
+    "opensearch-py>=2.8.0,<3.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/strands_tools/mem0_memory.py
+++ b/src/strands_tools/mem0_memory.py
@@ -1,0 +1,622 @@
+"""
+Tool for managing memories using Mem0 (store, delete, list, get, and retrieve)
+
+This module provides comprehensive memory management capabilities using
+Mem0 as the backend. It handles all aspects of memory management with
+a user-friendly interface and proper error handling.
+
+Key Features:
+------------
+1. Memory Management:
+   • store: Add new memories with automatic ID generation and metadata
+   • delete: Remove existing memories using memory IDs
+   • list: Retrieve all memories for a user or agent
+   • get: Retrieve specific memories by memory ID
+   • retrieve: Perform semantic search across all memories
+
+2. Safety Features:
+   • User confirmation for mutative operations
+   • Content previews before storage
+   • Warning messages before deletion
+   • DEV mode for bypassing confirmations in tests
+
+3. Advanced Capabilities:
+   • Automatic memory ID generation
+   • Structured memory storage with metadata
+   • Semantic search with relevance filtering
+   • Rich output formatting
+   • Support for both user and agent memories
+
+4. Error Handling:
+   • Memory ID validation
+   • Parameter validation
+   • Graceful API error handling
+   • Clear error messages
+
+Usage Examples:
+--------------
+```python
+from strands import Agent
+from strands_tools import mem0_memory
+
+agent = Agent(tools=[mem0_memory])
+
+# Store memory in Memory
+agent.tool.mem0_memory(
+    action="store",
+    content="Important information to remember",
+    user_id="alex",  # or agent_id="agent1"
+    metadata={"category": "meeting_notes"}
+)
+
+# Retrieve content using semantic search
+agent.tool.mem0_memory(
+    action="retrieve",
+    query="meeting information",
+    user_id="alex"  # or agent_id="agent1"
+)
+
+# List all memories
+agent.tool.mem0_memory(
+    action="list",
+    user_id="alex"  # or agent_id="agent1"
+)
+```
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import boto3
+from mem0 import Memory as Mem0Memory
+from opensearchpy import AWSV4SignerAuth, RequestsHttpConnection
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+from strands.types.tools import ToolResult, ToolResultContent, ToolUse
+
+# Set up logging
+logger = logging.getLogger(__name__)
+
+# Initialize Rich console
+console = Console()
+
+TOOL_SPEC = {
+    "name": "mem0_memory",
+    "description": (
+        "Memory management tool for storing, retrieving, and managing memories in Mem0.\n\n"
+        "Features:\n"
+        "1. Store memories with metadata (requires user_id or agent_id)\n"
+        "2. Retrieve memories by ID or semantic search (requires user_id or agent_id)\n"
+        "3. List all memories for a user/agent (requires user_id or agent_id)\n"
+        "4. Delete memories\n"
+        "5. Get memory history\n\n"
+        "Actions:\n"
+        "- store: Store new memory (requires user_id or agent_id)\n"
+        "- get: Get memory by ID\n"
+        "- list: List all memories (requires user_id or agent_id)\n"
+        "- retrieve: Semantic search (requires user_id or agent_id)\n"
+        "- delete: Delete memory\n"
+        "- history: Get memory history\n\n"
+        "Note: Most operations require either user_id or agent_id to be specified. The tool will automatically "
+        "attempt to retrieve relevant memories when user_id or agent_id is available."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": ("Action to perform (store, get, list, retrieve, delete, history)"),
+                    "enum": ["store", "get", "list", "retrieve", "delete", "history"],
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Content to store (required for store action)",
+                },
+                "memory_id": {
+                    "type": "string",
+                    "description": "Memory ID (required for get, delete, history actions)",
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Search query (required for retrieve action)",
+                },
+                "user_id": {
+                    "type": "string",
+                    "description": "User ID for the memory operations (required for store, list, retrieve actions)",
+                },
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID for the memory operations (required for store, list, retrieve actions)",
+                },
+                "metadata": {
+                    "type": "object",
+                    "description": "Optional metadata to store with the memory",
+                },
+            },
+            "required": ["action"],
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "action": {"enum": ["store", "list", "retrieve"]}
+                        }
+                    },
+                    "then": {
+                        "oneOf": [
+                            {"required": ["user_id"]},
+                            {"required": ["agent_id"]}
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+}
+
+
+class Mem0ServiceClient:
+    """Client for interacting with Mem0 service."""
+
+    DEFAULT_CONFIG = {
+        "embedder": {"provider": "aws_bedrock", "config": {"model": "amazon.titan-embed-text-v2:0"}},
+        "llm": {
+            "provider": "aws_bedrock",
+            "config": {
+                "model": "anthropic.claude-3-5-haiku-20241022-v1:0",
+                "temperature": 0.1,
+                "max_tokens": 2000,
+            },
+        },
+        "vector_store": {
+            "provider": "opensearch",
+            "config": {
+                "port": 443,
+                "collection_name": "mem0_memories",
+                "host": os.environ.get("OPENSEARCH_HOST"),
+                "embedding_model_dims": 1024,
+                "connection_class": RequestsHttpConnection,
+                "pool_maxsize": 20,
+                "use_ssl": True,
+                "verify_certs": True,
+            },
+        },
+    }
+
+    def __init__(self, config: Optional[Dict] = None):
+        """Initialize the Mem0 service client.
+
+        Args:
+            config: Optional configuration dictionary to override defaults.
+                   If provided, it will be merged with DEFAULT_CONFIG.
+
+        Raises:
+            ValueError: If OPENSEARCH_HOST environment variable is not set.
+        """
+        # Check if region is set in environment variables, default to us-west-2 if not
+        self.region = os.environ.get("AWS_REGION")
+        if not self.region:
+            os.environ["AWS_REGION"] = "us-west-2"
+            self.region = "us-west-2"
+
+        # Check for required OPENSEARCH_HOST
+        opensearch_host = os.environ.get("OPENSEARCH_HOST")
+        if not opensearch_host:
+            raise ValueError(
+                "OPENSEARCH_HOST environment variable is required but not set. "
+                "Please set it to your OpenSearch endpoint "
+                "(e.g., 'your-domain.us-west-2.aoss.amazonaws.com')"
+            )
+
+        # Set up session
+        session = boto3.Session()
+        credentials = session.get_credentials()
+        auth = AWSV4SignerAuth(credentials, self.region, "aoss")
+
+        # Start with default config
+        merged_config = self.DEFAULT_CONFIG.copy()
+        # If user provided config, merge it with defaults
+        if config:
+            # Deep merge the configs
+            for key, value in config.items():
+                if key in merged_config and isinstance(value, dict) and isinstance(merged_config[key], dict):
+                    merged_config[key].update(value)
+                else:
+                    merged_config[key] = value
+
+        # Add auth and host to vector store config
+        merged_config["vector_store"]["config"]["http_auth"] = auth
+        merged_config["vector_store"]["config"]["host"] = opensearch_host
+
+        self.mem0 = Mem0Memory.from_config(config_dict=merged_config)
+
+    def store_memory(
+        self,
+        content: str,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        metadata: Optional[Dict] = None,
+    ):
+        """Store a memory in Mem0."""
+        if not user_id and not agent_id:
+            raise ValueError("Either user_id or agent_id must be provided")
+
+        messages = [{"role": "user", "content": content}]
+        return self.mem0.add(messages, user_id=user_id, agent_id=agent_id, metadata=metadata)
+
+    def get_memory(self, memory_id: str):
+        """Get a memory by ID."""
+        return self.mem0.get(memory_id)
+
+    def list_memories(self, user_id: Optional[str] = None, agent_id: Optional[str] = None):
+        """List all memories for a user or agent."""
+        if not user_id and not agent_id:
+            raise ValueError("Either user_id or agent_id must be provided")
+
+        return self.mem0.get_all(user_id=user_id, agent_id=agent_id)
+
+    def search_memories(self, query: str, user_id: Optional[str] = None, agent_id: Optional[str] = None):
+        """Search memories using semantic search."""
+        if not user_id and not agent_id:
+            raise ValueError("Either user_id or agent_id must be provided")
+
+        return self.mem0.search(query=query, user_id=user_id, agent_id=agent_id)
+
+    def delete_memory(self, memory_id: str):
+        """Delete a memory by ID."""
+        return self.mem0.delete(memory_id)
+
+    def get_memory_history(self, memory_id: str):
+        """Get the history of a memory by ID."""
+        return self.mem0.get_history(memory_id)
+
+
+def format_get_response(memory: Dict) -> Panel:
+    """Format get memory response."""
+    memory_id = memory.get("id", "unknown")
+    content = memory.get("memory", "No content available")
+    metadata = memory.get("metadata")
+    created_at = memory.get("created_at", "Unknown")
+    user_id = memory.get("user_id", "Unknown")
+
+    result = [
+        "✅ Memory retrieved successfully:",
+        f"🔑 Memory ID: {memory_id}",
+        f"👤 User ID: {user_id}",
+        f"🕒 Created: {created_at}",
+    ]
+
+    if metadata:
+        result.append(f"📋 Metadata: {json.dumps(metadata, indent=2)}")
+
+    result.append(f"\n📄 Memory: {content}")
+
+    return Panel("\n".join(result), title="[bold green]Memory Retrieved", border_style="green")
+
+
+def format_list_response(memories: Dict) -> Panel:
+    """Format list memories response."""
+    if not memories.get("results"):
+        return Panel("No memories found.", title="[bold yellow]No Memories", border_style="yellow")
+
+    table = Table(title="Memories", show_header=True, header_style="bold magenta")
+    table.add_column("ID", style="cyan")
+    table.add_column("Memory", style="yellow", width=50)
+    table.add_column("Created At", style="blue")
+    table.add_column("User ID", style="green")
+    table.add_column("Metadata", style="magenta")
+
+    for memory in memories.get("results", []):
+        memory_id = memory.get("id", "unknown")
+        content = memory.get("memory", "No content available")
+        created_at = memory.get("created_at", "Unknown")
+        user_id = memory.get("user_id", "Unknown")
+        metadata = memory.get("metadata", {})
+
+        # Truncate content if too long
+        content_preview = content[:100] + "..." if len(content) > 100 else content
+
+        # Format metadata for display
+        metadata_str = json.dumps(metadata, indent=2) if metadata else "None"
+
+        table.add_row(memory_id, content_preview, created_at, user_id, metadata_str)
+
+    return Panel(table, title="[bold green]Memories List", border_style="green")
+
+
+def format_delete_response(memory_id: str) -> Panel:
+    """Format delete memory response."""
+    content = [
+        "✅ Memory deleted successfully:",
+        f"🔑 Memory ID: {memory_id}",
+    ]
+    return Panel("\n".join(content), title="[bold green]Memory Deleted", border_style="green")
+
+
+def format_retrieve_response(memories: Dict) -> Panel:
+    """Format retrieve response."""
+    if not memories.get("results"):
+        return Panel("No memories found matching the query.", title="[bold yellow]No Matches", border_style="yellow")
+
+    table = Table(title="Search Results", show_header=True, header_style="bold magenta")
+    table.add_column("ID", style="cyan")
+    table.add_column("Memory", style="yellow", width=50)
+    table.add_column("Relevance", style="green")
+    table.add_column("Created At", style="blue")
+    table.add_column("User ID", style="magenta")
+    table.add_column("Metadata", style="white")
+
+    for memory in memories.get("results", []):
+        memory_id = memory.get("id", "unknown")
+        content = memory.get("memory", "No content available")
+        score = memory.get("score", 0)
+        created_at = memory.get("created_at", "Unknown")
+        user_id = memory.get("user_id", "Unknown")
+        metadata = memory.get("metadata", {})
+
+        # Truncate content if too long
+        content_preview = content[:100] + "..." if len(content) > 100 else content
+
+        # Format metadata for display
+        metadata_str = json.dumps(metadata, indent=2) if metadata else "None"
+
+        # Color code the relevance score
+        if score > 0.8:
+            score_color = "green"
+        elif score > 0.5:
+            score_color = "yellow"
+        else:
+            score_color = "red"
+
+        table.add_row(
+            memory_id, content_preview, f"[{score_color}]{score}[/{score_color}]", created_at, user_id, metadata_str
+        )
+
+    return Panel(table, title="[bold green]Search Results", border_style="green")
+
+
+def format_history_response(history: List[Dict]) -> Panel:
+    """Format memory history response."""
+    if not history:
+        return Panel("No history found for this memory.", title="[bold yellow]No History", border_style="yellow")
+
+    table = Table(title="Memory History", show_header=True, header_style="bold magenta")
+    table.add_column("ID", style="cyan")
+    table.add_column("Memory ID", style="green")
+    table.add_column("Event", style="yellow")
+    table.add_column("Old Memory", style="blue", width=30)
+    table.add_column("New Memory", style="blue", width=30)
+    table.add_column("Created At", style="magenta")
+
+    for entry in history:
+        entry_id = entry.get("id", "unknown")
+        memory_id = entry.get("memory_id", "unknown")
+        event = entry.get("event", "UNKNOWN")
+        old_memory = entry.get("old_memory", "None")
+        new_memory = entry.get("new_memory", "None")
+        created_at = entry.get("created_at", "Unknown")
+
+        # Truncate memory content if too long
+        old_memory_preview = old_memory[:100] + "..." if old_memory and len(old_memory) > 100 else old_memory
+        new_memory_preview = new_memory[:100] + "..." if new_memory and len(new_memory) > 100 else new_memory
+
+        table.add_row(entry_id, memory_id, event, old_memory_preview, new_memory_preview, created_at)
+
+    return Panel(table, title="[bold green]Memory History", border_style="green")
+
+
+def format_store_response(results: Dict) -> Panel:
+    """Format store memory response."""
+    table = Table(title="Memory Stored", show_header=True, header_style="bold magenta")
+    table.add_column("Operation", style="green")
+    table.add_column("Content", style="yellow", width=50)
+
+    for memory in results.get("results", []):
+        event, text = memory.get("event"), memory.get("memory")
+        # Truncate content if too long
+        content_preview = text[:100] + "..." if len(text) > 100 else text
+        table.add_row(event, content_preview)
+
+    return Panel(table, title="[bold green]Memory Stored", border_style="green")
+
+
+def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """
+    Memory management tool for storing, retrieving, and managing memories in Mem0.
+
+    This tool provides a comprehensive interface for managing memories with Mem0,
+    including storing new memories, retrieving existing ones, listing all memories,
+    performing semantic searches, and managing memory history.
+
+    Args:
+        tool: ToolUse object containing the following input fields:
+            - action: The action to perform (store, get, list, retrieve, delete, history)
+            - content: Content to store (for store action)
+            - memory_id: Memory ID (for get, delete, history actions)
+            - query: Search query (for retrieve action)
+            - user_id: User ID for the memory operations
+            - agent_id: Agent ID for the memory operations
+            - metadata: Optional metadata to store with the memory
+        **kwargs: Additional keyword arguments
+
+    Returns:
+        ToolResult containing status and response content
+    """
+    try:
+        # Extract input from tool use object
+        tool_input = tool.get("input", {})
+        tool_use_id = tool.get("toolUseId", "default-id")
+
+        # Validate required parameters
+        if not tool_input.get("action"):
+            raise ValueError("action parameter is required")
+
+        # Initialize client
+        client = Mem0ServiceClient()
+
+        # Check if we're in development mode
+        strands_dev = os.environ.get("DEV", "").lower() == "true"
+
+        # Handle different actions
+        action = tool_input["action"]
+
+        # For mutative operations, show confirmation dialog unless in DEV mode
+        mutative_actions = {"store", "delete"}
+        needs_confirmation = action in mutative_actions and not strands_dev
+
+        if needs_confirmation:
+            if action == "store":
+                # Validate content
+                if not tool_input.get("content"):
+                    raise ValueError("content is required for store action")
+
+                # Preview what will be stored
+                content_preview = (
+                    tool_input["content"][:15000] + "..."
+                    if len(tool_input["content"]) > 15000
+                    else tool_input["content"]
+                )
+                preview_title = (
+                    f"Memory for {'user ' + tool_input.get('user_id', '')}"
+                    if tool_input.get("user_id")
+                    else f"agent {tool_input.get('agent_id', '')}"
+                )
+
+                console.print(Panel(content_preview, title=f"[bold green]{preview_title}", border_style="green"))
+
+            elif action == "delete":
+                # Validate memory_id
+                if not tool_input.get("memory_id"):
+                    raise ValueError("memory_id is required for delete action")
+
+                # Try to get memory info first for better context
+                try:
+                    memory = client.get_memory(tool_input["memory_id"])
+                    metadata = memory.get("metadata", {})
+
+                    console.print(
+                        Panel(
+                            (
+                                f"Memory ID: {tool_input['memory_id']}\n"
+                                f"Metadata: {json.dumps(metadata) if metadata else 'None'}"
+                            ),
+                            title="[bold red]⚠️ Memory to be permanently deleted",
+                            border_style="red",
+                        )
+                    )
+                except Exception:
+                    # Fall back to basic info if we can't get memory details
+                    console.print(
+                        Panel(
+                            f"Memory ID: {tool_input['memory_id']}",
+                            title="[bold red]⚠️ Memory to be permanently deleted",
+                            border_style="red",
+                        )
+                    )
+
+        # Execute the requested action
+        if action == "store":
+            if not tool_input.get("content"):
+                raise ValueError("content is required for store action")
+
+            results = client.store_memory(
+                tool_input["content"],
+                tool_input.get("user_id"),
+                tool_input.get("agent_id"),
+                tool_input.get("metadata"),
+            )
+
+            if results.get("results"):
+                panel = format_store_response(results)
+                console.print(panel)
+            return ToolResult(
+                toolUseId=tool_use_id,
+                status="success",
+                content=[ToolResultContent(text=f"Successfully stored {len(results.get('results', []))} memories")]
+            )
+
+        elif action == "get":
+            if not tool_input.get("memory_id"):
+                raise ValueError("memory_id is required for get action")
+
+            memory = client.get_memory(tool_input["memory_id"])
+            panel = format_get_response(memory)
+            console.print(panel)
+            return ToolResult(
+                toolUseId=tool_use_id,
+                status="success",
+                content=[ToolResultContent(text=json.dumps(memory, indent=2))]
+            )
+
+        elif action == "list":
+            memories = client.list_memories(tool_input.get("user_id"), tool_input.get("agent_id"))
+            panel = format_list_response(memories)
+            console.print(panel)
+            return ToolResult(
+                toolUseId=tool_use_id,
+                status="success",
+                content=[ToolResultContent(text=json.dumps(memories.get("results", []), indent=2))]
+            )
+
+        elif action == "retrieve":
+            if not tool_input.get("query"):
+                raise ValueError("query is required for retrieve action")
+
+            memories = client.search_memories(
+                tool_input["query"],
+                tool_input.get("user_id"),
+                tool_input.get("agent_id"),
+            )
+            panel = format_retrieve_response(memories)
+            console.print(panel)
+            return ToolResult(
+                toolUseId=tool_use_id,
+                status="success",
+                content=[ToolResultContent(text=json.dumps(memories.get("results", []), indent=2))]
+            )
+
+        elif action == "delete":
+            if not tool_input.get("memory_id"):
+                raise ValueError("memory_id is required for delete action")
+
+            client.delete_memory(tool_input["memory_id"])
+            panel = format_delete_response(tool_input["memory_id"])
+            console.print(panel)
+            return ToolResult(
+                toolUseId=tool_use_id,
+                status="success",
+                content=[ToolResultContent(text=f"Memory {tool_input['memory_id']} deleted successfully")]
+            )
+
+        elif action == "history":
+            if not tool_input.get("memory_id"):
+                raise ValueError("memory_id is required for history action")
+
+            history = client.get_memory_history(tool_input["memory_id"])
+            panel = format_history_response(history)
+            console.print(panel)
+            return ToolResult(
+                toolUseId=tool_use_id,
+                status="success",
+                content=[ToolResultContent(text=json.dumps(history, indent=2))]
+            )
+
+        else:
+            raise ValueError(f"Invalid action: {action}")
+
+    except Exception as e:
+        error_panel = Panel(
+            Text(str(e), style="red"),
+            title="❌ Memory Operation Error",
+            border_style="red",
+        )
+        console.print(error_panel)
+        return ToolResult(
+            toolUseId=tool_use_id,
+            status="error",
+            content=[ToolResultContent(text=f"Error: {str(e)}")]
+        )

--- a/tests/test_mem0.py
+++ b/tests/test_mem0.py
@@ -1,0 +1,408 @@
+"""
+Tests for the memory tool using the Agent interface.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+import json
+
+import pytest
+from strands import Agent
+from strands.types.tools import ToolUse
+from strands_tools import mem0_memory
+from strands_tools.mem0_memory import Mem0ServiceClient
+
+
+@pytest.fixture
+def agent():
+    """Create an agent with the memory tool loaded."""
+    return Agent(tools=[mem0_memory])
+
+
+@pytest.fixture
+def mock_mem0_service_client():
+    """Create a mock mem0 service client."""
+    client = MagicMock(spec=Mem0ServiceClient)
+    return client
+
+
+@pytest.fixture
+def mock_tool():
+    """Create a mock tool use object that properly mocks the tool interface."""
+    mock = MagicMock(spec=ToolUse)
+    # Set up the get method to behave like a dictionary get
+    mock.get = MagicMock()
+    mock.get.return_value = {}
+    # Set a default tool use ID
+    mock.get.side_effect = lambda key, default=None: {"toolUseId": "test-id", "input": {}}.get(key, default)
+    return mock
+
+
+def extract_result_text(result):
+    """Extract the result text from the agent response."""
+    if isinstance(result, dict) and "content" in result and isinstance(result["content"], list):
+        content = result["content"][0]
+        # Handle different response formats
+        if isinstance(content, dict):
+            if "text" in content:
+                return content["text"]
+            # Return the first key-value pair if it's a memory object
+            elif "id" in content and "memory" in content:
+                return content["memory"]
+    return str(result)
+
+
+@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_store_memory(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """Test store memory functionality."""
+    # Setup mocks
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    # Configure the mock_tool
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {
+            "action": "store",
+            "content": "Test memory content",
+            "user_id": "test_user",
+            "metadata": {"category": "test"},
+        },
+    }.get(key, default)
+
+    # Mock data
+    store_response = {
+        "results": [
+            {
+                "event": "store",
+                "memory": "Test memory content",
+                "id": "mem123",
+                "created_at": "2024-03-20T10:00:00Z",
+            }
+        ]
+    }
+
+    # Configure mocks
+    mock_mem0_service_client.store_memory.return_value = store_response
+
+    # Call the memory function
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    # Assertions
+    assert result["status"] == "success"
+    assert "Successfully stored" in str(result["content"][0]["text"])
+
+    # Verify correct functions were called - check just that it was called with the right values
+    mock_mem0_service_client.store_memory.assert_called_once()
+    call_args, call_kwargs = mock_mem0_service_client.store_memory.call_args
+    assert call_args[0] == "Test memory content"
+    assert call_args[1] == "test_user" or call_kwargs.get("user_id") == "test_user"
+    assert call_args[3] == {"category": "test"} or call_kwargs.get("metadata") == {"category": "test"}
+
+
+@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_get_memory(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """Test get memory functionality."""
+    # Setup mocks
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    # Configure the mock_tool
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "get", "memory_id": "mem123"},
+    }.get(key, default)
+
+    # Mock data
+    get_response = {
+        "id": "mem123",
+        "memory": "Test memory content",
+        "created_at": "2024-03-20T10:00:00Z",
+        "user_id": "test_user",
+        "metadata": {"category": "test"},
+    }
+
+    # Configure mocks
+    mock_mem0_service_client.get_memory.return_value = get_response
+
+    # Call the memory function
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    # Assertions
+    assert result["status"] == "success"
+    assert isinstance(result["content"], list)
+    assert len(result["content"]) > 0
+    assert "text" in result["content"][0]
+    memory = json.loads(result["content"][0]["text"])
+    assert memory["id"] == "mem123"
+    assert memory["memory"] == "Test memory content"
+    assert memory["user_id"] == "test_user"
+    assert memory["metadata"] == {"category": "test"}
+
+
+@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_list_memories(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """Test list memories functionality."""
+    # Setup mocks
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    # Configure the mock_tool
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "list", "user_id": "test_user"},
+    }.get(key, default)
+
+    # Mock data for list_memories response - the memory.py expects this format
+    list_response = {
+        "results": [
+            {
+                "id": "mem123",
+                "memory": "Test memory content",
+                "created_at": "2024-03-20T10:00:00Z",
+                "user_id": "test_user",
+                "metadata": {"category": "test"},
+            }
+        ]
+    }
+
+    # Configure mocks
+    mock_mem0_service_client.list_memories.return_value = list_response
+
+    # Call the memory function
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    # Assertions
+    assert result["status"] == "success"
+    assert isinstance(result["content"], list)
+    assert len(result["content"]) > 0
+    assert "text" in result["content"][0]
+    # Parse the JSON string in text
+    memories = json.loads(result["content"][0]["text"])
+    assert isinstance(memories, list)
+    assert len(memories) > 0
+    assert "id" in memories[0]
+    assert memories[0]["id"] == "mem123"
+
+
+@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_retrieve_memories(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """Test retrieve memories functionality."""
+    # Setup mocks
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    # Configure the mock_tool
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "retrieve", "query": "test query", "user_id": "test_user"},
+    }.get(key, default)
+
+    # Mock data for search_memories response - the memory.py expects this format
+    retrieve_response = {
+        "results": [
+            {
+                "id": "mem123",
+                "memory": "Test memory content",
+                "score": 0.85,
+                "created_at": "2024-03-20T10:00:00Z",
+                "user_id": "test_user",
+                "metadata": {"category": "test"},
+            }
+        ]
+    }
+
+    # Configure mocks
+    mock_mem0_service_client.search_memories.return_value = retrieve_response
+
+    # Call the memory function
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    # Assertions
+    assert result["status"] == "success"
+    assert isinstance(result["content"], list)
+    assert len(result["content"]) > 0
+    assert "text" in result["content"][0]
+    # Parse the JSON string in text
+    memories = json.loads(result["content"][0]["text"])
+    assert isinstance(memories, list)
+    assert len(memories) > 0
+    assert "id" in memories[0]
+    assert memories[0]["id"] == "mem123"
+
+
+@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com", "DEV": "true"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_delete_memory(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """Test delete memory functionality with DEV mode enabled."""
+    # Setup mocks
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    # Configure the mock_tool
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "delete", "memory_id": "mem123"},
+    }.get(key, default)
+
+    # Configure mocks
+    mock_mem0_service_client.delete_memory.return_value = {"status": "success"}
+
+    # Call the memory function
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    # Assertions
+    assert result["status"] == "success"
+    assert "Memory mem123 deleted successfully" in str(result["content"][0]["text"])
+
+    # Verify correct functions were called
+    mock_mem0_service_client.delete_memory.assert_called_once()
+    call_args = mock_mem0_service_client.delete_memory.call_args[0]
+    assert call_args[0] == "mem123"
+
+
+@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_get_memory_history(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """Test get memory history functionality."""
+    # Setup mocks
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    # Configure the mock_tool
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "history", "memory_id": "mem123"},
+    }.get(key, default)
+
+    # Mock data
+    history_response = [
+        {
+            "id": "hist123",
+            "memory_id": "mem123",
+            "event": "store",
+            "old_memory": None,
+            "new_memory": "Test memory content",
+            "created_at": "2024-03-20T10:00:00Z",
+        }
+    ]
+
+    # Configure mocks
+    mock_mem0_service_client.get_memory_history.return_value = history_response
+
+    # Call the memory function
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    # Assertions
+    assert result["status"] == "success"
+    assert isinstance(result["content"], list)
+    assert len(result["content"]) > 0
+    assert "text" in result["content"][0]
+    # Parse the JSON string in text
+    history = json.loads(result["content"][0]["text"])
+    assert isinstance(history, list)
+    assert len(history) > 0
+    assert "id" in history[0]
+    assert history[0]["id"] == "hist123"
+
+
+@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_invalid_action(mock_opensearch, mock_mem0_client, mock_tool):
+    """Test invalid action."""
+    # Configure the mock_tool
+    mock_tool.get.side_effect = lambda key, default=None: {"toolUseId": "test-id", "input": {"action": "invalid"}}.get(
+        key, default
+    )
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    assert "Invalid action" in str(result["content"][0]["text"])
+
+
+@patch.dict(os.environ, {})
+def test_missing_opensearch_host(mock_tool):
+    """Test missing OpenSearch host."""
+    # Configure the mock_tool
+    mock_tool.get.side_effect = lambda key, default=None: {"toolUseId": "test-id", "input": {"action": "list"}}.get(
+        key, default
+    )
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    assert "OPENSEARCH_HOST environment variable is required" in str(result["content"][0]["text"])
+
+
+@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_action_specific_missing_params(mock_opensearch, mock_mem0_client, mock_tool):
+    """Test missing action-specific parameters."""
+    # Setup mock
+    mock_client = MagicMock()
+    mock_mem0_client.return_value = mock_client
+
+    # Test missing content for store action
+    mock_tool.get.side_effect = lambda key, default=None: {"toolUseId": "test-id", "input": {"action": "store"}}.get(
+        key, default
+    )
+    store_result = mem0_memory.mem0_memory(tool=mock_tool)
+    assert store_result["status"] == "error"
+    assert "content is required for store action" in str(store_result["content"][0]["text"])
+
+    # Test missing memory_id for delete action
+    mock_tool.get.side_effect = lambda key, default=None: {"toolUseId": "test-id", "input": {"action": "delete"}}.get(
+        key, default
+    )
+    delete_result = mem0_memory.mem0_memory(tool=mock_tool)
+    assert delete_result["status"] == "error"
+    assert "memory_id is required for delete action" in str(delete_result["content"][0]["text"])
+
+    # Test missing memory_id for get action
+    mock_tool.get.side_effect = lambda key, default=None: {"toolUseId": "test-id", "input": {"action": "get"}}.get(
+        key, default
+    )
+    get_result = mem0_memory.mem0_memory(tool=mock_tool)
+    assert get_result["status"] == "error"
+    assert "memory_id is required for get action" in str(get_result["content"][0]["text"])
+
+    # Test missing query for retrieve action
+    mock_tool.get.side_effect = lambda key, default=None: {"toolUseId": "test-id", "input": {"action": "retrieve"}}.get(
+        key, default
+    )
+    retrieve_result = mem0_memory.mem0_memory(tool=mock_tool)
+    assert retrieve_result["status"] == "error"
+    assert "query is required for retrieve action" in str(retrieve_result["content"][0]["text"])
+
+
+@patch("boto3.Session")
+@patch("strands_tools.mem0_memory.Mem0Memory")
+@patch("opensearchpy.OpenSearch")
+def test_mem0_service_client_init(mock_opensearch, mock_mem0_memory, mock_session):
+    """Test Mem0ServiceClient initialization."""
+    # Mock session and credentials
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "test-access-key"
+    mock_credentials.secret_key = "test-secret-key"
+    mock_session.return_value.get_credentials.return_value = mock_credentials
+
+    # Test with default parameters
+    with patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"}):
+        client = Mem0ServiceClient()
+        assert client.region == os.environ.get("AWS_REGION", "us-west-2")
+
+    # Test with custom config
+    custom_config = {
+        "embedder": {"provider": "custom", "config": {"model": "custom-model"}},
+        "llm": {"provider": "custom", "config": {"model": "custom-model"}},
+    }
+    with patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"}):
+        custom_client = Mem0ServiceClient(config=custom_config)
+        assert custom_client.mem0 is not None

--- a/tests/test_mem0.py
+++ b/tests/test_mem0.py
@@ -2,9 +2,9 @@
 Tests for the memory tool using the Agent interface.
 """
 
+import json
 import os
 from unittest.mock import MagicMock, patch
-import json
 
 import pytest
 from strands import Agent


### PR DESCRIPTION
## Description
(Creating a new PR because of GitHub issue)

Adds support for `mem0_memory` tool to use memory with agents so that they can remember past states and personalize the experience of the users.

## Type of Change
- [x] New Tool

## Testing
Yes, tested locally and added tests as well.

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`