### PR TITLE
Make mem0 dependencies optional + add build to detect failures going forward

### DIFF
--- a/.github/workflows/test-lint-pr.yml
+++ b/.github/workflows/test-lint-pr.yml
@@ -108,7 +108,7 @@ jobs:
         continue-on-error: false
 
   test-install:
-    name: Dependency Checks - ${{ matrix.python-version }}
+    name: Dependency Check - Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Agents Tools is an open-source Python library that provides a unified toolkit fo
 pip install strands-agents-tools
 ```
 
+To install the dependencies for optional tools:
+
+```bash
+pip install strands-agents-tools[mem0_memory]
+```
+
 ### Development Install
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,6 @@ dependencies = [
     "tenacity>=9.1.2,<10.0.0",
     "watchdog>=6.0.0,<7.0.0",
     "slack_bolt>=1.23.0,<2.0.0",
-    "mem0ai>=0.1.99,<1.0.0",
-    "opensearch-py>=2.8.0,<3.0.0",
     # Note: Always want the latest tzdata
     "tzdata ; platform_system == 'Windows'",
 ]
@@ -63,15 +61,23 @@ dev = [
     "pre-commit>=3.2.0,<4.2.0",
     "pytest>=8.0.0,<9.0.0",
     "ruff>=0.4.4,<0.5.0",
-    "responses>=0.6.1,<1.0.0"
+    "responses>=0.6.1,<1.0.0",
+    "mem0ai>=0.1.99,<1.0.0",
+    "opensearch-py>=2.8.0,<3.0.0",
 ]
 docs = [
     "sphinx>=5.0.0,<6.0.0",
     "sphinx-rtd-theme>=1.0.0,<2.0.0",
     "sphinx-autodoc-typehints>=1.12.0,<2.0.0",
 ]
+mem0_memory = [
+    # Need to be optional as a fix for https://github.com/strands-agents/docs/issues/19
+    "mem0ai>=0.1.99,<1.0.0",
+    "opensearch-py>=2.8.0,<3.0.0",
+]
 
 [tool.hatch.envs.hatch-static-analysis]
+features = ["mem0_memory"]
 dependencies = [
   "strands-agents>=0.1.0,<1.0.0",
   "mypy>=0.981,<1.0.0",
@@ -96,6 +102,7 @@ lint-fix = [
 ]
 
 [tool.hatch.envs.hatch-test]
+features = ["mem0_memory"]
 extra-dependencies = [
     "moto>=5.1.0,<6.0.0",
     "pytest>=8.0.0,<9.0.0",


### PR DESCRIPTION
## Description

The root cause of https://github.com/strands-agents/docs/issues/19 ended up being the mem0 dependencies not being able to be resolved for the `manylinux2014_aarch64` platform which breaks lambda deployments.  

Long term, [we should come up with a better strategy](https://github.com/strands-agents/tools/issues/31), but for now let's make the dependencies for mem0 optional.

## Related Issues

 - https://github.com/strands-agents/docs/issues/19
 - https://github.com/strands-agents/tools/issues/31

## Documentation PR

N/A

## Type of Change
- Bug fix

## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
