### PR TITLE
feat(tools): add use_computer tool to Strands tools repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Strands Agents Tools is a community-driven project that provides a powerful set 
 - 🔍 **Browser Tool** - Tool giving an agent access to perform automated actions on a browser (chromium)
 - 📈 **Diagram** - Create AWS cloud diagrams, basic diagrams, or UML diagrams using python libraries
 - 📰 **RSS Feed Manager** - Subscribe, fetch, and process RSS feeds with content filtering and persistent storage
+- 🖱️ **Computer Tool** - Automate desktop actions including mouse movements, keyboard input, screenshots, and application management
 
 ## 📦 Installation
 
@@ -68,7 +69,7 @@ pip install strands-agents-tools
 To install the dependencies for optional tools:
 
 ```bash
-pip install strands-agents-tools[mem0_memory, use_browser, rss]
+pip install strands-agents-tools[mem0_memory, use_browser, rss, use_computer]
 ```
 
 ### Development Install
@@ -132,6 +133,7 @@ Below is a comprehensive table of all available tools, how to use them with an a
 | browser | `browser = LocalChromiumBrowser(); agent = Agent(tools=[browser.browser])` | Web scraping, automated testing, form filling, web automation tasks |
 | diagram | `agent.tool.diagram(diagram_type="cloud", nodes=[{"id": "s3", "type": "S3"}], edges=[])` | Create AWS cloud architecture diagrams, network diagrams, graphs, and UML diagrams (all 14 types) |
 | rss | `agent.tool.rss(action="subscribe", url="https://example.com/feed.xml", feed_id="tech_news")` | Manage RSS feeds: subscribe, fetch, read, search, and update content from various sources |
+| use_computer | `agent.tool.use_computer(action="click", x=100, y=200, app_name="Chrome") ` | Desktop automation, GUI interaction, screen capture |
 
 \* *These tools do not work on windows*
 
@@ -543,6 +545,33 @@ latest_news = agent.tool.rss(
     action="fetch",
     url="https://blog.example.org/feed",
     max_entries=3
+)
+```
+
+### Use Computer
+
+```python
+from strands import Agent
+from strands_tools import use_computer
+
+agent = Agent(tools=[use_computer])
+
+# Find mouse position
+result = agent.tool.use_computer(action="mouse_position")
+
+# Automate adding text
+result = agent.tool.use_computer(action="type", text="Hello, world!", app_name="Notepad")
+
+# Analyze current computer screen
+result = agent.tool.use_computer(action="analyze_screen")
+
+result = agent.tool.use_computer(action="open_app", app_name="Calculator")
+result = agent.tool.use_computer(action="close_app", app_name="Calendar")
+
+result = agent.tool.use_computer(
+    action="hotkey",
+    hotkey_str="command+ctrl+f",  # For macOS
+    app_name="Chrome"
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,15 @@ diagram = [
     "diagrams>=0.23.0,<1.0.0",
 ]
 rss = ["feedparser>=6.0.10,<7.0.0", "html2text>=2020.1.16,<2021.0.0"]
+use_computer = [
+    "opencv-python>=4.5.0,<5.0.0", 
+    "psutil>=5.8.0,<6.0.0", 
+    "pyautogui>=0.9.53,<1.0.0", 
+    "pytesseract>=0.3.8,<1.0.0"
+]
 
 [tool.hatch.envs.hatch-static-analysis]
-features = ["mem0_memory", "local_chromium_browser", "agent_core_browser", "agent_core_code_interpreter", "a2a_client", "diagram", "rss"]
+features = ["mem0_memory", "local_chromium_browser", "agent_core_browser", "agent_core_code_interpreter", "a2a_client", "diagram", "rss", "use_computer"]
 dependencies = [
     "strands-agents>=1.0.0",
     "mypy>=0.981,<1.0.0",
@@ -119,7 +125,7 @@ lint-check = [
 lint-fix = ["ruff check --fix"]
 
 [tool.hatch.envs.hatch-test]
-features = ["mem0_memory", "local_chromium_browser",  "agent_core_browser", "agent_core_code_interpreter", "a2a_client", "diagram", "rss"]
+features = ["mem0_memory", "local_chromium_browser",  "agent_core_browser", "agent_core_code_interpreter", "a2a_client", "diagram", "rss", "use_computer"]
 extra-dependencies = [
     "moto>=5.1.0,<6.0.0",
     "pytest>=8.0.0,<9.0.0",

--- a/src/strands_tools/use_computer.py
+++ b/src/strands_tools/use_computer.py
@@ -1,0 +1,734 @@
+import inspect
+import logging
+import os
+import platform
+import subprocess
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import cv2
+import numpy as np
+import psutil
+import pyautogui
+import pytesseract
+from strands import tool
+
+from strands_tools.utils.user_input import get_user_input
+
+# Import libraries for macOS
+if platform.system().lower() == "darwin":
+    from Quartz.CoreGraphics import (
+        CGEventCreateMouseEvent,
+        CGEventPost,
+        CGEventSetIntegerValueField,
+        kCGEventLeftMouseDown,
+        kCGEventLeftMouseUp,
+        kCGHIDEventTap,
+        kCGMouseButtonLeft,
+        kCGMouseEventClickState,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class UseComputerMethods:
+    def __init__(self):
+        pyautogui.FAILSAFE = True
+        pyautogui.PAUSE = 0.1  # Add small delay between actions for stability
+
+    # Basic Computer Automation Actions
+    def mouse_position(self):
+        x, y = pyautogui.position()
+        return f"Mouse position: ({x}, {y})"
+
+    def click(self, x: int, y: int, click_type: str = "left") -> str:
+        """Handle mouse clicks."""
+        x, y = self._prepare_mouse_position(x, y)
+        system = platform.system().lower()
+
+        if click_type == "left":
+            pyautogui.click()
+        elif click_type == "right":
+            pyautogui.rightClick()
+        elif click_type == "double":
+            if system == "darwin":
+                self._native_mac_double_click(x, y)
+            else:
+                pyautogui.click(clicks=2, interval=0.2)
+            time.sleep(0.1)
+        elif click_type == "middle":
+            pyautogui.middleClick()
+        else:
+            raise ValueError(f"Unknown click type: {click_type}")
+
+        return f"{click_type.title()} clicked at ({x}, {y})"
+
+    def move_mouse(self, x: int, y: int) -> str:
+        """Move mouse to specified coordinates."""
+        x, y = self._prepare_mouse_position(x, y, duration=0.5)
+        return f"Moved mouse to ({x}, {y})"
+
+    def drag(
+        self,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        drag_to_x: Optional[int] = None,
+        drag_to_y: Optional[int] = None,
+        duration: float = 1.0,
+        **kwargs,
+    ) -> str:
+        """
+        Perform a drag operation from one point to another.
+
+        Args:
+            x (Optional[int]): Starting X coordinate. If None, uses current mouse position.
+            y (Optional[int]): Starting Y coordinate. If None, uses current mouse position.
+            drag_to_x (int): Ending X coordinate.
+            drag_to_y (int): Ending Y coordinate.
+            duration (float): Duration of the drag operation in seconds.
+
+        Returns:
+            str: Description of the drag operation performed.
+        """
+        if drag_to_x is None or drag_to_y is None:
+            raise ValueError("Missing drag destination coordinates")
+
+        # If x and y are provided, move to that position first
+        if x is not None and y is not None:
+            x, y = self._prepare_mouse_position(x, y, duration=0.3)
+        else:
+            # If x and y are not provided, use current mouse position
+            x, y = pyautogui.position()
+
+        try:
+            # Use pyautogui.drag() which handles the complete drag operation
+            pyautogui.drag(drag_to_x - x, drag_to_y - y, duration=duration, button="left")
+            return f"Dragged from ({x}, {y}) to ({drag_to_x}, {drag_to_y})"
+        except Exception as e:
+            raise Exception(f"Drag operation failed: {str(e)}") from e
+
+    def scroll(
+        self,
+        x: Optional[int],
+        y: Optional[int],
+        app_name: Optional[str],
+        scroll_direction: str = "up",
+        scroll_amount: int = 15,
+        click_first: bool = True,
+    ) -> str:
+        """Handle scrolling actions."""
+        if x is None or y is None:
+            if app_name:
+                screen_width, screen_height = pyautogui.size()
+                x = screen_width // 2
+                y = screen_height // 2
+                logger.info(f"No coordinates provided for scroll, using app center: ({x}, {y})")
+            else:
+                raise ValueError(
+                    "Missing x or y coordinates for scrolling. "
+                    "For scrolling to work, mouse must be over the scrollable area."
+                )
+
+        pyautogui.moveTo(x, y, duration=0.3)
+
+        # Click to ensure the scrollable area has focus
+        if click_first:
+            pyautogui.click()
+            time.sleep(0.1)
+
+        if scroll_direction in ["up", "down"]:
+            scroll_value = scroll_amount if scroll_direction == "up" else -scroll_amount
+            pyautogui.scroll(scroll_value)
+
+        elif scroll_direction in ["left", "right"]:
+            # horizontal scrolling is handled differently on mac
+            if platform.system().lower() == "darwin":
+                # Use keycode for macOS
+                keycode = 124 if scroll_direction == "right" else 123  # macOS keycodes
+                for _ in range(scroll_amount):
+                    subprocess.run(
+                        ["osascript", "-e", f'tell application "System Events" to key code {keycode}'], check=False
+                    )
+                    time.sleep(0.01)
+            else:
+                # Use hscroll for Windows/Linux
+                scroll_value = scroll_amount if scroll_direction == "right" else -scroll_amount
+                pyautogui.hscroll(scroll_value)
+
+        return f"Scrolled {scroll_direction} by {scroll_amount} steps at coordinates ({x}, {y})"
+
+    def type(self, text: str) -> str:
+        """Type specified text."""
+        if not text:
+            raise ValueError("No text provided for typing")
+        pyautogui.typewrite(text)
+        return f"Typed: {text}"
+
+    def key_press(self, key: str, modifier_keys: Optional[List[str]] = None) -> str:
+        """Handle key press actions."""
+        if not key:
+            raise ValueError("No key specified for key press")
+
+        if modifier_keys:
+            keys_to_press = modifier_keys + [key]
+            pyautogui.hotkey(*keys_to_press)
+            return f"Pressed key combination: {'+'.join(keys_to_press)}"
+        else:
+            pyautogui.press(key)
+            return f"Pressed key: {key}"
+
+    def key_hold(
+        self, key: Optional[str] = None, modifier_keys: Optional[List[str]] = None, hold_duration: float = 0.1, **kwargs
+    ) -> str:
+        if not key:
+            raise ValueError("No key specified for key hold")
+
+        if modifier_keys:
+            # Hold modifier keys and press main key
+            for mod_key in modifier_keys:
+                pyautogui.keyDown(mod_key)
+
+            pyautogui.press(key)
+
+            for mod_key in reversed(modifier_keys):
+                pyautogui.keyUp(mod_key)
+
+            return f"Held {'+'.join(modifier_keys)} and pressed {key}"
+        else:
+            pyautogui.keyDown(key)
+            time.sleep(0.1)
+            pyautogui.keyUp(key)
+            return f"Held and released key: {key}"
+
+    def hotkey(self, hotkey_str: str) -> str:
+        """Handle hotkey combinations."""
+        if not hotkey_str:
+            raise ValueError("No hotkey string provided for hotkey action")
+
+        keys = hotkey_str.split("+")
+
+        if platform.system().lower() == "darwin":  # macOS
+            keys = ["command" if k.lower() == "cmd" else k for k in keys]
+
+        pyautogui.hotkey(*keys)
+        logger.info(f"Executing hotkey combination: {keys}")
+
+        return f"Pressed hotkey combination: {hotkey_str}"
+
+    def screenshot(self, region: Optional[List[int]] = None) -> str:
+        """Capture screen screenshot."""
+        filepath = create_screenshot(region)
+        return f"Screenshot saved to {filepath}"
+
+    def analyze_screenshot(
+        self, screenshot_path: Optional[str] = None, region: Optional[List[int]] = None, min_confidence: float = 0.5
+    ) -> str:
+        return handle_analyze_screenshot(screenshot_path, region, min_confidence)
+
+    def screen_size(self) -> str:
+        """Get screen dimensions."""
+        width, height = pyautogui.size()
+        return f"Screen size: {width}x{height}"
+
+    def open_app(self, app_name):
+        logger.info(f"Opening application: {app_name}")
+        if not app_name:
+            raise ValueError("No application name provided")
+        return open_application(app_name)
+
+    def close_app(self, app_name):
+        if not app_name:
+            raise ValueError("No application name provided")
+        return close_application(app_name)
+
+    # I cannot find a way to double click using pyautoguis built in functions on macos
+    # This function uses lower level mac functions to double click
+    def _native_mac_double_click(self, x: int, y: int):
+        """Perform a true macOS native double-click using Quartz."""
+
+        for i in range(2):
+            click_down = CGEventCreateMouseEvent(None, kCGEventLeftMouseDown, (x, y), kCGMouseButtonLeft)
+            click_up = CGEventCreateMouseEvent(None, kCGEventLeftMouseUp, (x, y), kCGMouseButtonLeft)
+
+            # Set click state: 1 = first click, 2 = second click
+            CGEventSetIntegerValueField(click_down, kCGMouseEventClickState, i + 1)
+            CGEventSetIntegerValueField(click_up, kCGMouseEventClickState, i + 1)
+
+            CGEventPost(kCGHIDEventTap, click_down)
+            CGEventPost(kCGHIDEventTap, click_up)
+
+            # Small delay between clicks for proper double-click timing
+            if i == 0:
+                time.sleep(0.05)
+
+    def _prepare_mouse_position(self, x: int, y: int, duration: float = 0.1) -> tuple[int, int]:
+        """Move mouse to specified coordinates with error handling."""
+        if x is None or y is None:
+            raise ValueError("Missing x or y coordinates")
+        pyautogui.moveTo(x, y, duration=duration)
+        time.sleep(0.05)  # Let pointer settle
+        return x, y
+
+
+def create_screenshot(region: Optional[List[int]] = None) -> str:
+    """Helper function to create and save a screenshot."""
+    screenshots_dir = "screenshots"
+    if not os.path.exists(screenshots_dir):
+        os.makedirs(screenshots_dir)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"screenshot_{timestamp}.png"
+    filepath = os.path.join(screenshots_dir, filename)
+
+    if region:
+        screenshot = pyautogui.screenshot(region=region)
+    else:
+        screenshot = pyautogui.screenshot()
+
+    screenshot.save(filepath)
+    return filepath
+
+
+# Helper function to sort the text extracted from the screenshots
+def group_text_by_lines(text_data: List[Dict[str, Any]], line_threshold: int = 10) -> List[List[Dict[str, Any]]]:
+    """Group text elements into lines based on y-coordinate proximity."""
+    if not text_data:
+        return []
+
+    # Sort by y-coordinate
+    sorted_data = sorted(text_data, key=lambda x: x["coordinates"]["y"])
+
+    lines = []
+    current_line = [sorted_data[0]]
+
+    for item in sorted_data[1:]:
+        # If y-coordinate is close to the previous item, keep in the same line
+        if abs(item["coordinates"]["y"] - current_line[-1]["coordinates"]["y"]) <= line_threshold:
+            current_line.append(item)
+        else:
+            # Sort current line by x-coordinate to get words in order
+            current_line.sort(key=lambda x: x["coordinates"]["x"])
+            lines.append(current_line)
+            current_line = [item]
+
+    # For the last line
+    if current_line:
+        current_line.sort(key=lambda x: x["coordinates"]["x"])
+        lines.append(current_line)
+
+    return lines
+
+
+def extract_text_from_image(image_path: str, min_confidence: float = 0.5) -> List[Dict[str, Any]]:
+    """
+    Extract text and coordinates from an image using Tesseract OCR.
+
+    Args:
+        image_path: Path to the image file
+        min_confidence: Minimum confidence level for OCR text detection (0.0-1.0)
+
+    Returns:
+        List of dictionaries with text and its coordinates
+    """
+    # Read the image
+    img = cv2.imread(image_path)
+    if img is None:
+        raise ValueError(f"Could not read image at {image_path}")
+
+    # Get image dimensions for potential scaling adjustments
+    img_height, img_width = img.shape[:2]
+
+    # Scale image if it's too small for good OCR (upscale by 2x if smaller than 1000px)
+    scale_factor = 1.0
+    if img_width < 1000 or img_height < 1000:
+        scale_factor = 2.0
+        img = cv2.resize(img, None, fx=scale_factor, fy=scale_factor, interpolation=cv2.INTER_CUBIC)
+
+    # Apply preprocessing to improve OCR accuracy
+    # Convert to grayscale
+    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+
+    # Apply noise reduction
+    denoised = cv2.medianBlur(gray, 3)
+
+    clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))  # Contrast Limited Adaptive Histogram Equalization
+    enhanced = clahe.apply(denoised)
+
+    # Apply sharpening kernel to improve text clarity
+    kernel = np.array([[-1, -1, -1], [-1, 9, -1], [-1, -1, -1]])
+    sharpened = cv2.filter2D(enhanced, -1, kernel)
+
+    gray = sharpened  # Use the enhanced image
+
+    # Try multiple OCR configurations for better text detection
+    # Include character whitelist for common characters to reduce noise
+    char_whitelist = (
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" ".,!?;:()[]{}\"'-_@#$%^&*+=<>/|\\~`"
+    )
+
+    configs = [
+        f"--oem 3 --psm 11 -c tessedit_char_whitelist={char_whitelist}",  # Sparse text with whitelist
+        "--oem 3 --psm 11",  # Sparse text without whitelist
+        "--oem 3 --psm 6",  # Single uniform block
+        "--oem 3 --psm 3",  # Fully automatic page segmentation
+        "--oem 3 --psm 8",  # Single word
+    ]
+
+    all_results = []
+    for config in configs:
+        try:
+            data = pytesseract.image_to_data(gray, config=config, output_type=pytesseract.Output.DICT)
+            all_results.append(data)
+        except Exception:
+            continue
+
+    # Use the configuration that detected the most text
+    if not all_results:
+        raise ValueError("OCR failed with all configurations")
+
+    data = max(all_results, key=lambda d: len([t for t in d["text"] if t.strip()]))
+
+    # Check for potential scaling issues by comparing with screen resolution
+    screen_width, screen_height = pyautogui.size()
+    scale_factor_x = 1.0
+    scale_factor_y = 1.0
+
+    # If the image dimensions don't match the screen dimensions, calculate scaling factors
+    if abs(img_width - screen_width) > 5 or abs(img_height - screen_height) > 5:
+        scale_factor_x = screen_width / img_width
+        scale_factor_y = screen_height / img_height
+
+    # Extract text and coordinates
+    results = []
+    for i in range(len(data["text"])):
+        if data["text"][i].strip() and float(data["conf"][i]) > min_confidence * 100:  # Tesseract confidence is 0-100
+            x, y, w, h = data["left"][i], data["top"][i], data["width"][i], data["height"][i]
+
+            # Apply scaling if necessary (account for both image upscaling and screen scaling)
+            adjusted_x = int((x / scale_factor) * scale_factor_x)
+            adjusted_y = int((y / scale_factor) * scale_factor_y)
+            adjusted_w = int((w / scale_factor) * scale_factor_x)
+            adjusted_h = int((h / scale_factor) * scale_factor_y)
+
+            # Calculate center with safety bounds checking
+            center_x = adjusted_x + adjusted_w // 2
+            center_y = adjusted_y + adjusted_h // 2
+
+            # Ensure coordinates are within screen bounds
+            center_x = max(0, min(center_x, screen_width))
+            center_y = max(0, min(center_y, screen_height))
+
+            results.append(
+                {
+                    "text": data["text"][i],
+                    "coordinates": {
+                        "x": adjusted_x,
+                        "y": adjusted_y,
+                        "width": adjusted_w,
+                        "height": adjusted_h,
+                        "center_x": center_x,
+                        "center_y": center_y,
+                        "raw_x": x,  # Store original coordinates for debugging
+                        "raw_y": y,
+                        "scaling_applied": (scale_factor_x != 1.0 or scale_factor_y != 1.0),
+                    },
+                    "confidence": float(data["conf"][i]) / 100,
+                }
+            )
+
+    # Group text into lines for better organization
+    lines = group_text_by_lines(results)
+
+    # Add line information to each text element
+    for line_idx, line in enumerate(lines):
+        for item in line:
+            item["line_number"] = line_idx
+            item["line_text"] = " ".join([text_item["text"] for text_item in line])
+
+    return results
+
+
+def open_application(app_name: str) -> str:
+    """Helper function to open applications cross-platform."""
+    system = platform.system().lower()
+
+    # Map common app name variations to their actual names
+    app_mappings = {
+        "outlook": "Microsoft Outlook",
+        "word": "Microsoft Word",
+        "excel": "Microsoft Excel",
+        "powerpoint": "Microsoft PowerPoint",
+        "chrome": "Google Chrome",
+        "firefox": "Firefox",
+        "safari": "Safari",
+        "notes": "Notes",
+        "calculator": "Calculator",
+        "terminal": "Terminal",
+        "finder": "Finder",
+    }
+
+    # Use mapped name if available, otherwise use original
+    actual_app_name = app_mappings.get(app_name.lower(), app_name)
+
+    try:
+        if system == "windows":
+            result = subprocess.run(f"start {actual_app_name}", shell=True, capture_output=True, text=True)
+        elif system == "darwin":  # macOS
+            result = subprocess.run(["open", "-a", actual_app_name], capture_output=True, text=True)
+        elif system == "linux":
+            result = subprocess.run([actual_app_name.lower()], capture_output=True, text=True)
+
+        if result.returncode == 0:
+            return f"Launched {actual_app_name}"
+        else:
+            return f"Unable to find application named '{actual_app_name}'"
+    except Exception as e:
+        return f"Error launching {actual_app_name}: {str(e)}"
+
+
+def close_application(app_name: str) -> str:
+    """Helper function to close applications cross-platform."""
+    if not psutil:
+        return "psutil not available - cannot close applications"
+
+    try:
+        closed_count = 0
+        for proc in psutil.process_iter(["pid", "name"]):
+            if app_name.lower() in proc.info["name"].lower():
+                proc.terminate()
+                closed_count += 1
+
+        if closed_count > 0:
+            return f"Closed {closed_count} instance(s) of {app_name}"
+        else:
+            return f"No running instances of {app_name} found"
+    except Exception as e:
+        return f"Error closing {app_name}: {str(e)}"
+
+
+def focus_application(app_name: str) -> bool:
+    """Focus on the specified application window."""
+    system = platform.system().lower()
+
+    try:
+        if system == "darwin":  # macOS
+            # Use AppleScript to bring app to front
+            script = f'tell application "{app_name}" to activate'
+            subprocess.run(["osascript", "-e", script], check=True, capture_output=True)
+            time.sleep(0.2)  # Brief pause for window to focus
+            return True
+        elif system == "windows":
+            # Use PowerShell to focus window
+            script = (
+                f"Add-Type -AssemblyName Microsoft.VisualBasic; "
+                f"[Microsoft.VisualBasic.Interaction]::AppActivate('{app_name}')"
+            )
+            subprocess.run(["powershell", "-Command", script], check=True, capture_output=True)
+            time.sleep(0.2)
+            return True
+        elif system == "linux":
+            # Use wmctrl if available
+            subprocess.run(["wmctrl", "-a", app_name], check=True, capture_output=True)
+            time.sleep(0.2)
+            return True
+    except Exception:
+        return False
+
+    return False
+
+
+def delete_screenshot(filepath: str) -> None:
+    """Helper function to delete a screenshot file."""
+    try:
+        if os.path.exists(filepath):
+            os.remove(filepath)
+    except Exception:
+        pass  # Silently ignore deletion errors
+
+
+def handle_analyze_screenshot(
+    screenshot_path: Optional[str], region: Optional[List[int]], min_confidence: float = 0.5
+) -> str:
+    """Extract text and coordinates from screenshot."""
+    # Check if screenshot_path was given then do not delete the screenshot
+    if screenshot_path:
+        if not os.path.exists(screenshot_path):
+            raise ValueError(f"Screenshot not found at {screenshot_path}")
+        image_path = screenshot_path
+        should_delete = False
+    else:
+        image_path = create_screenshot(region)
+        should_delete = True
+
+    try:
+        text_data = extract_text_from_image(image_path, min_confidence)
+        if not text_data:
+            result = f"No text detected in screenshot {image_path}"
+        else:
+            formatted_result = f"Detected {len(text_data)} text elements in {image_path}:\n\n"
+            for idx, item in enumerate(text_data, 1):
+                coords = item["coordinates"]
+                formatted_result += (
+                    f"{idx}. Text: '{item['text']}'\n"
+                    f"   Confidence: {item['confidence']:.2f}\n"
+                    f"   Position: X={coords['x']}, Y={coords['y']}, "
+                    f"W={coords['width']}, H={coords['height']}\n"
+                    f"   Center: ({coords['center_x']}, {coords['center_y']})\n\n"
+                )
+            result = formatted_result
+
+        if should_delete:
+            delete_screenshot(image_path)
+
+        return result
+
+    except Exception as e:
+        if should_delete:
+            delete_screenshot(image_path)
+        return f"Error analyzing screenshot: {str(e)}"
+
+
+@tool
+def use_computer(
+    action: str,
+    x: Optional[int] = None,
+    y: Optional[int] = None,
+    text: Optional[str] = None,
+    key: Optional[str] = None,
+    region: Optional[List[int]] = None,
+    app_name: Optional[str] = None,
+    click_type: Optional[str] = None,
+    modifier_keys: Optional[List[str]] = None,
+    scroll_direction: Optional[str] = None,
+    scroll_amount: Optional[int] = None,
+    drag_to_x: Optional[int] = None,
+    drag_to_y: Optional[int] = None,
+    screenshot_path: Optional[str] = None,
+    hotkey_str: Optional[str] = None,
+    min_confidence: Optional[float] = 0.5,
+) -> str:
+    """
+    Control computer using mouse, keyboard, and capture screenshots.
+    IMPORTANT: When performing actions within an application (clicking, typing, etc.),
+    always provide the app_name parameter to ensure proper focus on the target application.
+
+    Args:
+        action (str): The action to perform. Must be one of:
+            - mouse_position: Get current mouse coordinates
+            - click: Click at specified coordinates (requires app_name when clicking in application)
+            - move_mouse: Move mouse to specified coordinates (requires app_name when moving to application elements)
+            - drag: Click and drag from current position (requires app_name when dragging in application)
+            - scroll: Scroll in specified direction
+                (requires x,y coordinates and app_name when scrolling in application)
+            - type: Type specified text (requires app_name)
+            - key_press: Press specified key (requires app_name)
+            - key_hold: Hold key combination (requires app_name)
+            - hotkey: Press a hotkey combination (requires app_name)
+            - screenshot: Capture screen
+                (optionally in specified region or active window)(requires app_name when screenshotting an app)
+            - analyze_screenshot: Extract text and coordinates from screenshot
+            - screen_size: Get screen dimensions
+            - open_app: Open specified application
+            - close_app: Close specified application
+
+        app_name (str): Name of application to focus on before performing actions.
+            Required for all actions that interact with application windows
+            (clicking, typing, key presses, etc.). Examples: "Chrome", "Firefox", "Notepad"
+        x (int, optional): X coordinate for mouse actions
+        y (int, optional): Y coordinate for mouse actions
+        text (str, optional): Text to type
+        key (str, optional): Key to press (e.g., 'enter', 'tab', 'space')
+        region (List[int], optional): Region for screenshot [left, top, width, height]
+        click_type (str, optional): Type of click ('left', 'right', 'double', 'middle')
+        modifier_keys (List[str], optional): Modifier keys to hold ('shift', 'ctrl', 'alt', 'command')
+        scroll_direction (str, optional): Scroll direction ('up', 'down', 'left', 'right')
+        scroll_amount (int, optional): Number of scroll steps (default: 3)
+        drag_to_x (int, optional): X coordinate to drag to
+        drag_to_y (int, optional): Y coordinate to drag to
+        screenshot_path (str, optional): Path to screenshot file for analysis
+        hotkey_str (str, optional): Hotkey combination string (e.g., 'ctrl+c', 'alt+tab', 'ctrl+shift+esc')
+        min_confidence (float, optional): Minimum confidence level for OCR text detection (default: 0.5)
+
+    Returns:
+        str: Description of the action result or error message
+
+    Example Usage:
+        # Correct usage - with app_name for application interaction
+        use_computer(action="type", text="Hello world", app_name="Notepad")
+        use_computer(action="click", x=100, y=200, app_name="Chrome")
+
+        # Actions that don't require app_name
+        use_computer(action="screen_size")
+        use_computer(action="mouse_position")
+    """
+    all_params = locals()
+    params = [f"{k}: {v}" for k, v in all_params.items() if v is not None and not (k == "min_confidence" and v == 0.5)]
+
+    strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
+
+    if not strands_dev:
+        params_str = "\n ".join(params)
+        user_input = get_user_input(f"Do you want to proceed with {params_str}? (y/n)")
+        if user_input.lower().strip() != "y":
+            cancellation_reason = (
+                user_input if user_input.strip() != "n" else get_user_input("Please provide a reason for cancellation:")
+            )
+            error_message = f"Python code execution cancelled by the user. Reason: {cancellation_reason}"
+            return {
+                "status": "error",
+                "content": [{"text": error_message}],
+            }
+    # Auto-focus on target app before performing actions (except for certain actions)
+    actions_requiring_focus = [
+        "click",
+        "type",
+        "key_press",
+        "key_hold",
+        "hotkey",
+        "drag",
+        "scroll",
+        "scroll_to_bottom",
+        "screenshot",
+    ]
+    if action in actions_requiring_focus and app_name:
+        focus_success = focus_application(app_name)
+        if not focus_success:
+            return f"Warning: Could not focus on {app_name}. Proceeding with action anyway."
+    logger.info(f"Performing action: {action} in app: {app_name}")
+
+    computer = UseComputerMethods()
+
+    # This is so we only pass the parameters that are called with use_computer
+    method_params = {
+        "x": x,
+        "y": y,
+        "text": text,
+        "key": key,
+        "region": region,
+        "app_name": app_name,
+        "click_type": click_type,
+        "modifier_keys": modifier_keys,
+        "scroll_direction": scroll_direction,
+        "scroll_amount": scroll_amount,
+        "drag_to_x": drag_to_x,
+        "drag_to_y": drag_to_y,
+        "screenshot_path": screenshot_path,
+        "hotkey_str": hotkey_str,
+        "min_confidence": min_confidence,
+    }
+    # Remove None values
+    method_params = {k: v for k, v in method_params.items() if v is not None}
+
+    try:
+        method = getattr(computer, action, None)
+        if method:
+            # Get method signature to only pass valid parameters
+            sig = inspect.signature(method)
+            valid_params = {k: v for k, v in method_params.items() if k in sig.parameters}
+            return_value = method(**valid_params)
+            return return_value
+        else:
+            raise ValueError(f"Unknown action: {action}")
+    except Exception as e:
+        return f"Error: {str(e)}"

--- a/tests/test_use_computer.py
+++ b/tests/test_use_computer.py
@@ -647,11 +647,15 @@ class TestFocusApplication:
         from src.strands_tools.use_computer import focus_application
 
         with patch("platform.system", return_value=system), patch("subprocess.run") as mock_run, patch("time.sleep"):
-            mock_run.return_value = MagicMock()  # Successful run
+            # Set up the mock to return an object with returncode=0
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_run.return_value = mock_result  # Successful run with returncode 0
+
             result = focus_application("TestApp")
 
             assert result is True
-            mock_run.assert_called_once_with(expected_command, check=True, capture_output=True)
+            mock_run.assert_called_once_with(expected_command, check=True, capture_output=True, timeout=2.0)
 
     @pytest.mark.parametrize("system", ["darwin", "windows", "linux"])
     def test_focus_application_failure(self, system):
@@ -846,7 +850,7 @@ class TestUseComputerEdgeCases:
 
             result = use_computer(action="click", x=100, y=200, app_name="TestApp")
 
-            mock_focus.assert_called_once_with("TestApp")
+            mock_focus.assert_called_once_with("TestApp", timeout=2.0)
             mock_click.assert_called_once()
             mock_logger.assert_called_with("Performing action: click in app: TestApp")
 
@@ -911,7 +915,7 @@ class TestUseComputerEdgeCases:
 
             result = use_computer(action="analyze_screen", app_name="TestApp")
 
-            mock_focus.assert_called_once_with("TestApp")
+            mock_focus.assert_called_once_with("TestApp", timeout=2.0)
             mock_analyze_screen.assert_called_once()
 
             assert result["status"] == "success"

--- a/tests/test_use_computer.py
+++ b/tests/test_use_computer.py
@@ -1,0 +1,1114 @@
+# flake8: noqa: E402
+
+import sys
+from unittest import mock
+
+sys.modules["pyautogui"] = mock.MagicMock()
+sys.modules["mouseinfo"] = mock.MagicMock()
+sys.modules["cv2"] = mock.MagicMock()
+
+import platform
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from src.strands_tools.use_computer import (
+    UseComputerMethods,
+    close_application,
+    extract_text_from_image,
+    group_text_by_lines,
+    handle_analyze_screenshot,
+    open_application,
+    use_computer,
+)
+
+
+class TestUseComputerConsent:
+    """Tests for use_computer consent handling"""
+
+    def test_use_computer_with_bypass_consent(self, monkeypatch):
+        """Test use_computer proceeds immediately if BYPASS_TOOL_CONSENT is set"""
+        monkeypatch.setenv("BYPASS_TOOL_CONSENT", "true")
+
+        with patch("src.strands_tools.use_computer.UseComputerMethods.mouse_position") as mock_mouse:
+            mock_mouse.return_value = "Mouse position: (100, 200)"
+            result = use_computer(action="mouse_position")
+            assert result == "Mouse position: (100, 200)"
+
+    def test_use_computer_without_bypass_consent_user_says_no(self, monkeypatch):
+        """Test use_computer cancels with user input = 'n'"""
+        monkeypatch.setenv("BYPASS_TOOL_CONSENT", "false")
+
+        with patch("src.strands_tools.use_computer.get_user_input") as mock_input:
+            mock_input.side_effect = ["n", "Just testing"]
+            result = use_computer(action="mouse_position")
+            assert isinstance(result, dict)
+            assert result["status"] == "error"
+            assert "Just testing" in result["content"][0]["text"]
+
+    def test_use_computer_without_bypass_consent_user_says_yes(self, monkeypatch):
+        """Test use_computer runs if user confirms 'y'"""
+        monkeypatch.setenv("BYPASS_TOOL_CONSENT", "false")
+
+        with patch("src.strands_tools.use_computer.get_user_input", return_value="y"):
+            with patch("src.strands_tools.use_computer.UseComputerMethods.mouse_position") as mock_mouse:
+                mock_mouse.return_value = "Mouse position: (50, 60)"
+                result = use_computer(action="mouse_position")
+                assert result == "Mouse position: (50, 60)"
+
+
+class TestUseComputerMethods:
+    """Tests for UseComputerMethods class - basic functionality"""
+
+    @pytest.fixture
+    def computer(self):
+        return UseComputerMethods()
+
+    def test_mouse_position(self, computer):
+        with patch("pyautogui.position", return_value=(100, 200)):
+            result = computer.mouse_position()
+            assert result == "Mouse position: (100, 200)"
+
+    @pytest.mark.parametrize(
+        "click_type,expected",
+        [
+            ("left", "Left clicked at (100, 100)"),
+            ("right", "Right clicked at (100, 100)"),
+            ("double", "Double clicked at (100, 100)"),
+            ("middle", "Middle clicked at (100, 100)"),
+        ],
+    )
+    def test_click_types(self, computer, click_type, expected):
+        with (
+            patch("pyautogui.moveTo"),
+            patch("pyautogui.click"),
+            patch("pyautogui.rightClick"),
+            patch("pyautogui.middleClick"),
+            patch("time.sleep"),
+            patch("platform.system", return_value="windows"),
+        ):
+            result = computer.click(100, 100, click_type=click_type)
+            assert result == expected
+
+    def test_move_mouse(self, computer):
+        with patch("pyautogui.moveTo"):
+            result = computer.move_mouse(100, 200)
+            assert result == "Moved mouse to (100, 200)"
+
+    def test_type_text(self, computer):
+        with patch("pyautogui.typewrite"):
+            result = computer.type("Hello World")
+            assert result == "Typed: Hello World"
+
+    def test_type_text_empty(self, computer):
+        with pytest.raises(ValueError):
+            computer.type("")
+
+    def test_key_press(self, computer):
+        with patch("pyautogui.press"):
+            result = computer.key_press("enter")
+            assert result == "Pressed key: enter"
+
+    def test_key_press_with_modifiers(self, computer):
+        with patch("pyautogui.hotkey"):
+            result = computer.key_press("a", modifier_keys=["ctrl", "shift"])
+            assert result == "Pressed key combination: ctrl+shift+a"
+
+    def test_key_hold_simple(self, computer):
+        with patch("pyautogui.keyDown"), patch("pyautogui.keyUp"), patch("time.sleep"):
+            result = computer.key_hold("a")
+            assert result == "Held and released key: a"
+
+    def test_key_hold_with_modifiers(self, computer):
+        with patch("pyautogui.keyDown"), patch("pyautogui.keyUp"), patch("pyautogui.press"):
+            result = computer.key_hold("v", modifier_keys=["ctrl", "shift"])
+            assert result == "Held ctrl+shift and pressed v"
+
+    def test_key_hold_no_key(self, computer):
+        with pytest.raises(ValueError) as exc_info:
+            computer.key_hold(None)
+        assert str(exc_info.value) == "No key specified for key hold"
+
+    @pytest.mark.parametrize(
+        "system,hotkey_str,expected_keys",
+        [
+            ("windows", "ctrl+c", ["ctrl", "c"]),
+            ("darwin", "cmd+c", ["command", "c"]),
+            ("linux", "alt+tab", ["alt", "tab"]),
+        ],
+    )
+    def test_hotkey(self, computer, system, hotkey_str, expected_keys):
+        with (
+            patch("platform.system", return_value=system),
+            patch("pyautogui.hotkey") as mock_hotkey,
+            patch("builtins.print"),
+        ):  # Mock print to avoid output
+            result = computer.hotkey(hotkey_str)
+            mock_hotkey.assert_called_once_with(*expected_keys)
+            assert result == f"Pressed hotkey combination: {hotkey_str}"
+
+    def test_hotkey_empty_string(self, computer):
+        with pytest.raises(ValueError) as exc_info:
+            computer.hotkey("")
+        assert str(exc_info.value) == "No hotkey string provided for hotkey action"
+
+    def test_screen_size(self, computer):
+        with patch("pyautogui.size", return_value=(1920, 1080)):
+            result = computer.screen_size()
+            assert result == "Screen size: 1920x1080"
+
+    def test_open_app_success(self, computer):
+        with (
+            patch("src.strands_tools.use_computer.open_application", return_value="Launched TestApp") as mock_open,
+            patch("builtins.print"),
+        ):  # Mock print statement
+            result = computer.open_app("TestApp")
+            assert result == "Launched TestApp"
+            mock_open.assert_called_once_with("TestApp")
+
+    def test_open_app_no_name(self, computer):
+        with pytest.raises(ValueError) as exc_info:
+            computer.open_app("")
+        assert str(exc_info.value) == "No application name provided"
+
+    def test_open_app_none_name(self, computer):
+        with pytest.raises(ValueError) as exc_info:
+            computer.open_app(None)
+        assert str(exc_info.value) == "No application name provided"
+
+    def test_close_app_success(self, computer):
+        with patch(
+            "src.strands_tools.use_computer.close_application", return_value="Closed 1 instance(s) of TestApp"
+        ) as mock_close:
+            result = computer.close_app("TestApp")
+            assert result == "Closed 1 instance(s) of TestApp"
+            mock_close.assert_called_once_with("TestApp")
+
+    def test_close_app_no_name(self, computer):
+        with pytest.raises(ValueError) as exc_info:
+            computer.close_app("")
+        assert str(exc_info.value) == "No application name provided"
+
+    def test_close_app_none_name(self, computer):
+        with pytest.raises(ValueError) as exc_info:
+            computer.close_app(None)
+        assert str(exc_info.value) == "No application name provided"
+
+
+class TestScreenshotAndAnalysis:
+    """Tests for screenshot and analysis functionality"""
+
+    @pytest.fixture
+    def computer(self):
+        return UseComputerMethods()
+
+    def test_screenshot_creation(self, computer):
+        with (
+            patch("pyautogui.screenshot") as mock_screenshot,
+            patch("os.path.exists", return_value=True),
+            patch("os.makedirs"),
+            patch("datetime.datetime") as mock_datetime,
+        ):
+            mock_datetime.now.return_value.strftime.return_value = "20240101_120000"
+            mock_screenshot.return_value = MagicMock()
+            result = computer.screenshot()
+            assert "Screenshot saved to" in result
+
+    def test_analyze_screenshot_with_no_text(self):  # Add self parameter
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("src.strands_tools.use_computer.extract_text_from_image", return_value=[]),
+        ):
+            result = handle_analyze_screenshot("test.png", None)
+            assert "No text detected" in result
+
+    @patch("os.path.exists", return_value=True)
+    def test_analyze_screenshot_with_text(self, mock_exists):
+        mock_text_data = [
+            {
+                "text": "test",
+                "coordinates": {"x": 0, "y": 0, "width": 10, "height": 10, "center_x": 5, "center_y": 5},
+                "confidence": 0.9,
+            }
+        ]
+        with patch("src.strands_tools.use_computer.extract_text_from_image", return_value=mock_text_data):
+            result = handle_analyze_screenshot("test.png", None)
+            assert "Detected 1 text elements" in result
+
+
+class TestApplicationManagement:
+    """Tests for application management functionality"""
+
+    @pytest.mark.parametrize("system", ["windows", "darwin", "linux"])
+    def test_open_application(self, system):
+        with patch("platform.system", return_value=system), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = open_application("test_app")
+            assert "Launched" in result
+
+    def test_close_application(self):
+        mock_process = MagicMock()
+        mock_process.info = {"name": "test_app"}
+        mock_process.terminate = MagicMock()
+
+        with patch("psutil.process_iter", return_value=[mock_process]):
+            result = close_application("test_app")
+            assert "Closed" in result
+
+
+class TestMouseOperations:
+    """Tests for mouse operations like drag and scroll"""
+
+    @pytest.fixture
+    def computer(self):
+        return UseComputerMethods()
+
+    def test_drag_operation(self, computer):
+        with (
+            patch("pyautogui.moveTo") as mock_move,
+            patch("pyautogui.drag") as mock_drag,
+            patch("pyautogui.position", return_value=(100, 100)),
+            patch("time.sleep"),
+        ):
+            result = computer.drag(100, 100, drag_to_x=200, drag_to_y=200)
+
+            mock_move.assert_called_once()
+            mock_drag.assert_called_once()
+            assert "Dragged from (100, 100) to (200, 200)" in result
+
+    @pytest.mark.parametrize(
+        "direction,amount",
+        [
+            ("up", 15),
+            ("down", 15),
+            ("left", 15),
+            ("right", 15),
+        ],
+    )
+    def test_scroll_operations(self, computer, direction, amount):
+        with (
+            patch("pyautogui.moveTo") as mock_move,
+            patch("pyautogui.scroll") as mock_scroll,
+            patch("pyautogui.hscroll") as mock_hscroll,
+            patch("pyautogui.click"),
+            patch("platform.system", return_value="windows"),
+            patch("time.sleep"),
+            patch("subprocess.run"),
+        ):
+            result = computer.scroll(100, 100, None, direction, amount)
+
+            mock_move.assert_called_once_with(100, 100, duration=0.3)
+
+            if direction in ["up", "down"]:
+                scroll_value = amount if direction == "up" else -amount
+                mock_scroll.assert_called_once_with(scroll_value)
+            else:
+                scroll_value = amount if direction == "right" else -amount
+                mock_hscroll.assert_called_once_with(scroll_value)
+
+            assert f"Scrolled {direction}" in result
+
+    def test_scroll_operations_missing_coordinates_with_app_name(self, computer):
+        """Test scroll when coordinates are missing but app_name is provided - should use screen center"""
+        with (
+            patch("pyautogui.moveTo") as mock_move,
+            patch("pyautogui.scroll") as mock_scroll,
+            patch("pyautogui.click"),
+            patch("pyautogui.size", return_value=(1920, 1080)) as mock_size,
+            patch("src.strands_tools.use_computer.logger.info") as mock_logger,
+        ):
+            result = computer.scroll(None, None, "TestApp", "up", 15)
+
+            mock_size.assert_called_once()
+            mock_move.assert_called_once_with(960, 540, duration=0.3)
+            mock_logger.assert_called_once_with("No coordinates provided for scroll, using app center: (960, 540)")
+            mock_scroll.assert_called_once_with(15)
+
+            assert "Scrolled up by 15 steps at coordinates (960, 540)" in result
+
+    def test_scroll_operations_missing_coordinates_without_app_name(self, computer):
+        """Test scroll when coordinates are missing and no app_name - should raise ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            computer.scroll(None, None, None, "up", 15)
+
+        expected_message = (
+            "Missing x or y coordinates for scrolling. "
+            "For scrolling to work, mouse must be over the scrollable area."
+        )
+        assert str(exc_info.value) == expected_message
+
+    def test_scroll_operations_missing_x_coordinate_only(self, computer):
+        """Test scroll when only x coordinate is missing"""
+        with patch("pyautogui.size", return_value=(1920, 1080)):
+            with pytest.raises(ValueError) as exc_info:
+                computer.scroll(None, 100, None, "up", 15)
+
+            expected_message = (
+                "Missing x or y coordinates for scrolling. "
+                "For scrolling to work, mouse must be over the scrollable area."
+            )
+            assert str(exc_info.value) == expected_message
+
+    def test_scroll_operations_missing_y_coordinate_only(self, computer):
+        """Test scroll when only y coordinate is missing"""
+        with patch("pyautogui.size", return_value=(1920, 1080)):
+            with pytest.raises(ValueError) as exc_info:
+                computer.scroll(100, None, None, "up", 15)
+
+            expected_message = (
+                "Missing x or y coordinates for scrolling. "
+                "For scrolling to work, mouse must be over the scrollable area."
+            )
+            assert str(exc_info.value) == expected_message
+
+
+class TestTextProcessing:
+    @pytest.fixture
+    def sample_text_data(self):
+        return [
+            {
+                "text": "Hello",
+                "coordinates": {"x": 10, "y": 100},
+            },
+            {
+                "text": "World",
+                "coordinates": {"x": 60, "y": 102},  # Same line as "Hello"
+            },
+            {
+                "text": "New",
+                "coordinates": {"x": 10, "y": 150},  # New line
+            },
+            {
+                "text": "Line",
+                "coordinates": {"x": 60, "y": 152},  # Same line as "New"
+            },
+        ]
+
+    def test_group_text_by_lines_empty_input(self):
+        result = group_text_by_lines([])
+        assert result == []
+
+    def test_group_text_by_lines_single_line(self, sample_text_data):
+        # Only use first two items which should be on the same line
+        result = group_text_by_lines(sample_text_data[:2])
+        assert len(result) == 1  # One line
+        assert len(result[0]) == 2  # Two words in the line
+        assert result[0][0]["text"] == "Hello"
+        assert result[0][1]["text"] == "World"
+
+    def test_group_text_by_lines_multiple_lines(self, sample_text_data):
+        result = group_text_by_lines(sample_text_data)
+        assert len(result) == 2  # Two lines
+        assert len(result[0]) == 2  # Two words in first line
+        assert len(result[1]) == 2  # Two words in second line
+        assert result[0][0]["text"] == "Hello"
+        assert result[1][0]["text"] == "New"
+
+    def test_group_text_by_lines_threshold(self):
+        data = [
+            {"text": "Word1", "coordinates": {"x": 0, "y": 100}},
+            {"text": "Word2", "coordinates": {"x": 0, "y": 115}},  # > 10px difference
+        ]
+        # With default threshold (10), should be two lines
+        result = group_text_by_lines(data)
+        assert len(result) == 2
+
+        # With larger threshold (20), should be one line
+        result = group_text_by_lines(data, line_threshold=20)
+        assert len(result) == 1
+
+
+class TestExtractTextFromImage:
+    """Tests for OCR text extraction functionality"""
+
+    @pytest.fixture
+    def mock_image(self):
+        return np.zeros((1200, 1200), dtype=np.uint8)
+
+    @pytest.fixture
+    def mock_tesseract_data(self):
+        return {
+            "text": ["Hello", "World", "", "Test"],
+            "conf": [95.0, 95.0, 0.0, 95.0],
+            "left": [10, 60, 0, 10],
+            "top": [100, 100, 0, 150],
+            "width": [40, 40, 0, 40],
+            "height": [20, 20, 0, 20],
+        }
+
+    def test_extract_text_from_image_basic(self, mock_image, mock_tesseract_data):
+        with (
+            patch("cv2.imread", return_value=mock_image),
+            patch("cv2.cvtColor", return_value=mock_image),
+            patch("cv2.medianBlur", return_value=mock_image),
+            patch("cv2.createCLAHE") as mock_clahe,
+            patch("cv2.filter2D", return_value=mock_image),
+            patch("pytesseract.image_to_data", return_value=mock_tesseract_data),
+            patch("pyautogui.size", return_value=(1920, 1080)),
+        ):
+            mock_clahe.return_value.apply.return_value = mock_image
+
+            results = extract_text_from_image("test.png")
+
+            assert len(results) == 3
+            assert results[0]["text"] == "Hello"
+            assert results[1]["text"] == "World"
+            assert results[2]["text"] == "Test"
+
+    def test_extract_text_from_image_no_image(self):
+        with patch("cv2.imread", return_value=None):
+            with pytest.raises(ValueError) as exc_info:
+                extract_text_from_image("nonexistent.png")
+            assert "Could not read image" in str(exc_info.value)
+
+    def test_extract_text_from_image_scaling(self, mock_image, mock_tesseract_data):
+        small_image = np.zeros((800, 800, 3), dtype=np.uint8)
+
+        with (
+            patch("cv2.imread", return_value=small_image),
+            patch("cv2.resize", return_value=mock_image),
+            patch("cv2.cvtColor", return_value=mock_image),
+            patch("cv2.medianBlur", return_value=mock_image),
+            patch("cv2.createCLAHE") as mock_clahe,
+            patch("cv2.filter2D", return_value=mock_image),
+            patch("pytesseract.image_to_data", return_value=mock_tesseract_data),
+            patch("pyautogui.size", return_value=(1920, 1080)),
+        ):
+            mock_clahe.return_value.apply.return_value = mock_image
+
+            results = extract_text_from_image("test.png")
+
+            assert results[0]["coordinates"]["scaling_applied"]
+            assert "center_x" in results[0]["coordinates"]
+            assert "center_y" in results[0]["coordinates"]
+
+    def test_extract_text_from_image_ocr_failure(self, mock_image):
+        color_image = np.zeros((1200, 1200, 3), dtype=np.uint8)
+        gray_image = np.zeros((1200, 1200), dtype=np.uint8)
+
+        with (
+            patch("cv2.imread", return_value=color_image),
+            patch("cv2.cvtColor", return_value=gray_image),
+            patch("cv2.medianBlur", return_value=gray_image),
+            patch("cv2.createCLAHE") as mock_clahe,
+            patch("cv2.filter2D", return_value=gray_image),
+            patch("pytesseract.image_to_data", side_effect=Exception("OCR failed")),
+            patch("pyautogui.size", return_value=(1920, 1080)),
+        ):
+            mock_clahe.return_value.apply.return_value = gray_image
+
+            with pytest.raises(ValueError) as exc_info:
+                extract_text_from_image("test.png")
+            assert "OCR failed with all configurations" in str(exc_info.value)
+
+    def test_extract_text_from_image_confidence_threshold(self, mock_image):
+        color_image = np.zeros((1200, 1200, 3), dtype=np.uint8)
+        gray_image = np.zeros((1200, 1200), dtype=np.uint8)
+
+        test_data = {
+            "text": ["High1", "High2", "Low", ""],
+            "conf": [95.0, 92.0, 85.0, 0.0],
+            "left": [10, 60, 110, 0],
+            "top": [100, 100, 100, 0],
+            "width": [40, 40, 40, 0],
+            "height": [20, 20, 20, 0],
+        }
+
+        with (
+            patch("cv2.imread", return_value=color_image),
+            patch("cv2.cvtColor", return_value=gray_image),
+            patch("cv2.medianBlur", return_value=gray_image),
+            patch("cv2.createCLAHE") as mock_clahe,
+            patch("cv2.filter2D", return_value=gray_image),
+            patch("pytesseract.image_to_data", return_value=test_data),
+            patch("pyautogui.size", return_value=(1920, 1080)),
+        ):
+            mock_clahe.return_value.apply.return_value = gray_image
+
+            results = extract_text_from_image("test.png", min_confidence=0.9)
+
+            assert len(results) == 2
+            assert all(r["confidence"] >= 0.9 for r in results)
+            assert results[0]["text"] == "High1"
+            assert results[1]["text"] == "High2"
+
+
+class TestFocusApplication:
+    @pytest.mark.parametrize(
+        "system,expected_command",
+        [
+            ("darwin", ["osascript", "-e", 'tell application "TestApp" to activate']),
+            (
+                "windows",
+                [
+                    "powershell",
+                    "-Command",
+                    (
+                        "Add-Type -AssemblyName Microsoft.VisualBasic; "
+                        "[Microsoft.VisualBasic.Interaction]::AppActivate('TestApp')"
+                    ),
+                ],
+            ),
+            ("linux", ["wmctrl", "-a", "TestApp"]),
+        ],
+    )
+    def test_focus_application_success(self, system, expected_command):
+        from src.strands_tools.use_computer import focus_application
+
+        with patch("platform.system", return_value=system), patch("subprocess.run") as mock_run, patch("time.sleep"):
+            mock_run.return_value = MagicMock()  # Successful run
+            result = focus_application("TestApp")
+
+            assert result is True
+            mock_run.assert_called_once_with(expected_command, check=True, capture_output=True)
+
+    @pytest.mark.parametrize("system", ["darwin", "windows", "linux"])
+    def test_focus_application_failure(self, system):
+        from src.strands_tools.use_computer import focus_application
+
+        with (
+            patch("platform.system", return_value=system),
+            patch("subprocess.run", side_effect=Exception("Command failed")),
+            patch("time.sleep"),
+        ):
+            result = focus_application("TestApp")
+            assert result is False
+
+    def test_focus_application_unknown_system(self):
+        from src.strands_tools.use_computer import focus_application
+
+        with patch("platform.system", return_value="unknown"):
+            result = focus_application("TestApp")
+            assert result is False
+
+
+class TestHandleAnalyzeScreenshot:
+    """Tests for screenshot analysis handling"""
+
+    def test_handle_analyze_screenshot_with_existing_path(self):
+        mock_text_data = [
+            {
+                "text": "Sample Text",
+                "coordinates": {"x": 10, "y": 20, "width": 100, "height": 30, "center_x": 60, "center_y": 35},
+                "confidence": 0.95,
+            }
+        ]
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("src.strands_tools.use_computer.extract_text_from_image", return_value=mock_text_data),
+        ):
+            result = handle_analyze_screenshot("test.png", None)
+
+            assert "Detected 1 text elements" in result
+            assert "Sample Text" in result
+            assert "Confidence: 0.95" in result
+
+    def test_handle_analyze_screenshot_nonexistent_path(self):
+        with patch("os.path.exists", return_value=False):
+            with pytest.raises(ValueError) as exc_info:
+                handle_analyze_screenshot("nonexistent.png", None)
+            assert "Screenshot not found at nonexistent.png" in str(exc_info.value)
+
+    def test_handle_analyze_screenshot_no_path_provided(self):
+        mock_text_data = [
+            {
+                "text": "Auto Screenshot",
+                "coordinates": {"x": 5, "y": 10, "width": 50, "height": 20, "center_x": 30, "center_y": 20},
+                "confidence": 0.8,
+            }
+        ]
+
+        mock_screenshot = MagicMock()
+
+        with (
+            patch("os.path.exists", return_value=False),
+            patch("os.makedirs") as mock_makedirs,
+            patch("pyautogui.screenshot", return_value=mock_screenshot),
+            patch("src.strands_tools.use_computer.extract_text_from_image", return_value=mock_text_data),
+            patch("datetime.datetime") as mock_datetime,
+        ):
+            # Mock datetime.now().strftime()
+            mock_datetime.now.return_value.strftime.return_value = "20240101_120000"
+
+            result = handle_analyze_screenshot(None, None)
+
+            mock_makedirs.assert_called_once_with("screenshots")
+            mock_screenshot.save.assert_called_once()
+            assert "Detected 1 text elements" in result
+            assert "Auto Screenshot" in result
+
+    def test_handle_analyze_screenshot_with_region(self):
+        mock_text_data = []
+        mock_screenshot = MagicMock()
+
+        with (
+            patch("os.path.exists", return_value=False),
+            patch("os.makedirs"),
+            patch("pyautogui.screenshot", return_value=mock_screenshot) as mock_pyautogui_screenshot,
+            patch("src.strands_tools.use_computer.extract_text_from_image", return_value=mock_text_data),
+            patch("datetime.datetime") as mock_datetime,
+        ):
+            mock_datetime.now.return_value.strftime.return_value = "20240101_120000"
+
+            result = handle_analyze_screenshot(None, [0, 0, 100, 100])
+
+            # Verify screenshot was called with region
+            mock_pyautogui_screenshot.assert_called_once_with(region=[0, 0, 100, 100])
+            assert "No text detected" in result
+
+    def test_handle_analyze_screenshot_no_text_found(self):
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("src.strands_tools.use_computer.extract_text_from_image", return_value=[]),
+        ):
+            result = handle_analyze_screenshot("test.png", None)
+            assert "No text detected in screenshot test.png" in result
+
+    def test_handle_analyze_screenshot_analysis_error(self):
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("src.strands_tools.use_computer.extract_text_from_image", side_effect=Exception("OCR Error")),
+        ):
+            result = handle_analyze_screenshot("test.png", None)
+            assert "Error analyzing screenshot: OCR Error" in result
+
+    def test_handle_analyze_screenshot_formatted_output(self):
+        mock_text_data = [
+            {
+                "text": "First",
+                "coordinates": {"x": 10, "y": 20, "width": 40, "height": 15, "center_x": 30, "center_y": 27},
+                "confidence": 0.9,
+            },
+            {
+                "text": "Second",
+                "coordinates": {"x": 60, "y": 20, "width": 50, "height": 15, "center_x": 85, "center_y": 27},
+                "confidence": 0.85,
+            },
+        ]
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("src.strands_tools.use_computer.extract_text_from_image", return_value=mock_text_data),
+        ):
+            result = handle_analyze_screenshot("test.png", None)
+
+            # Check that both text elements are included with proper formatting
+            assert "Detected 2 text elements" in result
+            assert "1. Text: 'First'" in result
+            assert "2. Text: 'Second'" in result
+            assert "Confidence: 0.90" in result
+            assert "Confidence: 0.85" in result
+            assert "Position: X=10, Y=20, W=40, H=15" in result
+            assert "Center: (30, 27)" in result
+
+
+class TestUseComputerEdgeCases:
+    """Tests for edge cases and error handling in use_computer"""
+
+    def test_use_computer_unknown_action(self, monkeypatch):
+        """Test use_computer with unknown action raises ValueError"""
+        monkeypatch.setenv("BYPASS_TOOL_CONSENT", "true")
+
+        result = use_computer(action="invalid_unknown_action")
+        assert result == "Error: Unknown action: invalid_unknown_action"
+
+    def test_use_computer_method_exception(self, monkeypatch):
+        """Test use_computer catches exceptions from methods and returns error message"""
+        monkeypatch.setenv("BYPASS_TOOL_CONSENT", "true")
+
+        with patch("src.strands_tools.use_computer.UseComputerMethods.mouse_position") as mock_mouse:
+            mock_mouse.side_effect = RuntimeError("Test error message")
+            result = use_computer(action="mouse_position")
+            assert result == "Error: Test error message"
+
+    def test_use_computer_method_different_exception_type(self, monkeypatch):
+        """Test use_computer catches different exception types"""
+        monkeypatch.setenv("BYPASS_TOOL_CONSENT", "true")
+
+        with patch("src.strands_tools.use_computer.UseComputerMethods.click") as mock_click:
+            mock_click.side_effect = ConnectionError("Network issue")
+            result = use_computer(action="click", x=100, y=200)
+            assert result == "Error: Network issue"
+
+    def test_use_computer_getattr_returns_none(self, monkeypatch):
+        """Test use_computer when getattr returns None (method doesn't exist)"""
+        monkeypatch.setenv("BYPASS_TOOL_CONSENT", "true")
+
+        result = use_computer(action="completely_nonexistent_method")
+        assert result == "Error: Unknown action: completely_nonexistent_method"
+
+    def test_use_computer_focus_application_success(self, monkeypatch):
+        """Test use_computer calls focus_application when action requires focus and app_name provided - success case"""
+        monkeypatch.setenv("BYPASS_TOOL_CONSENT", "true")
+
+        with (
+            patch("src.strands_tools.use_computer.focus_application", return_value=True) as mock_focus,
+            patch("src.strands_tools.use_computer.UseComputerMethods.click") as mock_click,
+            patch("src.strands_tools.use_computer.logger.info") as mock_logger,
+        ):
+            mock_click.return_value = "Left clicked at (100, 200)"
+
+            result = use_computer(action="click", x=100, y=200, app_name="TestApp")
+
+            mock_focus.assert_called_once_with("TestApp")
+            mock_click.assert_called_once()
+            mock_logger.assert_called_with("Performing action: click in app: TestApp")
+
+            assert result == "Left clicked at (100, 200)"
+
+    def test_use_computer_focus_not_required_no_app_name(self, monkeypatch):
+        """Test use_computer skips focus when action requires focus but no app_name provided"""
+        monkeypatch.setenv("BYPASS_TOOL_CONSENT", "true")
+
+        with (
+            patch("src.strands_tools.use_computer.focus_application") as mock_focus,
+            patch("src.strands_tools.use_computer.UseComputerMethods.scroll") as mock_scroll,
+            patch("src.strands_tools.use_computer.logger.info") as mock_logger,
+        ):
+            mock_scroll.return_value = "Scrolled up by 15 steps at coordinates (100, 100)"
+
+            result = use_computer(action="scroll", x=100, y=100, scroll_direction="up", scroll_amount=15)
+
+            mock_focus.assert_not_called()
+            mock_scroll.assert_called_once()
+            mock_logger.assert_called_with("Performing action: scroll in app: None")
+
+            assert result == "Scrolled up by 15 steps at coordinates (100, 100)"
+
+    def test_use_computer_action_not_requiring_focus(self, monkeypatch):
+        """Test use_computer skips focus for actions that don't require focus"""
+        monkeypatch.setenv("BYPASS_TOOL_CONSENT", "true")
+
+        with (
+            patch("src.strands_tools.use_computer.focus_application") as mock_focus,
+            patch("src.strands_tools.use_computer.UseComputerMethods.mouse_position") as mock_mouse,
+            patch("src.strands_tools.use_computer.logger.info") as mock_logger,
+        ):
+            mock_mouse.return_value = "Mouse position: (100, 200)"
+
+            result = use_computer(action="mouse_position", app_name="TestApp")
+
+            mock_focus.assert_not_called()
+            mock_mouse.assert_called_once()
+            mock_logger.assert_called_with("Performing action: mouse_position in app: TestApp")
+
+            assert result == "Mouse position: (100, 200)"
+
+    def test_use_computer_screenshot_requires_focus(self, monkeypatch):
+        """Test use_computer calls focus for screenshot action when app_name provided"""
+        monkeypatch.setenv("BYPASS_TOOL_CONSENT", "true")
+
+        with (
+            patch("src.strands_tools.use_computer.focus_application", return_value=True) as mock_focus,
+            patch("src.strands_tools.use_computer.UseComputerMethods.screenshot") as mock_screenshot,
+            patch("builtins.print"),
+        ):
+            mock_screenshot.return_value = "Screenshot saved to test.png"
+
+            result = use_computer(action="screenshot", app_name="TestApp")
+
+            mock_focus.assert_called_once_with("TestApp")
+            mock_screenshot.assert_called_once()
+
+            assert result == "Screenshot saved to test.png"
+
+
+# Only run this test if on mac, because the tool has some mac specific way of performing actions
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Tests only valid on macOS")
+class TestNativeMacDoubleClick:
+    @pytest.fixture
+    def computer(self):
+        return UseComputerMethods()
+
+    def test_native_mac_double_click_basic_functionality(self, computer):
+        """Test that _native_mac_double_click calls all required Quartz functions"""
+        # Mock all the Quartz CoreGraphics functions
+        mock_create_mouse_event = MagicMock()
+        mock_set_integer_value_field = MagicMock()
+        mock_event_post = MagicMock()
+        mock_click_down_event = MagicMock()
+        mock_click_up_event = MagicMock()
+
+        # Configure the mouse event creation to return our mock events
+        mock_create_mouse_event.side_effect = [
+            mock_click_down_event,  # First down
+            mock_click_up_event,  # First up
+            mock_click_down_event,  # Second down
+            mock_click_up_event,  # Second up
+        ]
+
+        with (
+            patch("src.strands_tools.use_computer.CGEventCreateMouseEvent", mock_create_mouse_event),
+            patch("src.strands_tools.use_computer.CGEventSetIntegerValueField", mock_set_integer_value_field),
+            patch("src.strands_tools.use_computer.CGEventPost", mock_event_post),
+            patch("time.sleep") as mock_sleep,
+        ):
+            computer._native_mac_double_click(100, 200)
+
+            # Verify CGEventCreateMouseEvent was called 4 times (2 down, 2 up)
+            assert mock_create_mouse_event.call_count == 4
+
+            # Verify CGEventPost was called 4 times (post each event)
+            assert mock_event_post.call_count == 4
+
+            # Verify CGEventSetIntegerValueField was called 4 times (set state for each event)
+            assert mock_set_integer_value_field.call_count == 4
+
+            # Verify sleep was called once (between first and second click)
+            mock_sleep.assert_called_once_with(0.05)
+
+    def test_native_mac_double_click_coordinates(self, computer):
+        """Test that coordinates are passed correctly to mouse events"""
+        mock_create_mouse_event = MagicMock()
+        mock_set_integer_value_field = MagicMock()
+        mock_event_post = MagicMock()
+
+        with (
+            patch("src.strands_tools.use_computer.CGEventCreateMouseEvent", mock_create_mouse_event),
+            patch("src.strands_tools.use_computer.CGEventPost", mock_event_post),
+            patch("time.sleep"),
+        ):
+            with patch.dict(
+                "sys.modules",
+                {"Quartz.CoreGraphics": MagicMock(CGEventSetIntegerValueField=mock_set_integer_value_field)},
+            ):
+                computer._native_mac_double_click(150, 250)
+
+                # Verify all mouse events were created with correct coordinates
+                expected_calls = [
+                    # First click down and up
+                    unittest.mock.call(None, mock.ANY, (150, 250), mock.ANY),
+                    unittest.mock.call(None, mock.ANY, (150, 250), mock.ANY),
+                    # Second click down and up
+                    unittest.mock.call(None, mock.ANY, (150, 250), mock.ANY),
+                    unittest.mock.call(None, mock.ANY, (150, 250), mock.ANY),
+                ]
+
+                mock_create_mouse_event.assert_has_calls(expected_calls)
+
+    def test_native_mac_double_click_event_types(self, computer):
+        """Test that correct event types are used for mouse down and up"""
+        mock_create_mouse_event = MagicMock()
+        mock_set_integer_value_field = MagicMock()
+        mock_event_post = MagicMock()
+
+        # Import the constants to verify they're used correctly
+        from src.strands_tools.use_computer import kCGEventLeftMouseDown, kCGEventLeftMouseUp, kCGMouseButtonLeft
+
+        with (
+            patch("src.strands_tools.use_computer.CGEventCreateMouseEvent", mock_create_mouse_event),
+            patch("src.strands_tools.use_computer.CGEventPost", mock_event_post),
+            patch("time.sleep"),
+        ):
+            with patch.dict(
+                "sys.modules",
+                {"Quartz.CoreGraphics": MagicMock(CGEventSetIntegerValueField=mock_set_integer_value_field)},
+            ):
+                computer._native_mac_double_click(100, 200)
+
+                # Verify the event types and button types are correct
+                expected_calls = [
+                    # First click: down, up
+                    unittest.mock.call(None, kCGEventLeftMouseDown, (100, 200), kCGMouseButtonLeft),
+                    unittest.mock.call(None, kCGEventLeftMouseUp, (100, 200), kCGMouseButtonLeft),
+                    # Second click: down, up
+                    unittest.mock.call(None, kCGEventLeftMouseDown, (100, 200), kCGMouseButtonLeft),
+                    unittest.mock.call(None, kCGEventLeftMouseUp, (100, 200), kCGMouseButtonLeft),
+                ]
+
+                mock_create_mouse_event.assert_has_calls(expected_calls)
+
+    def test_native_mac_double_click_click_states(self, computer):
+        """Test that click states are set correctly (1 for first click, 2 for second)"""
+        mock_create_mouse_event = MagicMock()
+        mock_set_integer_value_field = MagicMock()
+        mock_event_post = MagicMock()
+        mock_down_event = MagicMock()
+        mock_up_event = MagicMock()
+
+        # Return the same mock events so we can track what state they're set to
+        mock_create_mouse_event.return_value = mock_down_event
+        mock_create_mouse_event.side_effect = [
+            mock_down_event,
+            mock_up_event,  # First click pair
+            mock_down_event,
+            mock_up_event,  # Second click pair
+        ]
+
+        from src.strands_tools.use_computer import kCGMouseEventClickState
+
+        with (
+            patch("src.strands_tools.use_computer.CGEventCreateMouseEvent", mock_create_mouse_event),
+            patch("src.strands_tools.use_computer.CGEventSetIntegerValueField", mock_set_integer_value_field),
+            patch("src.strands_tools.use_computer.CGEventPost", mock_event_post),
+            patch("time.sleep"),
+        ):
+            computer._native_mac_double_click(100, 200)
+
+            # Verify click states are set correctly
+            expected_calls = [
+                # First click: state = 1
+                unittest.mock.call(mock_down_event, kCGMouseEventClickState, 1),
+                unittest.mock.call(mock_up_event, kCGMouseEventClickState, 1),
+                # Second click: state = 2
+                unittest.mock.call(mock_down_event, kCGMouseEventClickState, 2),
+                unittest.mock.call(mock_up_event, kCGMouseEventClickState, 2),
+            ]
+
+            mock_set_integer_value_field.assert_has_calls(expected_calls)
+
+    def test_native_mac_double_click_event_posting(self, computer):
+        """Test that events are posted in the correct order"""
+        mock_create_mouse_event = MagicMock()
+        mock_set_integer_value_field = MagicMock()
+        mock_event_post = MagicMock()
+
+        # Create distinct mock objects for each event
+        mock_first_down = MagicMock()
+        mock_first_up = MagicMock()
+        mock_second_down = MagicMock()
+        mock_second_up = MagicMock()
+
+        mock_create_mouse_event.side_effect = [mock_first_down, mock_first_up, mock_second_down, mock_second_up]
+
+        from src.strands_tools.use_computer import kCGHIDEventTap
+
+        with (
+            patch("src.strands_tools.use_computer.CGEventCreateMouseEvent", mock_create_mouse_event),
+            patch("src.strands_tools.use_computer.CGEventPost", mock_event_post),
+            patch("time.sleep"),
+        ):
+            with patch.dict(
+                "sys.modules",
+                {"Quartz.CoreGraphics": MagicMock(CGEventSetIntegerValueField=mock_set_integer_value_field)},
+            ):
+                computer._native_mac_double_click(100, 200)
+
+                # Verify events are posted in correct order with correct tap
+                expected_calls = [
+                    unittest.mock.call(kCGHIDEventTap, mock_first_down),
+                    unittest.mock.call(kCGHIDEventTap, mock_first_up),
+                    unittest.mock.call(kCGHIDEventTap, mock_second_down),
+                    unittest.mock.call(kCGHIDEventTap, mock_second_up),
+                ]
+
+                mock_event_post.assert_has_calls(expected_calls)
+
+    def test_native_mac_double_click_sleep_timing(self, computer):
+        """Test that sleep is only called once and with correct duration"""
+        mock_create_mouse_event = MagicMock()
+        mock_set_integer_value_field = MagicMock()
+        mock_event_post = MagicMock()
+
+        with (
+            patch("src.strands_tools.use_computer.CGEventCreateMouseEvent", mock_create_mouse_event),
+            patch("src.strands_tools.use_computer.CGEventPost", mock_event_post),
+            patch("time.sleep") as mock_sleep,
+        ):
+            with patch.dict(
+                "sys.modules",
+                {"Quartz.CoreGraphics": MagicMock(CGEventSetIntegerValueField=mock_set_integer_value_field)},
+            ):
+                computer._native_mac_double_click(100, 200)
+
+                # Verify sleep is called exactly once with 0.05 seconds
+                mock_sleep.assert_called_once_with(0.05)
+
+    def test_native_mac_double_click_different_coordinates(self, computer):
+        """Test with different coordinate values"""
+        mock_create_mouse_event = MagicMock()
+        mock_set_integer_value_field = MagicMock()
+        mock_event_post = MagicMock()
+
+        test_coordinates = [(0, 0), (500, 300), (1920, 1080)]
+
+        with (
+            patch("src.strands_tools.use_computer.CGEventCreateMouseEvent", mock_create_mouse_event),
+            patch("src.strands_tools.use_computer.CGEventPost", mock_event_post),
+            patch("time.sleep"),
+        ):
+            with patch.dict(
+                "sys.modules",
+                {"Quartz.CoreGraphics": MagicMock(CGEventSetIntegerValueField=mock_set_integer_value_field)},
+            ):
+                for x, y in test_coordinates:
+                    mock_create_mouse_event.reset_mock()
+                    computer._native_mac_double_click(x, y)
+
+                    # Verify coordinates are used in all 4 calls
+                    for call in mock_create_mouse_event.call_args_list:
+                        args, kwargs = call
+                        assert args[2] == (x, y)  # Third argument should be coordinates tuple
+
+    def test_native_mac_double_click_integration_with_click_method(self, computer):
+        """Test that _native_mac_double_click is called from click method on macOS"""
+        with (
+            patch("platform.system", return_value="darwin"),
+            patch("pyautogui.moveTo"),
+            patch("time.sleep"),
+            patch.object(computer, "_native_mac_double_click") as mock_native_click,
+        ):
+            computer.click(100, 200, click_type="double")
+
+            # Verify _native_mac_double_click was called with correct coordinates
+            mock_native_click.assert_called_once_with(100, 200)
+
+    def test_native_mac_double_click_function_call_sequence(self, computer):
+        """Test the complete sequence of function calls in correct order"""
+        mock_create_mouse_event = MagicMock()
+        mock_set_integer_value_field = MagicMock()
+        mock_event_post = MagicMock()
+        mock_sleep = MagicMock()
+
+        # Track call order
+        call_order = []
+
+        def track_create_mouse_event(*args, **kwargs):
+            call_order.append("create_mouse_event")
+            return MagicMock()
+
+        def track_set_integer_value_field(*args, **kwargs):
+            call_order.append("set_integer_value_field")
+
+        def track_event_post(*args, **kwargs):
+            call_order.append("event_post")
+
+        def track_sleep(*args, **kwargs):
+            call_order.append("sleep")
+
+        mock_create_mouse_event.side_effect = track_create_mouse_event
+        mock_set_integer_value_field.side_effect = track_set_integer_value_field
+        mock_event_post.side_effect = track_event_post
+        mock_sleep.side_effect = track_sleep
+
+        with (
+            patch("src.strands_tools.use_computer.CGEventCreateMouseEvent", mock_create_mouse_event),
+            patch("src.strands_tools.use_computer.CGEventSetIntegerValueField", mock_set_integer_value_field),
+            patch("src.strands_tools.use_computer.CGEventPost", mock_event_post),
+            patch("time.sleep", mock_sleep),
+        ):
+            computer._native_mac_double_click(100, 200)
+
+            # Expected sequence: create_down, create_up, set_field_down, set_field_up,
+            # post_down, post_up, sleep, create_down, create_up, set_field_down,
+            # set_field_up, post_down, post_up
+            expected_sequence = [
+                "create_mouse_event",  # First down
+                "create_mouse_event",  # First up
+                "set_integer_value_field",  # Set first down state
+                "set_integer_value_field",  # Set first up state
+                "event_post",  # Post first down
+                "event_post",  # Post first up
+                "sleep",  # Delay between clicks
+                "create_mouse_event",  # Second down
+                "create_mouse_event",  # Second up
+                "set_integer_value_field",  # Set second down state
+                "set_integer_value_field",  # Set second up state
+                "event_post",  # Post second down
+                "event_post",  # Post second up
+            ]
+
+            assert call_order == expected_sequence


### PR DESCRIPTION
## Description
### Key Features
- This tool was tested on macOS, so some features may not work on Windows/Linux
- **Basic Computer Control:**
  - Mouse operations (click, move, drag)
  - Keyboard input (typing, key combinations, hotkeys)
  - Scrolling (vertical and horizontal)
  - Application management (open, close, focus)

- **Screen Analysis:**
  - Screenshot capture and analysis
  - OCR text detection using Pytesseract
  - Coordinate mapping for detected elements
  - Text grouping and line organization
  - Return the image as bytes to the LLM model

- **Cross-Platform Support:**
  - Windows, macOS, and Linux compatibility
  - Platform-specific optimizations (e.g., native macOS double-click)
  - Adaptive application naming conventions

### Technical Implementation
- Utilizes `pyautogui` for computer control
- Integrates OpenCV and Pytesseract for image processing and text detection
- Implements error handling and safety measures
- Provides coordinate system for precise interaction

### Dependencies
- opencv-python
- pytesseract
- pyautogui
- psutil
- numpy
- Note: Tesseract OCR engine needs to be installed separately on the system for text detection functionality.

Download Tesseract OCR on mac: `brew install tesseract` 

## Related Issues
[[Link to related issues using #issue-number format]](https://github.com/strands-agents/private-sdk-python-staging/issues/88)

## Documentation PR
TBD

## Type of Change
- [ ] Bug fix
- [x] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
