### PR TITLE
Unset AWS_REGION environment variable for tests

### DIFF
--- a/src/strands_tools/utils/user_input.py
+++ b/src/strands_tools/utils/user_input.py
@@ -12,7 +12,7 @@ from prompt_toolkit.patch_stdout import patch_stdout
 session: PromptSession | None = None
 
 
-async def get_user_input_async(prompt: str, default: str = "n", keyboard_interrupt_return_default: bool = True) -> str:
+async def get_user_input_async(prompt: str, default: str = "", keyboard_interrupt_return_default: bool = True) -> str:
     """
     Asynchronously get user input with prompt_toolkit's features (history, arrow keys, styling, etc.).
 
@@ -48,7 +48,7 @@ async def get_user_input_async(prompt: str, default: str = "n", keyboard_interru
     return await _get_input()
 
 
-def get_user_input(prompt: str, default: str = "n", keyboard_interrupt_return_default: bool = True) -> str:
+def get_user_input(prompt: str, default: str = "", keyboard_interrupt_return_default: bool = True) -> str:
     """
     Synchronous wrapper for get_user_input_async.
 

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -61,6 +61,15 @@ def mock_boto3_client():
         yield mock_client
 
 
+@pytest.fixture(autouse=True)
+def clear_aws_region_env():
+    """Ensure AWS_REGION is not set for any test, and restore it after test is run."""
+    aws_region_env_var = os.environ.pop("AWS_REGION", None)
+    yield
+    if aws_region_env_var is not None:
+        os.environ["AWS_REGION"] = aws_region_env_var
+
+
 def extract_result_text(result):
     """Extract the result text from the agent response."""
     if isinstance(result, dict) and "content" in result and isinstance(result["content"], list):


### PR DESCRIPTION
## Description
Tests were failing locally because I had set AWS_REGION to us-east-1 in my environment variables. Adding a pytest fixture to unset the environment variable (and reset it after tests run) to avoid having to manually reset the variable.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`

Before change:
```
E           AssertionError: expected call not found.
E           Expected: client('bedrock-agent-runtime', region_name='us-west-2')
E             Actual: client('bedrock-agent-runtime', region_name='us-east-1')
E           
E           pytest introspection follows:
E           
E           Kwargs:
E           assert {'region_name': 'us-east-1'} == {'region_name': 'us-west-2'}
E             
E             Differing items:
E             {'region_name': 'us-east-1'} != {'region_name': 'us-west-2'}
E             
E             Full diff:
E               {
E             -     'region_name': 'us-west-2',
E             ?                        -    ^
E             +     'region_name': 'us-east-1',
E             ?                         +   ^
E               }
```

After change:
```
================================================== 536 passed, 5 skipped, 5 warnings in 9.30s ==================================================
(.venv) shanaxml@b0f1d8591f07 tools % echo $AWS_REGION
us-east-1
```

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
