### PR TITLE
fix: Current time tool test fails on Ubuntu Linux with TZ as US/Pacific

### DIFF
--- a/tests/test_current_time.py
+++ b/tests/test_current_time.py
@@ -56,7 +56,7 @@ def test_current_time_direct_utc(agent):
 def test_current_time_direct_custom_timezone(agent):
     """Test direct invocation with a custom timezone."""
     # Test with US/Pacific timezone
-    result = agent.tool.current_time(timezone="US/Pacific")
+    result = agent.tool.current_time(timezone="America/Los_Angeles")
 
     result_text = extract_result_text(result)
 
@@ -71,7 +71,7 @@ def test_current_time_direct_custom_timezone(agent):
 
     # Verify the time is roughly correct by comparing to UTC with appropriate offset
     returned_time = datetime.fromisoformat(result_text)
-    pacific_tz = ZoneInfo("US/Pacific")
+    pacific_tz = ZoneInfo("America/Los_Angeles")
     now_pacific = datetime.now(pacific_tz)
 
     # Times should be within 5 seconds of each other


### PR DESCRIPTION
## Description
Current time tool test fails on Ubuntu Linux with TZ as US/Pacific. Details reported in bug #84

## Related Issues
#84 

## Documentation PR
N/A

## Type of Change
- [ x] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
Passed all the tests using hatch successfully

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
