### PR TITLE
feat: add sleep tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ These variables affect multiple tools:
 
 | Environment Variable | Description | Default | 
 |----------------------|-------------|---------|
-| SLEEP_MAX_SECONDS | Maximum allowed sleep duration in seconds | 300 |
+| MAX_SLEEP_SECONDS | Maximum allowed sleep duration in seconds | 300 |
 
 #### Mem0 Memory Tool
 

--- a/src/strands_tools/sleep.py
+++ b/src/strands_tools/sleep.py
@@ -6,7 +6,7 @@ from typing import Union
 from strands import tool
 
 # Default maximum sleep time (5 minutes)
-MAX_SLEEP_SECONDS = int(os.environ.get("SLEEP_MAX_SECONDS", "300"))
+max_sleep_seconds = int(os.environ.get("MAX_SLEEP_SECONDS", "300"))
 
 
 @tool
@@ -21,7 +21,7 @@ def sleep(seconds: Union[int, float]) -> str:
         seconds (Union[int, float]): Number of seconds to sleep.
             Must be a positive number greater than 0 and less than or equal to
             the maximum allowed value (default: 300 seconds, configurable via
-            SLEEP_MAX_SECONDS environment variable).
+            MAX_SLEEP_SECONDS environment variable).
 
     Returns:
         str: A message indicating the sleep completed or was interrupted.
@@ -44,8 +44,8 @@ def sleep(seconds: Union[int, float]) -> str:
     if seconds <= 0:
         raise ValueError("Sleep duration must be greater than 0")
 
-    if seconds > MAX_SLEEP_SECONDS:
-        raise ValueError(f"Sleep duration cannot exceed {MAX_SLEEP_SECONDS} seconds")
+    if seconds > max_sleep_seconds:
+        raise ValueError(f"Sleep duration cannot exceed {max_sleep_seconds} seconds")
 
     try:
         start_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -83,7 +83,7 @@ def test_sleep_keyboard_interrupt(agent):
 def test_sleep_exceeds_max(agent):
     """Test error handling when sleep duration exceeds maximum allowed value."""
     # Temporarily set a smaller max sleep time for testing
-    with mock.patch.dict(os.environ, {"SLEEP_MAX_SECONDS": "10"}):
+    with mock.patch.dict(os.environ, {"MAX_SLEEP_SECONDS": "10"}):
         # This will reload the module with the new environment variable
         import importlib
 


### PR DESCRIPTION
## Description
This PR adds a new sleep tool to the Strands Agents toolkit. 
The tool provides a simple way to pause execution for a specified number of seconds, which can be interrupted with SIGINT (Ctrl+C).

## Related Issues
closes #36 


## Type of Change
- [ ] Bug fix
- [x] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
Added new tests.

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
