### PR TITLE
Add GitHub actions to run tests on Windows/MacOS & handle failures on Windows

### DIFF
--- a/.github/workflows/test-lint-pr.yml
+++ b/.github/workflows/test-lint-pr.yml
@@ -48,8 +48,7 @@ jobs:
             return true;
 
   unit-test:
-    name: Run Tests on Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    name: Unit Tests - Python ${{ matrix.python-version }} - ${{ matrix.os-name }}
     needs: check-approval
     permissions:
       contents: read
@@ -57,8 +56,39 @@ jobs:
     if: github.event_name == 'push' || needs.check-approval.outputs.approved == 'true'
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        include:
+          # Linux
+          - os: ubuntu-latest
+            os-name: linux
+            python-version: "3.10"
+          - os: ubuntu-latest
+            os-name: linux
+            python-version: "3.11"
+          - os: ubuntu-latest
+            os-name: linux
+            python-version: "3.12"
+          - os: ubuntu-latest
+            os-name: linux
+            python-version: "3.13"
+          # Windows
+          - os: windows-latest
+            os-name: windows
+            python-version: "3.10"
+          - os: windows-latest
+            os-name: windows
+            python-version: "3.11"
+          - os: windows-latest
+            os-name: windows
+            python-version: "3.12"
+          - os: windows-latest
+            os-name: windows
+            python-version: "3.13"
+          # MacOS - latest only; not enough runners for MacOS
+          - os: macos-latest
+            os-name: macos
+            python-version: "3.13"
       fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -78,7 +108,7 @@ jobs:
         continue-on-error: false
 
   lint:
-    name: Run Lint
+    name: Lint
     runs-on: ubuntu-latest
     needs: check-approval
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     "slack_bolt>=1.23.0,<2.0.0",
     "mem0ai>=0.1.99,<1.0.0",
     "opensearch-py>=2.8.0,<3.0.0",
+    # Note: Always want the latest tzdata
+    "tzdata ; platform_system == 'Windows'",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/strands_tools/mem0_memory.py
+++ b/src/strands_tools/mem0_memory.py
@@ -141,19 +141,10 @@ TOOL_SPEC = {
             "required": ["action"],
             "allOf": [
                 {
-                    "if": {
-                        "properties": {
-                            "action": {"enum": ["store", "list", "retrieve"]}
-                        }
-                    },
-                    "then": {
-                        "oneOf": [
-                            {"required": ["user_id"]},
-                            {"required": ["agent_id"]}
-                        ]
-                    }
+                    "if": {"properties": {"action": {"enum": ["store", "list", "retrieve"]}}},
+                    "then": {"oneOf": [{"required": ["user_id"]}, {"required": ["agent_id"]}]},
                 }
-            ]
+            ],
         }
     },
 }
@@ -536,7 +527,7 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
             return ToolResult(
                 toolUseId=tool_use_id,
                 status="success",
-                content=[ToolResultContent(text=f"Successfully stored {len(results.get('results', []))} memories")]
+                content=[ToolResultContent(text=f"Successfully stored {len(results.get('results', []))} memories")],
             )
 
         elif action == "get":
@@ -547,9 +538,7 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
             panel = format_get_response(memory)
             console.print(panel)
             return ToolResult(
-                toolUseId=tool_use_id,
-                status="success",
-                content=[ToolResultContent(text=json.dumps(memory, indent=2))]
+                toolUseId=tool_use_id, status="success", content=[ToolResultContent(text=json.dumps(memory, indent=2))]
             )
 
         elif action == "list":
@@ -559,7 +548,7 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
             return ToolResult(
                 toolUseId=tool_use_id,
                 status="success",
-                content=[ToolResultContent(text=json.dumps(memories.get("results", []), indent=2))]
+                content=[ToolResultContent(text=json.dumps(memories.get("results", []), indent=2))],
             )
 
         elif action == "retrieve":
@@ -576,7 +565,7 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
             return ToolResult(
                 toolUseId=tool_use_id,
                 status="success",
-                content=[ToolResultContent(text=json.dumps(memories.get("results", []), indent=2))]
+                content=[ToolResultContent(text=json.dumps(memories.get("results", []), indent=2))],
             )
 
         elif action == "delete":
@@ -589,7 +578,7 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
             return ToolResult(
                 toolUseId=tool_use_id,
                 status="success",
-                content=[ToolResultContent(text=f"Memory {tool_input['memory_id']} deleted successfully")]
+                content=[ToolResultContent(text=f"Memory {tool_input['memory_id']} deleted successfully")],
             )
 
         elif action == "history":
@@ -600,9 +589,7 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
             panel = format_history_response(history)
             console.print(panel)
             return ToolResult(
-                toolUseId=tool_use_id,
-                status="success",
-                content=[ToolResultContent(text=json.dumps(history, indent=2))]
+                toolUseId=tool_use_id, status="success", content=[ToolResultContent(text=json.dumps(history, indent=2))]
             )
 
         else:
@@ -615,8 +602,4 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
             border_style="red",
         )
         console.print(error_panel)
-        return ToolResult(
-            toolUseId=tool_use_id,
-            status="error",
-            content=[ToolResultContent(text=f"Error: {str(e)}")]
-        )
+        return ToolResult(toolUseId=tool_use_id, status="error", content=[ToolResultContent(text=f"Error: {str(e)}")])

--- a/src/strands_tools/utils/user_input.py
+++ b/src/strands_tools/utils/user_input.py
@@ -8,10 +8,13 @@ import asyncio
 from prompt_toolkit import HTML, PromptSession
 from prompt_toolkit.patch_stdout import patch_stdout
 
-session: PromptSession = PromptSession()
+# Lazy initialize to avoid import errors for tests on windows without a terminal
+session: PromptSession | None = None
 
 
 async def get_user_input_async(prompt: str, default: str = "n") -> str:
+    global session
+
     """
     Asynchronously get user input with prompt_toolkit's features (history, arrow keys, styling, etc).
 
@@ -25,6 +28,9 @@ async def get_user_input_async(prompt: str, default: str = "n") -> str:
 
     try:
         with patch_stdout(raw=True):
+            if session is None:
+                session = PromptSession()
+
             response = await session.prompt_async(HTML(f"{prompt} "))
 
         if not response:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -79,6 +79,7 @@ def test_direct_set_protected_var(agent, monkeypatch):
     assert os.environ["PATH"] != "/bad/path"
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Need to mock console output for Windows (see #17)")
 def test_direct_set_var_cancelled(agent, monkeypatch):
     """Test cancelling setting an environment variable."""
     # Mock get_user_input to return 'n' to cancel
@@ -137,6 +138,7 @@ def test_direct_delete_protected_var(agent, monkeypatch):
             os.environ["PATH"] = original_path
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Need to mock console output for Windows (see #17)")
 def test_direct_delete_var_cancelled(agent, monkeypatch):
     """Test cancelling deletion of an environment variable."""
     # Mock get_user_input to return 'n' to cancel

--- a/tests/test_file_write.py
+++ b/tests/test_file_write.py
@@ -148,8 +148,6 @@ def test_file_write_error_handling(mock_user_input, temp_file):
     # This should fail on most systems
     if os.name == "posix":  # Unix/Linux/Mac
         invalid_path = "/root/test_no_permission.txt"
-    elif os.name == "nt":  # Windows
-        invalid_path = "C:\\Windows\\System32\\config\\nopermission.txt"
     else:
         # Fallback - create a path that's too long
         invalid_path = os.path.join(temp_file, "a" * 1000 + ".txt")

--- a/tests/test_python_repl.py
+++ b/tests/test_python_repl.py
@@ -12,6 +12,10 @@ from unittest.mock import patch
 import dill
 import pytest
 from strands import Agent
+
+if os.name == "nt":
+    pytest.skip("skipping on windows until issue #17 is resolved", allow_module_level=True)
+
 from strands_tools import python_repl
 
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -5,12 +5,17 @@ Tests for the shell tool including execution, formatting, and various modes.
 import os
 import signal
 import sys
-import termios
 from unittest.mock import MagicMock, patch
 
 import pytest
 from rich.panel import Panel
 from strands import Agent
+
+if os.name == "nt":
+    pytest.skip("skipping on windows until issue #17 is resolved", allow_module_level=True)
+
+import termios
+
 from strands_tools import shell
 
 


### PR DESCRIPTION
## Description

Per #17 - Windows compatibility is currently unknown and all changes are currently only tested on Linux.  For [parity with the SDK](https://github.com/strands-agents/sdk-python/blob/912e1104fd52e3da99767a644b90b22b7eb606de/.github/workflows/test-lint-pr.yml#L59), start running tests on MacOS & Windows.

On MacOS all tests were already passing.  On Windows I:

 - added [`tzdata` as a dependency](https://pypi.org/project/tzdata/) to make the `current_time` work
 - lazy loaded `session: PromptSession` in `get_user_input` to avoid import errors as part of the tests 
 - updated [test_file_write.py](https://github.com/strands-agents/tools/compare/main...zastrowm:tools:windows_support#diff-a2998f18449d69766944a95d9058de448de22c38443a848876abaf22674df84a) to not use a permissions check, as the GitHub action runners seemingly run as super-admin and can write to the provided folders
 - disabled tests that were not trivial to fix - `test_shell`, `test_python_repl`
 - disabled some environment tests to better mock `get_user_input` - the two tests are failing on windows because of the lack of an interactive console.  I'd like to fix these two tests to properly mock `get_user_input` but I'm going to break that out into a separate PR to keep this one more focused.

To get linting to pass, I formatted the mem0 tool.

## Related Issues
#17 

## Documentation PR
N/A

## Type of Change
Other: Action to run tests on Windows

## Testing

All of below; workflows in my fork are passing.

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [-] I have updated the documentation accordingly
- [-] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
