### PR TITLE
fix: Make use_llm respect callback_handler if passed, otherwise use parent agent's if available (#54)

### DIFF
--- a/src/strands_tools/swarm.py
+++ b/src/strands_tools/swarm.py
@@ -593,6 +593,8 @@ def swarm(tool: ToolUse, **kwargs: Any) -> ToolResult:
             "messages": messages,
             "tool_config": tool_config,
         }
+        if "callback_handler" in kwargs:
+            tool_context["callback_handler"] = kwargs["callback_handler"]
 
         # Extract parameters
         task = tool_input["task"]


### PR DESCRIPTION
## Description
Before, `use_llm` created an agent with the default `callback_handler`, which would make it print to stdout, even if the parent agent's `callback_handler` was changed from the default.

Now, `use_llm` checks for a `callback_handler` to use if passed, otherwise it tries to use the parent's `callback_handler`.  If that is missing, it falls back to using the previous default.

## Related Issues
#54 

## Documentation PR
[Link to related associated PR in the agent-docs repo]
- I don't think this documentation update is necessary

## Type of Change
- [X] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
  - I have updated the doc string
- [ ] I have added an appropriate example to the documentation to outline the feature
  - (I don't think this is necessary)
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
