### PR TITLE
Feat/issue28 batch tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,68 @@ result = agent.tool.use_aws(
 )
 ```
 
+### Batch Tool
+
+```python
+import logging
+import os
+import sys
+
+from strands import Agent
+from strands.models.anthropic import AnthropicModel
+
+from strands_tools import batch_tool, http_request, use_aws
+
+# Enables Strands debug log level
+logging.getLogger("strands").setLevel(logging.WARNING)
+
+# Sets the logging format and streams logs to stderr
+logging.basicConfig(
+    format="%(levelname)s | %(name)s | %(message)s",
+    handlers=[logging.StreamHandler()]
+)
+
+os.environ["ANTHROPIC_API_KEY"] = (
+    "<type your actual API key here>"
+)
+
+anthropic_model = AnthropicModel(
+    model_id="claude-3-5-haiku-20241022",  # Example model ID, replace with your actual model
+    temperature=0.7,
+    max_tokens=2000,
+    top_p=0.9,
+    top_k=40,
+    stop=["\n\n"],
+    stream=True,
+    anthropic_api_key=(
+        "<type your actual API key here>"
+    ),  # Replace with your actual API key. IMPORTANT: Do not hardcode sensitive keys in production code.
+    anthropic_base_url="https://api.anthropic.com/v1",  # Replace with your actual base URL if needed
+)
+
+anthropic_model_config = anthropic_model.get_config()
+
+# Example usage of the batch_tool with http_request and use_aws tools
+agent = Agent(model=anthropic_model, tools=[batch_tool, http_request, use_aws])
+result = agent.tool.batch_tool(
+    invocations=[
+        {"name": "http_request", "arguments": {"method": "GET", "url": "https://api.ipify.org?format=json"}},
+        {
+            "name": "use_aws",
+            "arguments": {
+                "service_name": "s3",
+                "operation_name": "list_buckets",
+                "parameters": {},
+                "region": "us-east-1",
+                "label": "List S3 Buckets"
+            }
+        },
+    ]
+)
+
+print(result)
+```
+
 ## 🌍 Environment Variables Configuration
 
 Agents Tools provides extensive customization through environment variables. This allows you to configure tool behavior without modifying code, making it ideal for different environments (development, testing, production).

--- a/src/strands_tools/batch_tool.py
+++ b/src/strands_tools/batch_tool.py
@@ -43,7 +43,7 @@ Example usage:
 
     anthropic_model_config = anthropic_model.get_config()
 
-    # Example usage of the batch_tool with think and stop tools
+    # Example usage of the batch_tool with http_request and use_aws tools
     agent = Agent(model=anthropic_model, tools=[batch_tool, http_request, use_aws])
     result = agent.tool.batch_tool(
         invocations=[

--- a/tests/test_batch_tool.py
+++ b/tests/test_batch_tool.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+
+import pytest
+from strands_tools.batch_tool import batch_tool
+
+
+@pytest.fixture
+def mock_agent():
+    """Fixture to create a mock agent with tools."""
+    agent = MagicMock()
+    agent.tool.think = MagicMock(return_value="Think tool executed")
+    agent.tool.stop = MagicMock(return_value="Stop tool executed")
+    agent.tool.error_tool = MagicMock(side_effect=Exception("Tool execution failed"))
+    return agent
+
+
+def test_batch_tool_success(mock_agent):
+    """Test successful execution of multiple tools."""
+    mock_tool = ("mock_tool",)
+    invocations = [
+        {"name": "think", "arguments": {"thought": "How to improve AI?", "cycle_count": 2}},
+        {"name": "stop", "arguments": {}},
+    ]
+
+    result = batch_tool(tool=mock_tool, agent=mock_agent, invocations=invocations)
+
+    assert result["status"] == "success"
+    assert len(result["results"]) == 2
+    assert result["results"][0]["name"] == "think"
+    assert result["results"][0]["status"] == "success"
+    assert result["results"][0]["result"] == "Think tool executed"
+    assert result["results"][1]["name"] == "stop"
+    assert result["results"][1]["status"] == "success"
+    assert result["results"][1]["result"] == "Stop tool executed"


### PR DESCRIPTION
## Description
### Batch Tool for Parallel Tool Invocation

This PR introduces a new batch_tool to the repository, enabling the invocation of multiple tools in parallel within the Strands framework. The batch_tool is designed to streamline tool execution by processing a list of tool invocations and their respective arguments, returning detailed results for each invocation.

**Key Features:**
- Parallel Tool Invocation: Supports invoking multiple tools in a single call, with each tool receiving its own set of arguments.
- Error Handling: Captures and reports errors for individual tool invocations, including detailed traceback information.
- Dynamic Tool Resolution: Dynamically resolves and invokes tools registered with the agent.
- JSON-Serializable Results: Ensures all results are JSON-serializable for easy integration with other systems.

**Additional Changes:**
- Added unit tests for batch_tool under test_batch_tool.py using pytest and unittest.mock.
- Updated documentation (README.md) and examples to demonstrate the usage of the new tool.

This tool enhances the flexibility and efficiency of tool invocation within the Strands framework, making it easier to handle complex workflows.

## Related Issues
Issue #28 

## Documentation PR
N/A

## Type of Change
- [ ] Bug fix
- [x] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
Yes. All following tests passed successfully in local runs

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
