### PR TITLE
fix: replace print() calls with console.print() in nova_reels and think tools

### DIFF
--- a/tests/test_think.py
+++ b/tests/test_think.py
@@ -124,7 +124,8 @@ def test_think_error_handling():
 
 def test_thought_processor():
     """Test the ThoughtProcessor class."""
-    processor = ThoughtProcessor({"system_prompt": "System prompt", "messages": []})
+    mock_console = MagicMock()
+    processor = ThoughtProcessor({"system_prompt": "System prompt", "messages": []}, mock_console)
 
     # Test creating thinking prompt
     prompt = processor.create_thinking_prompt("Test thought", 1, 3)


### PR DESCRIPTION
## Description
Replace print() calls with console.print() in nova_reels and think tools

Currently these tools always print to stdout and don't respect the `STRANDS_TOOL_CONSOLE_MODE` environment variable.

## Type of Change
- [X] Bug fix

## Testing
* `hatch fmt`
* `hatch run test-lint`
* `hatch test`


## Checklist
- [X] I have read the CONTRIBUTING document
- [-] I have added tests that prove my fix is effective or my feature works
- [-] I have updated the documentation accordingly
- [-] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [-] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
