### PR TITLE
refactor: rename DEV environment variable to BYPASS_TOOL_CONSENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ These variables affect multiple tools:
 
 | Environment Variable | Description | Default | Affected Tools |
 |----------------------|-------------|---------|---------------|
-| DEV | Bypass consent for tool invocation, set to "true" to enable | false | All tools that require consent |
+| BYPASS_TOOL_CONSENT | Bypass consent for tool invocation, set to "true" to enable | false | All tools that require consent (e.g. shell, file_write, python_repl) |
 | STRANDS_TOOL_CONSOLE_MODE | Enable rich UI for tools, set to "enabled" to enable | disabled | All tools that have optional rich UI |
 | AWS_REGION | Default AWS region for AWS operations | us-west-2 | use_aws, retrieve, generate_image, memory, nova_reels |
 | AWS_PROFILE | AWS profile name to use from ~/.aws/credentials | default | use_aws, retrieve |

--- a/src/strands_tools/cron.py
+++ b/src/strands_tools/cron.py
@@ -28,9 +28,9 @@ def cron(
     and best practices for Strands agent scheduling.
 
     # Strands Agent Job Best Practices:
-    - Use 'DEV=true peccy "<your_prompt>"' to run Strands agent tasks
+    - Use 'BYPASS_TOOL_CONSENT=true peccy "<your_prompt>"' to run Strands agent tasks
     - Always add output redirection to log files: '>> /path/to/log.file 2>&1'
-    - Example: 'DEV=true peccy "Generate a report" >> /tmp/report.log 2>&1'
+    - Example: 'BYPASS_TOOL_CONSENT=true peccy "Generate a report" >> /tmp/report.log 2>&1'
     - Consider creating organized log directories like '/tmp/strands_logs/'
 
     # Cron Schedule Examples:

--- a/src/strands_tools/editor.py
+++ b/src/strands_tools/editor.py
@@ -444,9 +444,9 @@ def editor(tool: ToolUse, **kwargs: Any) -> ToolResult:
         result = ""
 
         # Check if we're in development mode
-        strands_dev = os.environ.get("DEV", "").lower() == "true"
+        strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
 
-        # For modifying operations, show confirmation dialog unless in DEV mode
+        # For modifying operations, show confirmation dialog unless in BYPASS_TOOL_CONSENT mode
         modifying_commands = {"create", "str_replace", "pattern_replace", "insert"}
         needs_confirmation = command in modifying_commands and not strands_dev
 

--- a/src/strands_tools/environment.py
+++ b/src/strands_tools/environment.py
@@ -273,7 +273,9 @@ def format_operation_preview(
         title=f"[bold {risk_level[1]}]🔧 Environment Operation Preview[/bold {risk_level[1]}]",
         border_style=risk_level[1],
         box=box.ROUNDED,
-        subtitle="[dim]Dev Mode: " + ("✓" if os.environ.get("DEV", "").lower() == "true" else "✗") + "[/dim]",
+        subtitle="[dim]Dev Mode: "
+        + ("✓" if os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true" else "✗")
+        + "[/dim]",
     )
 
 
@@ -371,7 +373,7 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
     How It Works:
     ------------
     1. The function processes the requested action (list, get, set, delete, validate)
-    2. For destructive actions, it requires user confirmation unless in DEV mode
+    2. For destructive actions, it requires user confirmation unless in BYPASS_TOOL_CONSENT mode
     3. Protected system variables are identified and cannot be modified
     4. Sensitive values (tokens, passwords, etc.) are automatically masked
     5. Rich output formatting provides clear visual feedback on operations
@@ -391,7 +393,7 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
     - Sensitive values are masked in output by default
     - Destructive actions require explicit confirmation
     - Clear risk level indicators for all operations
-    - DEV mode controls for testing and automation
+    - BYPASS_TOOL_CONSENT mode controls for testing and automation
 
     Args:
         tool: The ToolUse object containing the action and parameters
@@ -409,7 +411,7 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
             - content: List of content objects with results or error messages
 
     Notes:
-        - The ENV var "DEV" can be set to "true" to bypass confirmation prompts
+        - The ENV var "BYPASS_TOOL_CONSENT" can be set to "true" to bypass confirmation prompts
         - Protected variables include PATH, PYTHONPATH, STRANDS_HOME, SHELL, USER, HOME
         - Sensitive variables are detected by keywords in their names (TOKEN, SECRET, etc.)
         - For security reasons, values of sensitive variables are masked in output
@@ -430,16 +432,16 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
     # Get environment variables at runtime
     env_vars_masked_default = os.getenv("ENV_VARS_MASKED_DEFAULT", "true").lower() == "true"
 
-    # Check for DEV mode
-    strands_dev = os.environ.get("DEV", "").lower() == "true"
+    # Check for BYPASS_TOOL_CONSENT mode
+    strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
 
     # Actions that need confirmation
     dangerous_actions = {"set", "delete"}
     needs_confirmation = tool_input["action"] in dangerous_actions and not strands_dev
 
-    # Print DEV mode status for debugging
+    # Print BYPASS_TOOL_CONSENT mode status for debugging
     if strands_dev:
-        console.print("[bold green]Running in DEV mode - confirmation bypassed[/bold green]")
+        console.print("[bold green]Running in BYPASS_TOOL_CONSENT mode - confirmation bypassed[/bold green]")
 
     try:
         action = tool_input["action"]

--- a/src/strands_tools/file_write.py
+++ b/src/strands_tools/file_write.py
@@ -21,7 +21,7 @@ Key Features:
 
 3. Safety Features:
    • Directory creation if parent directories don't exist
-   • Development mode toggle (DEV environment variable)
+   • Development mode toggle (BYPASS_TOOL_CONSENT environment variable)
    • Write operation confirmation dialog
    • Detailed error reporting
 
@@ -179,7 +179,7 @@ def file_write(tool: ToolUse, **kwargs: Any) -> ToolResult:
         }
 
     Notes:
-        - The DEV environment variable can be set to "true" to bypass the confirmation step
+        - The BYPASS_TOOL_CONSENT environment variable can be set to "true" to bypass the confirmation step
         - Parent directories are automatically created if they don't exist
         - File content is previewed with syntax highlighting based on file extension
         - User can cancel the write operation and provide a reason for cancellation
@@ -192,7 +192,7 @@ def file_write(tool: ToolUse, **kwargs: Any) -> ToolResult:
     path = expanduser(tool_input["path"])
     content = tool_input["content"]
 
-    strands_dev = os.environ.get("DEV", "").lower() == "true"
+    strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
 
     # Create a panel with file information
     info_panel = Panel(

--- a/src/strands_tools/http_request.py
+++ b/src/strands_tools/http_request.py
@@ -600,9 +600,9 @@ def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
         console.print(preview_panel)
 
         # Check if we're in development mode
-        strands_dev = os.environ.get("DEV", "").lower() == "true"
+        strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
 
-        # For modifying operations (non-GET requests), show confirmation dialog unless in DEV mode
+        # For modifying operations (non-GET requests), show confirmation dialog unless in BYPASS_TOOL_CONSENT mode
         modifying_methods = {"POST", "PUT", "PATCH", "DELETE"}
         needs_confirmation = method.upper() in modifying_methods and not strands_dev
 

--- a/src/strands_tools/mem0_memory.py
+++ b/src/strands_tools/mem0_memory.py
@@ -18,7 +18,7 @@ Key Features:
    • User confirmation for mutative operations
    • Content previews before storage
    • Warning messages before deletion
-   • DEV mode for bypassing confirmations in tests
+   • BYPASS_TOOL_CONSENT mode for bypassing confirmations in tests
 
 3. Advanced Capabilities:
    • Automatic memory ID generation
@@ -450,12 +450,12 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
         client = Mem0ServiceClient()
 
         # Check if we're in development mode
-        strands_dev = os.environ.get("DEV", "").lower() == "true"
+        strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
 
         # Handle different actions
         action = tool_input["action"]
 
-        # For mutative operations, show confirmation dialog unless in DEV mode
+        # For mutative operations, show confirmation dialog unless in BYPASS_TOOL_CONSENT mode
         mutative_actions = {"store", "delete"}
         needs_confirmation = action in mutative_actions and not strands_dev
 

--- a/src/strands_tools/memory.py
+++ b/src/strands_tools/memory.py
@@ -18,7 +18,7 @@ Key Features:
    • User confirmation for mutative operations
    • Content previews before storage
    • Warning messages before deletion
-   • DEV mode for bypassing confirmations in tests
+   • BYPASS_TOOL_CONSENT mode for bypassing confirmations in tests
 
 3. Advanced Capabilities:
    • Automatic document ID generation
@@ -568,7 +568,7 @@ def memory(
     This tool provides a user-friendly interface for managing knowledge base content
     with built-in safety measures for mutative operations. For operations that modify
     data (store, delete), users will be shown a preview and asked for explicit confirmation
-    before changes are made, unless the DEV environment variable is set to "true".
+    before changes are made, unless the BYPASS_TOOL_CONSENT environment variable is set to "true".
 
     Args:
         action: The action to perform ('store', 'delete', 'list', 'get', or 'retrieve').
@@ -587,7 +587,7 @@ def memory(
         A dictionary containing the result of the operation.
 
     Notes:
-        - Store and delete operations require user confirmation (unless in DEV mode)
+        - Store and delete operations require user confirmation (unless in BYPASS_TOOL_CONSENT mode)
         - Content previews are shown before storage to verify accuracy
         - Warning messages are provided before document deletion
         - Operation can be cancelled by the user during confirmation
@@ -648,7 +648,7 @@ def memory(
 
     # Define mutative actions that need confirmation
     mutative_actions = {"store", "delete"}
-    strands_dev = os.environ.get("DEV", "").lower() == "true"
+    strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
     needs_confirmation = action in mutative_actions and not strands_dev
 
     # Show confirmation dialog for mutative operations

--- a/src/strands_tools/python_repl.py
+++ b/src/strands_tools/python_repl.py
@@ -72,7 +72,7 @@ TOOL_SPEC = {
     "2. Code Preview: Shows syntax-highlighted code before execution\n"
     "3. State Management: Maintains variables between executions\n"
     "4. Error Handling: Captures and formats errors with suggestions\n"
-    "5. Development Mode: Can bypass confirmation in DEV environments\n\n"
+    "5. Development Mode: Can bypass confirmation in BYPASS_TOOL_CONSENT environments\n\n"
     "Key Features:\n"
     "- Persistent state between executions\n"
     "- Interactive PTY support for real-time feedback\n"
@@ -423,7 +423,7 @@ def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
     reset_state = tool_input.get("reset_state", False)
 
     # Check for development mode
-    strands_dev = os.environ.get("DEV", "").lower() == "true"
+    strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
 
     # Check for non_interactive_mode parameter
     non_interactive_mode = kwargs.get("non_interactive_mode", False)
@@ -443,7 +443,8 @@ def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
             )
         )
 
-        # Add permissions check - only show confirmation dialog if not in DEV mode and not in non_interactive mode
+        # Add permissions check - only show confirmation dialog if not
+        # in BYPASS_TOOL_CONSENT mode and not in non_interactive mode
         if not strands_dev and not non_interactive_mode:
             # Create a table with code details for better visualization
             details_table = Table(show_header=False, box=box.SIMPLE)

--- a/src/strands_tools/shell.py
+++ b/src/strands_tools/shell.py
@@ -505,7 +505,7 @@ def shell(tool: ToolUse, **kwargs: Any) -> ToolResult:
     work_dir = tool_input.get("work_dir", os.getcwd())
 
     # Development mode check
-    STRANDS_DEV = os.environ.get("DEV", "").lower() == "true"
+    STRANDS_BYPASS_TOOL_CONSENT = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
 
     # Only show UI elements in interactive mode
     if not non_interactive_mode:
@@ -520,7 +520,7 @@ def shell(tool: ToolUse, **kwargs: Any) -> ToolResult:
             if i < len(commands) - 1:
                 console.print()
 
-    if not STRANDS_DEV and not non_interactive_mode:
+    if not STRANDS_BYPASS_TOOL_CONSENT and not non_interactive_mode:
         console.print()  # Empty line for spacing
         confirm = get_user_input("<yellow><bold>Do you want to proceed with execution?</bold> [y/*]</yellow>")
         if confirm.lower() != "y":

--- a/src/strands_tools/use_aws.py
+++ b/src/strands_tools/use_aws.py
@@ -270,7 +270,7 @@ def use_aws(tool: ToolUse, **kwargs: Any) -> ToolResult:
 
     Notes:
         - Mutative operations (create, delete, etc.) require user confirmation in non-dev environments
-        - You can disable confirmation by setting the environment variable DEV=true
+        - You can disable confirmation by setting the environment variable BYPASS_TOOL_CONSENT=true
         - The tool automatically handles special response types like streaming bodies
         - For validation errors, the tool attempts to generate the correct input schema
         - All datetime objects are automatically converted to strings for proper JSON serialization
@@ -287,7 +287,7 @@ def use_aws(tool: ToolUse, **kwargs: Any) -> ToolResult:
     region = tool_input.get("region", aws_region)
     label = tool_input.get("label", "AWS Operation Details")
 
-    STRANDS_DEV = os.environ.get("DEV", "").lower() == "true"
+    STRANDS_BYPASS_TOOL_CONSENT = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
 
     # Create a panel for AWS Operation Details
     operation_details = f"{Fore.CYAN}Service:{Style.RESET_ALL} {service_name}\n"
@@ -305,7 +305,7 @@ def use_aws(tool: ToolUse, **kwargs: Any) -> ToolResult:
     # Check if the operation is potentially mutative
     is_mutative = any(op in operation_name.lower() for op in MUTATIVE_OPERATIONS)
 
-    if is_mutative and not STRANDS_DEV:
+    if is_mutative and not STRANDS_BYPASS_TOOL_CONSENT:
         # Prompt for confirmation before executing the operation
         confirm = get_user_input(
             f"<yellow><bold>The operation '{operation_name}' is potentially mutative. "

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -192,10 +192,10 @@ class TestEditorDirectCalls:
         # Mock user cancelling the write
         mock_user_input.side_effect = ["n", "Changed my mind"]  # Cancel with reason
 
-        # Ensure DEV mode is disabled to force confirmation
-        current_dev = os.environ.get("DEV", None)
+        # Ensure BYPASS_TOOL_CONSENT mode is disabled to force confirmation
+        current_dev = os.environ.get("BYPASS_TOOL_CONSENT", None)
         if current_dev:
-            os.environ.pop("DEV")
+            os.environ.pop("BYPASS_TOOL_CONSENT")
 
         test_file = str(tmp_path / "should_not_exist.txt")
         tool_use = {
@@ -388,7 +388,7 @@ class TestEditorErrors:
         assert result["status"] == "error"
         assert "Error:" in result["content"][0]["text"]
 
-    @patch.dict(os.environ, {"DEV": "true"})
+    @patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"})
     def test_missing_path(self):
         """Test error when path is missing."""
         tool_use = {"toolUseId": "test-id", "input": {"command": "view"}}
@@ -398,7 +398,7 @@ class TestEditorErrors:
         assert "Error:" in result["content"][0]["text"]
 
     @patch("strands_tools.editor.get_user_input")
-    @patch.dict(os.environ, {"DEV": "true"})
+    @patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"})
     def test_create_without_file_text(self, mock_user_input):
         """Test error when file_text is missing for create command."""
         tool_use = {
@@ -411,7 +411,7 @@ class TestEditorErrors:
         assert "Error:" in result["content"][0]["text"]
 
     @patch("strands_tools.editor.get_user_input")
-    @patch.dict(os.environ, {"DEV": "true"})
+    @patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"})
     def test_str_replace_without_required_params(self, mock_user_input):
         """Test error when required params are missing for str_replace."""
         tool_use = {
@@ -428,7 +428,7 @@ class TestEditorErrors:
         assert "Error:" in result["content"][0]["text"]
 
     @patch("strands_tools.editor.get_user_input")
-    @patch.dict(os.environ, {"DEV": "true"})
+    @patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"})
     def test_pattern_replace_invalid_pattern(self, mock_user_input):
         """Test error with invalid regex pattern."""
         tool_use = {
@@ -462,18 +462,18 @@ class TestEditorViaAgent:
     """Test editor tool via the Agent interface."""
 
     @patch("strands_tools.editor.get_user_input")
-    @patch.dict("os.environ", {"DEV": "true"})
+    @patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "true"})
     def test_editor_via_agent_view(self, mock_user_input, agent, temp_file, clean_content_history):
-        """Test viewing a file via agent in DEV mode."""
+        """Test viewing a file via agent in BYPASS_TOOL_CONSENT mode."""
         result = agent.tool.editor(command="view", path=temp_file)
 
         result_text = extract_result_text(result)
         assert "File content displayed in console" in result_text
 
     @patch("strands_tools.editor.get_user_input")
-    @patch.dict("os.environ", {"DEV": "true"})
+    @patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "true"})
     def test_editor_via_agent_create(self, mock_user_input, agent, tmp_path, clean_content_history):
-        """Test creating a file via agent in DEV mode."""
+        """Test creating a file via agent in BYPASS_TOOL_CONSENT mode."""
         test_file = str(tmp_path / "agent_created.txt")
 
         result = agent.tool.editor(command="create", path=test_file, file_text="Created via agent")

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -202,11 +202,11 @@ def test_direct_missing_parameters(agent):
 
 
 def test_environment_dev_mode_delete(agent, os_environment):
-    """Test the environment tool in DEV mode with delete action."""
-    # Set DEV mode
-    os_environment["DEV"] = "true"
+    """Test the environment tool in BYPASS_TOOL_CONSENT mode with delete action."""
+    # Set BYPASS_TOOL_CONSENT mode
+    os_environment["BYPASS_TOOL_CONSENT"] = "true"
 
-    var_name = "DEV_MODE_DELETE_VAR"
+    var_name = "BYPASS_TOOL_CONSENT_MODE_DELETE_VAR"
     var_value = "dev_mode_delete_value"
 
     # Set up the variable
@@ -218,9 +218,9 @@ def test_environment_dev_mode_delete(agent, os_environment):
 
 
 def test_environment_dev_mode_protected_var(agent, os_environment):
-    """Test that protected variables are still protected in DEV mode."""
-    # Set DEV mode
-    os_environment["DEV"] = True
+    """Test that protected variables are still protected in BYPASS_TOOL_CONSENT mode."""
+    # Set BYPASS_TOOL_CONSENT mode
+    os_environment["BYPASS_TOOL_CONSENT"] = True
 
     unchanging_value = "/original/path"
     os_environment["PATH"] = unchanging_value

--- a/tests/test_file_write.py
+++ b/tests/test_file_write.py
@@ -91,10 +91,10 @@ def test_file_write_cancel(mock_user_input, temp_file):
     # Mock user cancelling the write
     mock_user_input.side_effect = ["n", "User changed their mind"]
 
-    # Ensure DEV mode is disabled to force confirmation
-    current_dev = os.environ.get("DEV", None)
+    # Ensure BYPASS_TOOL_CONSENT mode is disabled to force confirmation
+    current_dev = os.environ.get("BYPASS_TOOL_CONSENT", None)
     if current_dev:
-        os.environ.pop("DEV")
+        os.environ.pop("BYPASS_TOOL_CONSENT")
 
     tool_use = {
         "toolUseId": "test-tool-use-id",
@@ -111,9 +111,9 @@ def test_file_write_cancel(mock_user_input, temp_file):
     # Verify file was not created
     assert not os.path.exists(temp_file)
 
-    # Restore DEV mode if it was set
+    # Restore BYPASS_TOOL_CONSENT mode if it was set
     if current_dev:
-        os.environ["DEV"] = current_dev
+        os.environ["BYPASS_TOOL_CONSENT"] = current_dev
 
 
 @patch("strands_tools.file_write.get_user_input")
@@ -165,15 +165,15 @@ def test_file_write_error_handling(mock_user_input, temp_file):
 
 
 @patch("strands_tools.file_write.get_user_input")
-@patch.dict("os.environ", {"DEV": "true"})
+@patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "true"})
 def test_file_write_dev_mode(mock_user_input, temp_file):
-    """Test file_write in DEV mode (skipping confirmation)."""
-    # Mock should not be called in DEV mode
+    """Test file_write in BYPASS_TOOL_CONSENT mode (skipping confirmation)."""
+    # Mock should not be called in BYPASS_TOOL_CONSENT mode
     mock_user_input.return_value = "should not be called"
 
     tool_use = {
         "toolUseId": "test-tool-use-id",
-        "input": {"path": temp_file, "content": "DEV mode test"},
+        "input": {"path": temp_file, "content": "BYPASS_TOOL_CONSENT mode test"},
     }
 
     result = file_write.file_write(tool=tool_use)
@@ -182,16 +182,16 @@ def test_file_write_dev_mode(mock_user_input, temp_file):
     assert result["status"] == "success"
     assert os.path.exists(temp_file)
     with open(temp_file, "r") as f:
-        assert f.read() == "DEV mode test"
+        assert f.read() == "BYPASS_TOOL_CONSENT mode test"
 
     # Verify user input was not called
     mock_user_input.assert_not_called()
 
 
 def test_file_write_via_agent(agent, temp_file):
-    """Test file_write via the agent interface with DEV mode to bypass user input."""
-    # For agent testing, we need to use the DEV environment to bypass user input
-    os.environ["DEV"] = "true"
+    """Test file_write via the agent interface with BYPASS_TOOL_CONSENT mode to bypass user input."""
+    # For agent testing, we need to use the BYPASS_TOOL_CONSENT environment to bypass user input
+    os.environ["BYPASS_TOOL_CONSENT"] = "true"
     try:
         # Use the agent to write a file
         result = agent.tool.file_write(path=temp_file, content="Testing via agent")
@@ -206,8 +206,8 @@ def test_file_write_via_agent(agent, temp_file):
             assert f.read() == "Testing via agent"
     finally:
         # Restore the environment
-        if "DEV" in os.environ:
-            del os.environ["DEV"]
+        if "BYPASS_TOOL_CONSENT" in os.environ:
+            del os.environ["BYPASS_TOOL_CONSENT"]
 
 
 @patch("strands_tools.file_write.get_user_input")
@@ -216,10 +216,10 @@ def test_file_write_alternative_rejection(mock_user_input, temp_file):
     # Mock user providing an alternative rejection (not just 'n')
     mock_user_input.return_value = "I need to review this more"
 
-    # Ensure DEV mode is disabled to force confirmation
-    current_dev = os.environ.get("DEV", None)
+    # Ensure BYPASS_TOOL_CONSENT mode is disabled to force confirmation
+    current_dev = os.environ.get("BYPASS_TOOL_CONSENT", None)
     if current_dev:
-        os.environ.pop("DEV")
+        os.environ.pop("BYPASS_TOOL_CONSENT")
 
     tool_use = {
         "toolUseId": "test-tool-use-id",
@@ -233,9 +233,9 @@ def test_file_write_alternative_rejection(mock_user_input, temp_file):
     assert "cancelled" in result["content"][0]["text"].lower()
     assert "review this more" in result["content"][0]["text"]
 
-    # Restore DEV mode if it was set
+    # Restore BYPASS_TOOL_CONSENT mode if it was set
     if current_dev:
-        os.environ["DEV"] = current_dev
+        os.environ["BYPASS_TOOL_CONSENT"] = current_dev
     assert "cancelled" in result["content"][0]["text"]
     assert "I need to review this more" in result["content"][0]["text"]
 

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -397,9 +397,9 @@ def test_custom_headers():
 @responses.activate
 def test_cancellation(monkeypatch):
     """Test request cancellation by user."""
-    # Temporarily override DEV environment variable for this test
-    original_env = os.environ.get("DEV")
-    monkeypatch.setenv("DEV", "false")  # Force DEV mode off
+    # Temporarily override BYPASS_TOOL_CONSENT environment variable for this test
+    original_env = os.environ.get("BYPASS_TOOL_CONSENT")
+    monkeypatch.setenv("BYPASS_TOOL_CONSENT", "false")  # Force BYPASS_TOOL_CONSENT mode off
 
     try:
         # Register a mock response even though we'll cancel before sending
@@ -435,9 +435,9 @@ def test_cancellation(monkeypatch):
     finally:
         # Restore original environment variable state
         if original_env is not None:
-            monkeypatch.setenv("DEV", original_env)
+            monkeypatch.setenv("BYPASS_TOOL_CONSENT", original_env)
         else:
-            monkeypatch.delenv("DEV", raising=False)
+            monkeypatch.delenv("BYPASS_TOOL_CONSENT", raising=False)
 
 
 @responses.activate
@@ -623,7 +623,7 @@ def test_verify_ssl_option():
 
 @responses.activate
 def test_dev_mode_no_confirmation():
-    """Test that in DEV mode, no confirmation is requested for modifying requests."""
+    """Test that in BYPASS_TOOL_CONSENT mode, no confirmation is requested for modifying requests."""
     # Set up mock POST response
     responses.add(
         responses.POST,
@@ -641,15 +641,15 @@ def test_dev_mode_no_confirmation():
         },
     }
 
-    # Set DEV environment variable
+    # Set BYPASS_TOOL_CONSENT environment variable
     original_env = os.environ.copy()
-    os.environ["DEV"] = "true"
+    os.environ["BYPASS_TOOL_CONSENT"] = "true"
 
     try:
-        # In DEV mode, get_user_input should not be called for confirmation
+        # In BYPASS_TOOL_CONSENT mode, get_user_input should not be called for confirmation
         with patch("strands_tools.http_request.get_user_input") as mock_input:
             # This will be called if the test fails
-            mock_input.side_effect = AssertionError("Should not ask for confirmation in DEV mode")
+            mock_input.side_effect = AssertionError("Should not ask for confirmation in BYPASS_TOOL_CONSENT mode")
             result = http_request.http_request(tool=tool_use)
 
         # Verify the result

--- a/tests/test_mem0.py
+++ b/tests/test_mem0.py
@@ -235,11 +235,11 @@ def test_retrieve_memories(mock_opensearch, mock_mem0_client, mock_mem0_service_
     assert memories[0]["id"] == "mem123"
 
 
-@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com", "DEV": "true"})
+@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com", "BYPASS_TOOL_CONSENT": "true"})
 @patch("strands_tools.mem0_memory.Mem0ServiceClient")
 @patch("opensearchpy.OpenSearch")
 def test_delete_memory(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
-    """Test delete memory functionality with DEV mode enabled."""
+    """Test delete memory functionality with BYPASS_TOOL_CONSENT mode enabled."""
     # Setup mocks
     mock_mem0_client.return_value = mock_mem0_service_client
 

--- a/tests/test_memory/test_memory.py
+++ b/tests/test_memory/test_memory.py
@@ -72,11 +72,11 @@ def test_list_documents(mock_get_formatter, mock_get_client, mock_memory_service
     mock_memory_formatter.format_list_response.assert_called_once_with(list_response)
 
 
-@patch.dict(os.environ, {"STRANDS_KNOWLEDGE_BASE_ID": "test123kb", "DEV": "true"})
+@patch.dict(os.environ, {"STRANDS_KNOWLEDGE_BASE_ID": "test123kb", "BYPASS_TOOL_CONSENT": "true"})
 @patch("strands_tools.memory.get_memory_service_client")
 @patch("strands_tools.memory.get_memory_formatter")
 def test_store_document(mock_get_formatter, mock_get_client, mock_memory_service_client, mock_memory_formatter):
-    """Test store document functionality with DEV mode enabled."""
+    """Test store document functionality with BYPASS_TOOL_CONSENT mode enabled."""
     # Setup mocks
     mock_get_client.return_value = mock_memory_service_client
     mock_get_formatter.return_value = mock_memory_formatter
@@ -106,11 +106,11 @@ def test_store_document(mock_get_formatter, mock_get_client, mock_memory_service
     mock_memory_formatter.format_store_response.assert_called_once()
 
 
-@patch.dict(os.environ, {"STRANDS_KNOWLEDGE_BASE_ID": "test123kb", "DEV": "true"})
+@patch.dict(os.environ, {"STRANDS_KNOWLEDGE_BASE_ID": "test123kb", "BYPASS_TOOL_CONSENT": "true"})
 @patch("strands_tools.memory.get_memory_service_client")
 @patch("strands_tools.memory.get_memory_formatter")
 def test_delete_document(mock_get_formatter, mock_get_client, mock_memory_service_client, mock_memory_formatter):
-    """Test delete document functionality with DEV mode enabled."""
+    """Test delete document functionality with BYPASS_TOOL_CONSENT mode enabled."""
     # Setup mocks
     mock_get_client.return_value = mock_memory_service_client
     mock_get_formatter.return_value = mock_memory_formatter

--- a/tests/test_memory/test_memory_error.py
+++ b/tests/test_memory/test_memory_error.py
@@ -127,7 +127,7 @@ def test_list_invalid_max_results(mock_get_client):
     assert "max_results must be between 1 and 1000" in result["content"][0]["text"]
 
 
-@patch.dict(os.environ, {"STRANDS_KNOWLEDGE_BASE_ID": "test123kb", "DEV": "true"})
+@patch.dict(os.environ, {"STRANDS_KNOWLEDGE_BASE_ID": "test123kb", "BYPASS_TOOL_CONSENT": "true"})
 @patch("strands_tools.memory.get_memory_service_client")
 def test_store_api_error(mock_get_client):
     """Test error handling when store operation fails."""
@@ -143,7 +143,7 @@ def test_store_api_error(mock_get_client):
     assert "Error during store operation" in result["content"][0]["text"]
 
 
-@patch.dict(os.environ, {"STRANDS_KNOWLEDGE_BASE_ID": "test123kb", "DEV": "true"})
+@patch.dict(os.environ, {"STRANDS_KNOWLEDGE_BASE_ID": "test123kb", "BYPASS_TOOL_CONSENT": "true"})
 @patch("strands_tools.memory.get_memory_service_client")
 def test_delete_api_error(mock_get_client):
     """Test error handling when delete operation fails."""

--- a/tests/test_memory/test_memory_flow.py
+++ b/tests/test_memory/test_memory_flow.py
@@ -55,7 +55,9 @@ def test_store_with_user_confirmation(
     ]
 
     # Call memory function with store action (which should trigger confirmation flow)
-    with patch.dict(os.environ, {"DEV": "false"}):  # Ensure DEV mode is off to trigger confirmation
+    with patch.dict(
+        os.environ, {"BYPASS_TOOL_CONSENT": "false"}
+    ):  # Ensure BYPASS_TOOL_CONSENT mode is off to trigger confirmation
         result = memory.memory(action="store", content="Test content", title=doc_title)
 
     # Assertions
@@ -79,7 +81,9 @@ def test_store_with_user_cancellation(
     mock_get_user_input.side_effect = ["n", "Changed my mind"]  # User cancels and provides reason
 
     # Call memory function with store action
-    with patch.dict(os.environ, {"DEV": "false"}):  # Ensure DEV mode is off to trigger confirmation
+    with patch.dict(
+        os.environ, {"BYPASS_TOOL_CONSENT": "false"}
+    ):  # Ensure BYPASS_TOOL_CONSENT mode is off to trigger confirmation
         result = memory.memory(action="store", content="Test content", title="Test Title")
 
     # Assertions
@@ -131,7 +135,7 @@ def test_delete_with_document_preview(
     ]
 
     # Call memory function with delete action
-    with patch.dict(os.environ, {"DEV": "false"}):  # Ensure DEV mode is off
+    with patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "false"}):  # Ensure BYPASS_TOOL_CONSENT mode is off
         result = memory.memory(action="delete", document_id=doc_id)
 
     # Assertions
@@ -172,7 +176,7 @@ def test_delete_with_error_in_preview(
     ]
 
     # Call memory function with delete action
-    with patch.dict(os.environ, {"DEV": "false"}):  # Ensure DEV mode is off
+    with patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "false"}):  # Ensure BYPASS_TOOL_CONSENT mode is off
         result = memory.memory(action="delete", document_id=doc_id)
 
     # Assertions

--- a/tests/test_python_repl.py
+++ b/tests/test_python_repl.py
@@ -286,15 +286,15 @@ class TestPythonRepl:
         assert "test_var" not in python_repl.repl_state.get_namespace()
 
     def test_dev_mode_bypass_confirmation(self, mock_console):
-        """Test that DEV mode bypasses the confirmation dialog."""
+        """Test that BYPASS_TOOL_CONSENT mode bypasses the confirmation dialog."""
         tool_use = {
             "toolUseId": "test-id",
             "input": {"code": "dev_mode_test = 42", "interactive": False},
         }
 
-        # Set DEV environment variable to true
-        with patch.dict(os.environ, {"DEV": "true"}):
-            # We shouldn't need to mock get_user_input here since DEV mode should bypass it
+        # Set BYPASS_TOOL_CONSENT environment variable to true
+        with patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"}):
+            # We shouldn't need to mock get_user_input here since BYPASS_TOOL_CONSENT mode should bypass it
             result = python_repl.python_repl(tool=tool_use)
 
             assert result["status"] == "success"

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -106,10 +106,10 @@ def test_shell_cancel_execution(mock_get_user_input, mock_execute_commands):
     # Mock the user input to 'n' (no)
     mock_get_user_input.return_value = "n"
 
-    # Ensure DEV mode is disabled to force confirmation
-    current_dev = os.environ.get("DEV", None)
+    # Ensure BYPASS_TOOL_CONSENT mode is disabled to force confirmation
+    current_dev = os.environ.get("BYPASS_TOOL_CONSENT", None)
     if current_dev:
-        os.environ.pop("DEV")
+        os.environ.pop("BYPASS_TOOL_CONSENT")
 
     # Create a tool use dictionary
     tool_use = {
@@ -120,9 +120,9 @@ def test_shell_cancel_execution(mock_get_user_input, mock_execute_commands):
     # Call the shell function
     result = shell.shell(tool=tool_use)
 
-    # Restore DEV mode if it was set
+    # Restore BYPASS_TOOL_CONSENT mode if it was set
     if current_dev:
-        os.environ["DEV"] = current_dev
+        os.environ["BYPASS_TOOL_CONSENT"] = current_dev
 
     # Verify the result shows cancellation
     assert result["status"] == "error"
@@ -819,8 +819,8 @@ def test_shell_with_work_dir(mock_get_user_input, mock_execute_commands):
 @patch("strands_tools.shell.execute_commands")
 @patch("strands_tools.shell.get_user_input")
 def test_shell_dev_mode(mock_get_user_input, mock_execute_commands, mock_environ):
-    """Test shell tool in DEV mode (skips confirmation)."""
-    # Set DEV mode
+    """Test shell tool in BYPASS_TOOL_CONSENT mode (skips confirmation)."""
+    # Set BYPASS_TOOL_CONSENT mode
     mock_environ.get.return_value = "true"
 
     # Mock setup
@@ -843,7 +843,7 @@ def test_shell_dev_mode(mock_get_user_input, mock_execute_commands, mock_environ
     # Verify the result
     assert result["status"] == "success"
 
-    # Verify get_user_input was not called (no confirmation in DEV mode)
+    # Verify get_user_input was not called (no confirmation in BYPASS_TOOL_CONSENT mode)
     mock_get_user_input.assert_not_called()
 
 

--- a/tests/test_use_aws.py
+++ b/tests/test_use_aws.py
@@ -236,7 +236,7 @@ def test_use_aws_mutative_operation_confirm(
     mock_user_input.return_value = "y"
 
     # Configure environment variable
-    with patch.dict("os.environ", {"DEV": "false"}):
+    with patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "false"}):
         tool_use = {
             "toolUseId": "test-tool-use-id",
             "input": {
@@ -267,7 +267,7 @@ def test_use_aws_mutative_operation_cancel(
     mock_user_input.return_value = "n"
 
     # Configure environment variable
-    with patch.dict("os.environ", {"DEV": "false"}):
+    with patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "false"}):
         tool_use = {
             "toolUseId": "test-tool-use-id",
             "input": {


### PR DESCRIPTION
## Description
rename DEV environment variable to BYPASS_TOOL_CONSENT

## Related Issues
https://github.com/strands-agents/tools/issues/48

## Documentation PR
N/A

## Type of Change
- Breaking change

## Testing
* `hatch fmt`
* `hatch run test-lint`
* `hatch test --all`
* Manually tested with `BYPASS_TOOL_CONSENT=true strands` with agent-builder

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [N/A] I have updated the documentation accordingly
- [N/A] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
