### PR TITLE
Remove default 'n' string from get_user_input methods

### DIFF
--- a/src/strands_tools/utils/user_input.py
+++ b/src/strands_tools/utils/user_input.py
@@ -12,7 +12,7 @@ from prompt_toolkit.patch_stdout import patch_stdout
 session: PromptSession | None = None
 
 
-async def get_user_input_async(prompt: str, default: str = "n", keyboard_interrupt_return_default: bool = True) -> str:
+async def get_user_input_async(prompt: str, default: str = "", keyboard_interrupt_return_default: bool = True) -> str:
     """
     Asynchronously get user input with prompt_toolkit's features (history, arrow keys, styling, etc.).
 
@@ -48,7 +48,7 @@ async def get_user_input_async(prompt: str, default: str = "n", keyboard_interru
     return await _get_input()
 
 
-def get_user_input(prompt: str, default: str = "n", keyboard_interrupt_return_default: bool = True) -> str:
+def get_user_input(prompt: str, default: str = "", keyboard_interrupt_return_default: bool = True) -> str:
     """
     Synchronous wrapper for get_user_input_async.
 


### PR DESCRIPTION
## Description
To maintain parity with [agent builder](https://github.com/strands-agents/agent-builder/blob/7a54ef74c0ccc2472770e1c580952fdedaceb4df/src/strands_agents_builder/strands.py#L151), and fix the bug where the message "n" is sent as user input instead of moving onto the next line. 

## Related Issues
https://github.com/strands-agents/tools/issues/38 

## Type of Change
- [x] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
