### PR TITLE
feat(utils): add keyboard_interrupt_return_default bool argument to get_user_input() to allow for optional propagation of KeyboardInterrupt and EOFError exceptions

### DIFF
--- a/src/strands_tools/utils/user_input.py
+++ b/src/strands_tools/utils/user_input.py
@@ -12,21 +12,22 @@ from prompt_toolkit.patch_stdout import patch_stdout
 session: PromptSession | None = None
 
 
-async def get_user_input_async(prompt: str, default: str = "n") -> str:
-    global session
-
+async def get_user_input_async(prompt: str, default: str = "n", keyboard_interrupt_return_default: bool = True) -> str:
     """
     Asynchronously get user input with prompt_toolkit's features (history, arrow keys, styling, etc).
 
     Args:
         prompt: The prompt to show
         default: Default response (default is 'n')
+        keyboard_interrupt_return_default: Return default value on keyboard interrupt or EOF error (default is True)
 
     Returns:
         str: The user's input response
     """
 
-    try:
+    async def _get_input():
+        global session
+
         with patch_stdout(raw=True):
             if session is None:
                 session = PromptSession()
@@ -37,17 +38,24 @@ async def get_user_input_async(prompt: str, default: str = "n") -> str:
             return str(default)
 
         return str(response)
-    except (KeyboardInterrupt, EOFError):
-        return default
+
+    if keyboard_interrupt_return_default:
+        try:
+            return await _get_input()
+        except (KeyboardInterrupt, EOFError):
+            return default
+
+    return await _get_input()
 
 
-def get_user_input(prompt: str, default: str = "n") -> str:
+def get_user_input(prompt: str, default: str = "n", keyboard_interrupt_return_default: bool = True) -> str:
     """
     Synchronous wrapper for get_user_input_async.
 
     Args:
         prompt: The prompt to show
         default: Default response shown in prompt (default is 'n')
+        keyboard_interrupt_return_default: Return default value on keyboard interrupt or EOF error (default is True)
 
     Returns:
         str: The user's input response
@@ -59,5 +67,5 @@ def get_user_input(prompt: str, default: str = "n") -> str:
         asyncio.set_event_loop(loop)
 
     # Get result and ensure it's returned as a string
-    result = loop.run_until_complete(get_user_input_async(prompt, default))
+    result = loop.run_until_complete(get_user_input_async(prompt, default, keyboard_interrupt_return_default))
     return str(result)

--- a/tests/utils/test_user_input.py
+++ b/tests/utils/test_user_input.py
@@ -16,7 +16,7 @@ class TestUserInputAsync:
         test_prompt = "Enter input:"
 
         # Setup mock for async function
-        async def mock_success(prompt, default=None):
+        async def mock_success(prompt, default=None, keyboard_interrupt_return_default=True):
             assert prompt == test_prompt
             return test_input
 
@@ -41,7 +41,7 @@ class TestUserInputAsync:
         default_value = "default_response"
 
         # Setup mock for async function
-        async def mock_empty(prompt, default):
+        async def mock_empty(prompt, default, keyboard_interrupt_return_default=True):
             assert prompt == test_prompt
             assert default == default_value
             return default  # Empty input returns default
@@ -66,7 +66,8 @@ class TestUserInputAsync:
         default_value = "default_response"
 
         # Setup mock for async function that raises KeyboardInterrupt
-        async def mock_interrupt(prompt, default):
+        async def mock_interrupt(prompt, default, keyboard_interrupt_return_default):
+            assert keyboard_interrupt_return_default is True
             raise KeyboardInterrupt()
 
         # Mock event loop to handle the exception and return default
@@ -81,7 +82,7 @@ class TestUserInputAsync:
             patch("asyncio.get_event_loop", return_value=mock_loop),
             patch(
                 "strands_tools.utils.user_input.get_user_input",
-                side_effect=lambda p, d=default_value: d,
+                side_effect=lambda p, d=default_value, k=True: d,
             ),
         ):
             # We're testing that get_user_input properly handles the exception
@@ -89,13 +90,43 @@ class TestUserInputAsync:
             result = get_user_input(test_prompt, default_value)
             assert result == default_value
 
+    def test_get_user_input_async_keyboard_interrupt_propagation(self):
+        """Test KeyboardInterrupt propagation when keyboard_interrupt_return_default=False."""
+        test_prompt = "Enter input:"
+        default_value = "default_response"
+
+        # Setup mock for async function that raises KeyboardInterrupt
+        async def mock_interrupt(prompt, default, keyboard_interrupt_return_default):
+            assert keyboard_interrupt_return_default is False
+            raise KeyboardInterrupt()
+
+        # Mock event loop to propagate the exception
+        mock_loop = MagicMock()
+        mock_loop.run_until_complete.side_effect = KeyboardInterrupt()
+
+        with (
+            patch(
+                "strands_tools.utils.user_input.get_user_input_async",
+                side_effect=mock_interrupt,
+            ),
+            patch("asyncio.get_event_loop", return_value=mock_loop),
+        ):
+            # When keyboard_interrupt_return_default is False, the exception should propagate
+            try:
+                get_user_input(test_prompt, default_value, keyboard_interrupt_return_default=False)
+                raise AssertionError("KeyboardInterrupt should have been raised")
+            except KeyboardInterrupt:
+                # Expected behavior - test passes
+                pass
+
     def test_get_user_input_async_eof_error_via_sync(self):
         """Test handling of EOFError during input via sync wrapper."""
         test_prompt = "Enter input:"
         default_value = "default_response"
 
         # Setup mock for async function that raises EOFError
-        async def mock_eof(prompt, default):
+        async def mock_eof(prompt, default, keyboard_interrupt_return_default):
+            assert keyboard_interrupt_return_default is True
             raise EOFError()
 
         # Mock event loop to handle the exception and return default
@@ -110,13 +141,42 @@ class TestUserInputAsync:
             patch("asyncio.get_event_loop", return_value=mock_loop),
             patch(
                 "strands_tools.utils.user_input.get_user_input",
-                side_effect=lambda p, d=default_value: d,
+                side_effect=lambda p, d=default_value, k=True: d,
             ),
         ):
             # We're testing that get_user_input properly handles the exception
             # and returns the default value
             result = get_user_input(test_prompt, default_value)
             assert result == default_value
+
+    def test_get_user_input_async_eof_error_propagation(self):
+        """Test EOFError propagation when keyboard_interrupt_return_default=False."""
+        test_prompt = "Enter input:"
+        default_value = "default_response"
+
+        # Setup mock for async function that raises EOFError
+        async def mock_eof(prompt, default, keyboard_interrupt_return_default):
+            assert keyboard_interrupt_return_default is False
+            raise EOFError()
+
+        # Mock event loop to propagate the exception
+        mock_loop = MagicMock()
+        mock_loop.run_until_complete.side_effect = EOFError()
+
+        with (
+            patch(
+                "strands_tools.utils.user_input.get_user_input_async",
+                side_effect=mock_eof,
+            ),
+            patch("asyncio.get_event_loop", return_value=mock_loop),
+        ):
+            # When keyboard_interrupt_return_default is False, the exception should propagate
+            try:
+                get_user_input(test_prompt, default_value, keyboard_interrupt_return_default=False)
+                raise AssertionError("EOFError should have been raised")
+            except EOFError:
+                # Expected behavior - test passes
+                pass
 
 
 class TestUserInputSync:
@@ -185,30 +245,36 @@ class TestUserInputSync:
             # Verify the coroutine was run to completion
             mock_loop.run_until_complete.assert_called_once()
 
-    def test_get_user_input_with_default(self):
-        """Test get_user_input with a default value passed through."""
+    def test_get_user_input_with_default_and_keyboard_interrupt_param(self):
+        """Test get_user_input with different values for keyboard_interrupt_return_default."""
         test_prompt = "Enter input:"
         default_value = "default_response"
 
-        # Create a mock coroutine with arguments check
-        async def mock_async_func(prompt, default):
-            assert prompt == test_prompt
-            assert default == default_value
-            return default_value
+        for keyboard_interrupt_value in [True, False]:
+            # Create a mock coroutine with arguments check
+            async def mock_async_func(
+                prompt, default, keyboard_interrupt_return_default, keyboard_interrupt_value=keyboard_interrupt_value
+            ):
+                assert prompt == test_prompt
+                assert default == default_value
+                assert keyboard_interrupt_return_default is keyboard_interrupt_value
+                return default_value
 
-        # Mock the event loop
-        mock_loop = MagicMock()
-        mock_loop.run_until_complete.return_value = default_value
+            # Mock the event loop
+            mock_loop = MagicMock()
+            mock_loop.run_until_complete.return_value = default_value
 
-        with (
-            patch(
-                "strands_tools.utils.user_input.get_user_input_async",
-                side_effect=mock_async_func,
-            ),
-            patch("asyncio.get_event_loop", return_value=mock_loop),
-        ):
-            # Call the function with default value
-            result = get_user_input(test_prompt, default_value)
+            with (
+                patch(
+                    "strands_tools.utils.user_input.get_user_input_async",
+                    side_effect=mock_async_func,
+                ),
+                patch("asyncio.get_event_loop", return_value=mock_loop),
+            ):
+                # Call the function with the current keyboard_interrupt_return_default value
+                result = get_user_input(
+                    test_prompt, default_value, keyboard_interrupt_return_default=keyboard_interrupt_value
+                )
 
-            # Verify the result
-            assert result == default_value
+                # Verify the result
+                assert result == default_value


### PR DESCRIPTION
## Description
* Add keyboard_interrupt_return_default bool argument to get_user_input() to allow for optional propagation of KeyboardInterrupt and EOFError exceptions

## Type of Change
- [X] Other (please describe):
New feature in get_user_input() utility function.

## Testing
* `hatch fmt`
* `hatch run test-lint`
* `hatch test --all`
* Manually tested `strands` in the CLI

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [-] I have updated the documentation accordingly
- [-] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
