### PR TITLE
fix(file_read): remove redundant base64 encoding of file content

### DIFF
--- a/src/strands_tools/file_read.py
+++ b/src/strands_tools/file_read.py
@@ -96,7 +96,6 @@ agent.tool.file_read(
 See the file_read function docstring for more details on modes and parameters.
 """
 
-import base64
 import glob
 import json
 import os
@@ -188,13 +187,12 @@ def create_document_block(
             name_uuid = str(uuid.uuid4())[:8]
             neutral_name = f"{os.path.splitext(base_name)[0]}-{name_uuid}"
 
-        # Read and encode file content
+        # Read file content
         with open(file_path, "rb") as f:
             content = f.read()
-            encoded = base64.b64encode(content).decode("utf-8")
 
         # Create document block
-        return {"name": neutral_name, "format": format, "source": {"bytes": encoded}}
+        return {"name": neutral_name, "format": format, "source": {"bytes": content}}
 
     except Exception as e:
         raise Exception(f"Error creating document block for {file_path}: {str(e)}") from e


### PR DESCRIPTION
## Description
The AWS SDK automatically base64 encodes binary content when sending requests, but the file_read tool was also encoding it, resulting in double-encoding. According to the Bedrock API documentation: "If you use an AWS SDK, you don't need to encode the bytes in base64."

This change fixes the issue by removing the extra base64 encoding step and letting the bedrock client handle it.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/converse_stream.html

## Related Issues
Fixes #26 

## Documentation PR
N/A

## Type of Change
- [X] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
* installing in my private application

## Checklist
- [X] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
