### PR TITLE
Fix(multi-agent #20): inherit model from parent/caller in swarm, agent graph, workflow, use_llm and think tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ errors/
 repl_state/
 venv/
 *.egg-info
+.idea

--- a/src/strands_tools/agent_graph.py
+++ b/src/strands_tools/agent_graph.py
@@ -513,6 +513,7 @@ def agent_graph(tool: ToolUse, **kwargs: Any) -> ToolResult:
     inference_config = kwargs.get("inference_config")
     messages = kwargs.get("messages")
     tool_config = kwargs.get("tool_config")
+    agent = kwargs.get("agent")
 
     try:
         # Create tool context
@@ -522,6 +523,7 @@ def agent_graph(tool: ToolUse, **kwargs: Any) -> ToolResult:
             "inference_config": inference_config,
             "messages": messages,
             "tool_config": tool_config,
+            "agent": agent,
         }
 
         # Get manager instance thread-safely

--- a/src/strands_tools/memory.py
+++ b/src/strands_tools/memory.py
@@ -583,7 +583,7 @@ def memory(
         next_token: Token for pagination in 'list' or 'retrieve' action (optional).
         query: The search query for semantic search (required for 'retrieve' action).
         min_score: Minimum relevance score threshold (0.0-1.0) for 'retrieve' action. Default is 0.4.
-        region_name: Optional AWS region name. If not provided, will use the AWS_REGION env variable. 
+        region_name: Optional AWS region name. If not provided, will use the AWS_REGION env variable.
             If AWS_REGION is not specified, it will default to us-west-2.
 
     Returns:

--- a/src/strands_tools/swarm.py
+++ b/src/strands_tools/swarm.py
@@ -586,12 +586,14 @@ def swarm(tool: ToolUse, **kwargs: Any) -> ToolResult:
         inference_config = kwargs.get("inference_config")
         messages = kwargs.get("messages")
         tool_config = kwargs.get("tool_config")
+        agent = kwargs.get("agent")
         # Create tool context
         tool_context = {
             "system_prompt": system_prompt,
             "inference_config": inference_config,
             "messages": messages,
             "tool_config": tool_config,
+            "agent": agent,
         }
         if "callback_handler" in kwargs:
             tool_context["callback_handler"] = kwargs["callback_handler"]

--- a/src/strands_tools/think.py
+++ b/src/strands_tools/think.py
@@ -95,13 +95,21 @@ Please provide your analysis directly:
         # Get tools from parent agent if available
         tools = []
         trace_attributes = {}
+        extra_kwargs = {}
         parent_agent = kwargs.get("agent")
         if parent_agent:
             tools = list(parent_agent.tool_registry.registry.values())
             trace_attributes = parent_agent.trace_attributes
+            extra_kwargs["model"] = parent_agent.model
 
         # Initialize the new Agent with provided parameters
-        agent = Agent(messages=[], tools=tools, system_prompt=custom_system_prompt, trace_attributes=trace_attributes)
+        agent = Agent(
+            messages=[],
+            tools=tools,
+            system_prompt=custom_system_prompt,
+            trace_attributes=trace_attributes,
+            **extra_kwargs,
+        )
 
         # Run the agent with the provided prompt
         result = agent(prompt)

--- a/src/strands_tools/use_llm.py
+++ b/src/strands_tools/use_llm.py
@@ -126,6 +126,7 @@ def use_llm(tool: ToolUse, **kwargs: Any) -> ToolResult:
         tools = list(parent_agent.tool_registry.registry.values())
         trace_attributes = parent_agent.trace_attributes
         extra_kwargs["callback_handler"] = parent_agent.callback_handler
+        extra_kwargs["model"] = parent_agent.model
     if "callback_handler" in kwargs:
         extra_kwargs["callback_handler"] = kwargs["callback_handler"]
 


### PR DESCRIPTION
## Description
### Summary

- In the multi-agent systems (Swarm, Agent Graph, Workflow) + (use llm, think tools), when new dynamic agents (nodes) are created, they were incorrectly defaulting to the global model. This caused mismatches and unintended behaviours, especially when different agents were intended to use different models.

- This PR resolves that by ensuring all dynamically created agents consistently inherit the `model` from the parent (caller) agent across the Swarm, Agent Graph, Workflow systems and use llm , think tools.
[Provide a detailed description of the changes in this PR]

## Related Issues
Fix [#20](https://github.com/strands-agents/tools/issues/20)
[Link to related issues using #issue-number format]

## Documentation PR
[Link to related associated PR in the agent-docs repo]

## Type of Change
- [x] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
