### PR TITLE
Remove allOf from Mem0 Tool Spec

### DIFF
--- a/src/strands_tools/mem0_memory.py
+++ b/src/strands_tools/mem0_memory.py
@@ -140,13 +140,7 @@ TOOL_SPEC = {
                     "description": "Optional metadata to store with the memory",
                 },
             },
-            "required": ["action"],
-            "allOf": [
-                {
-                    "if": {"properties": {"action": {"enum": ["store", "list", "retrieve"]}}},
-                    "then": {"oneOf": [{"required": ["user_id"]}, {"required": ["agent_id"]}]},
-                }
-            ],
+            "required": ["action"]
         }
     },
 }


### PR DESCRIPTION
## Description
As the `allOf` was causing the issue in Mem0 Tool Spec so removing it.

## Related Issues
[Link to related issues using #issue-number format]

## Documentation PR
[Link to related associated PR in the agent-docs repo]

## Type of Change
- [x] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
[How have you tested the change?]

* `hatch fmt --linter` - Yes
* `hatch fmt --formatter` - Yes
* `hatch test --all` - Yes


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
