### PR TITLE
docs: update memory examples to use agent.tool.X syntax

### DIFF
--- a/src/strands_tools/memory.py
+++ b/src/strands_tools/memory.py
@@ -42,7 +42,7 @@ from strands_tools.memory import memory
 agent = Agent(tools=[memory])
 
 # Store content in Knowledge Base
-agent.memory(
+agent.tool.memory(
     action="store",
     content="Important information to remember",
     title="Meeting Notes",
@@ -50,7 +50,7 @@ agent.memory(
 )
 
 # Retrieve content using semantic search
-agent.memory(
+agent.tool.memory(
     action="retrieve",
     query="meeting information",
     min_score=0.7,
@@ -58,7 +58,7 @@ agent.memory(
 )
 
 # List all documents
-agent.memory(
+agent.tool.memory(
     action="list",
     max_results=50,
     STRANDS_KNOWLEDGE_BASE_ID="my1234kb"


### PR DESCRIPTION
This PR updates the docstring examples in the memory tool to use the current `agent.tool.memory` syntax instead of the deprecated `agent.memory` direct call syntax.

## Change
- Updated 3 example code snippets in memory.py to use the new agent.tool.memory pattern

## Related Issues
Relates to the agent API evolution from direct tool calls to using the .tool namespace

Fixes: https://github.com/strands-agents/sdk-python/issues/42

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.