### PR TITLE
feat: Added support to specify custom AWS region in the memory tool

### DIFF
--- a/src/strands_tools/memory.py
+++ b/src/strands_tools/memory.py
@@ -561,6 +561,7 @@ def memory(
     max_results: int = None,
     next_token: Optional[str] = None,
     min_score: float = None,
+    region_name: str = None,
 ) -> Dict[str, Any]:
     """
     Manage content in a Bedrock Knowledge Base (store, delete, list, get, or retrieve).
@@ -582,6 +583,7 @@ def memory(
         next_token: Token for pagination in 'list' or 'retrieve' action (optional).
         query: The search query for semantic search (required for 'retrieve' action).
         min_score: Minimum relevance score threshold (0.0-1.0) for 'retrieve' action. Default is 0.4.
+        region_name: Optional AWS region name. If not provided, will use the AWS_REGION env variable.
 
     Returns:
         A dictionary containing the result of the operation.
@@ -597,7 +599,7 @@ def memory(
     console = console_util.create()
 
     # Initialize the client and formatter using factory functions
-    client = get_memory_service_client()
+    client = get_memory_service_client(region=region_name)
     formatter = get_memory_formatter()
 
     # Get environment variables at runtime

--- a/tests/test_memory/test_memory.py
+++ b/tests/test_memory/test_memory.py
@@ -106,6 +106,22 @@ def test_store_document(mock_get_formatter, mock_get_client, mock_memory_service
     mock_memory_formatter.format_store_response.assert_called_once()
 
 
+@patch("strands_tools.memory.get_memory_service_client")
+def test_store_document_different_region(mock_memory_service_client):
+    """Test store document functionality with a different region than default."""
+
+    # Mock data
+    doc_title = "Test Title"
+
+    # Call the memory function
+    memory.memory(action="store", content="Test content", title=doc_title, region_name="eu-west-1")
+
+    # Verify correct functions were called and that the specified region was used
+    # memory_service_client uses region as the parameter name,
+    # hile the memory tool uses region_name to maintain the standard of public AWS APIs
+    mock_memory_service_client.assert_called_once_with(region="eu-west-1")
+
+
 @patch.dict(os.environ, {"STRANDS_KNOWLEDGE_BASE_ID": "test123kb", "DEV": "true"})
 @patch("strands_tools.memory.get_memory_service_client")
 @patch("strands_tools.memory.get_memory_formatter")

--- a/tests/test_memory/test_memory.py
+++ b/tests/test_memory/test_memory.py
@@ -106,7 +106,6 @@ def test_store_document(mock_get_formatter, mock_get_client, mock_memory_service
     mock_memory_formatter.format_store_response.assert_called_once()
 
 
-<<<<<<< HEAD
 @patch("strands_tools.memory.get_memory_service_client")
 def test_store_document_different_region(mock_memory_service_client):
     """Test store document functionality with a different region than default."""
@@ -123,10 +122,7 @@ def test_store_document_different_region(mock_memory_service_client):
     mock_memory_service_client.assert_called_once_with(region="eu-west-1")
 
 
-@patch.dict(os.environ, {"STRANDS_KNOWLEDGE_BASE_ID": "test123kb", "DEV": "true"})
-=======
 @patch.dict(os.environ, {"STRANDS_KNOWLEDGE_BASE_ID": "test123kb", "BYPASS_TOOL_CONSENT": "true"})
->>>>>>> origin/main
 @patch("strands_tools.memory.get_memory_service_client")
 @patch("strands_tools.memory.get_memory_formatter")
 def test_delete_document(mock_get_formatter, mock_get_client, mock_memory_service_client, mock_memory_formatter):


### PR DESCRIPTION
* Added region_name optional parameter to memory()
* Created test to validate region_name is properly passed to the knowledge base client## Description

## Related Issues
This closes [[#30](https://github.com/strands-agents/tools/issues/30)]

## Type of Change
- [X] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
Added new test and executed hatch fmt & hatch test 


## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
