### PR TITLE
feat: add model switching support to think, agent_graph, swarm and use_llm tools

### DIFF
--- a/src/strands_tools/models/__init__.py
+++ b/src/strands_tools/models/__init__.py
@@ -1,0 +1,6 @@
+"""Model provider modules for strands_tools."""
+
+# This package contains model provider modules that can be dynamically loaded
+# by the model utilities in strands_tools.utils.models
+
+__all__ = ["bedrock", "anthropic", "litellm", "llamaapi", "ollama", "openai"]

--- a/src/strands_tools/models/anthropic.py
+++ b/src/strands_tools/models/anthropic.py
@@ -1,0 +1,18 @@
+"""Create instance of SDK's Anthropic model provider."""
+
+from typing import Any
+
+from strands.models.anthropic import AnthropicModel
+from strands.types.models import Model
+
+
+def instance(**model_config: Any) -> Model:
+    """Create instance of SDK's Anthropic model provider.
+
+    Args:
+        **model_config: Configuration options for the Anthropic model.
+
+    Returns:
+        Anthropic model provider.
+    """
+    return AnthropicModel(**model_config)

--- a/src/strands_tools/models/bedrock.py
+++ b/src/strands_tools/models/bedrock.py
@@ -1,0 +1,22 @@
+"""Create instance of SDK's Bedrock model provider."""
+
+from botocore.config import Config as BotocoreConfig
+from strands.models import BedrockModel
+from strands.types.models import Model
+from typing_extensions import Unpack
+
+
+def instance(**model_config: Unpack[BedrockModel.BedrockConfig]) -> Model:
+    """Create instance of SDK's Bedrock model provider.
+
+    Args:
+        **model_config: Configuration options for the Bedrock model.
+
+    Returns:
+        Bedrock model provider.
+    """
+    # Handle conversion of boto_client_config from dict to BotocoreConfig
+    if "boto_client_config" in model_config and isinstance(model_config["boto_client_config"], dict):
+        model_config["boto_client_config"] = BotocoreConfig(**model_config["boto_client_config"])
+
+    return BedrockModel(**model_config)

--- a/src/strands_tools/models/litellm.py
+++ b/src/strands_tools/models/litellm.py
@@ -1,0 +1,17 @@
+"""Create instance of SDK's LiteLLM model provider."""
+
+from strands.models.litellm import LiteLLMModel
+from strands.types.models import Model
+from typing_extensions import Unpack
+
+
+def instance(**model_config: Unpack[LiteLLMModel.LiteLLMConfig]) -> Model:
+    """Create instance of SDK's LiteLLM model provider.
+
+    Args:
+        **model_config: Configuration options for the LiteLLM model.
+
+    Returns:
+        LiteLLM model provider.
+    """
+    return LiteLLMModel(**model_config)

--- a/src/strands_tools/models/llamaapi.py
+++ b/src/strands_tools/models/llamaapi.py
@@ -1,0 +1,17 @@
+"""Create instance of SDK's LlamaAPI model provider."""
+
+from strands.models.llamaapi import LlamaAPIModel
+from strands.types.models import Model
+from typing_extensions import Unpack
+
+
+def instance(**model_config: Unpack[LlamaAPIModel.LlamaConfig]) -> Model:
+    """Create instance of SDK's LlamaAPI model provider.
+
+    Args:
+        **model_config: Configuration options for the LlamaAPI model.
+
+    Returns:
+        LlamaAPI model provider.
+    """
+    return LlamaAPIModel(**model_config)

--- a/src/strands_tools/models/ollama.py
+++ b/src/strands_tools/models/ollama.py
@@ -1,0 +1,18 @@
+"""Create instance of SDK's Ollama model provider."""
+
+from typing import Any
+
+from strands.models.ollama import OllamaModel
+from strands.types.models import Model
+
+
+def instance(**model_config: Any) -> Model:
+    """Create instance of SDK's Ollama model provider.
+
+    Args:
+        **model_config: Configuration options for the Ollama model.
+
+    Returns:
+        Ollama model provider.
+    """
+    return OllamaModel(**model_config)

--- a/src/strands_tools/models/openai.py
+++ b/src/strands_tools/models/openai.py
@@ -1,0 +1,18 @@
+"""Create instance of SDK's OpenAI model provider."""
+
+from typing import Any
+
+from strands.models.openai import OpenAIModel
+from strands.types.models import Model
+
+
+def instance(**model_config: Any) -> Model:
+    """Create instance of SDK's OpenAI model provider.
+
+    Args:
+        **model_config: Configuration options for the OpenAI model.
+
+    Returns:
+        OpenAI model provider.
+    """
+    return OpenAIModel(**model_config)

--- a/src/strands_tools/think.py
+++ b/src/strands_tools/think.py
@@ -1,56 +1,23 @@
 """
-Advanced recursive thinking tool for Strands Agent.
+Advanced recursive thinking tool for Strands Agent with model switching support.
 
 This module provides functionality for deep analytical thinking through multiple recursive cycles,
-enabling sophisticated thought processing, learning, and self-reflection capabilities.
-The tool processes thoughts through sequential cycles, each building upon the previous,
-to generate progressively refined insights.
-
-Usage with Strands Agent:
-```python
-from strands import Agent
-from strands_tools import think, stop
-
-agent = Agent(tools=[think, stop])
-
-# Basic usage with default system prompt (inherits all parent tools)
-result = agent.tool.think(
-    thought="How might we improve renewable energy storage solutions?",
-    cycle_count=3,
-    system_prompt="You are an expert energy systems analyst."
-)
-
-# Usage with specific tools filtered from parent agent
-result = agent.tool.think(
-    thought="Calculate energy efficiency and analyze the data",
-    cycle_count=3,
-    system_prompt="You are an expert energy systems analyst.",
-    tools=["calculator", "file_read", "python_repl"]
-)
-
-# Usage with mixed tool filtering from parent agent
-result = agent.tool.think(
-    thought="Analyze the implications of quantum computing on cryptography.",
-    cycle_count=5,
-    system_prompt="You are a specialist in quantum computing and cryptography. Analyze this topic deeply,
-    considering both technical and practical aspects.",
-    tools=["retrieve", "calculator", "http_request"]
-)
-```
-
-See the think function docstring for more details on configuration options and parameters.
+enabling sophisticated thought processing, learning, and self-reflection capabilities with support
+for different model providers for specialized thinking tasks.
 """
 
 import logging
+import os
 import traceback
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 from rich.console import Console
 from strands import Agent, tool
 from strands.telemetry.metrics import metrics_to_string
 
 from strands_tools.utils import console_util
+from strands_tools.utils.models import create_model
 
 logger = logging.getLogger(__name__)
 
@@ -62,9 +29,13 @@ class ThoughtProcessor:
         self.tool_use_id = str(uuid.uuid4())
         self.console = console
 
-    def create_thinking_prompt(self, thought: str, cycle: int, total_cycles: int) -> str:
-        """Create a focused prompt for the thinking process."""
-        prompt = f"""
+    def create_thinking_prompt(
+        self, thought: str, cycle: int, total_cycles: int, thinking_system_prompt: Optional[str] = None
+    ) -> str:
+        """Create a focused prompt for the thinking process with optional custom thinking instructions."""
+
+        # Default thinking instructions
+        default_instructions = """
 Direct Tasks:
 1. Process this thought deeply and analytically
 2. Generate clear, structured insights
@@ -72,7 +43,15 @@ Direct Tasks:
 4. Provide actionable conclusions
 5. DO NOT call the think tool again
 6. USE other tools.
+"""
 
+        # Use custom thinking instructions if provided, otherwise use defaults
+        if thinking_system_prompt:
+            thinking_instructions = f"\n{thinking_system_prompt}\n"
+        else:
+            thinking_instructions = default_instructions
+
+        prompt = f"""{thinking_instructions}
 Current Cycle: {cycle}/{total_cycles}
 
 Thought to process:
@@ -89,41 +68,90 @@ Please provide your analysis directly:
         total_cycles: int,
         custom_system_prompt: str,
         specified_tools=None,
+        model_provider: Optional[str] = None,
+        model_settings: Optional[Dict[str, Any]] = None,
+        thinking_system_prompt: Optional[str] = None,
         **kwargs: Any,
     ) -> str:
-        """Process a single thinking cycle."""
+        """Process a single thinking cycle with optional model switching and custom thinking instructions."""
 
         logger.debug(f"🧠 Thinking Cycle {cycle}/{total_cycles}: Processing cycle...")
         self.console.print(f"🧠 Thinking Cycle {cycle}/{total_cycles}: Processing cycle...")
 
-        # Create cycle-specific prompt
-        prompt = self.create_thinking_prompt(thought, cycle, total_cycles)
+        # Create cycle-specific prompt with custom thinking instructions
+        prompt = self.create_thinking_prompt(thought, cycle, total_cycles, thinking_system_prompt)
 
         # Display input prompt
         logger.debug(f"\n--- Input Prompt ---\n{prompt}\n")
 
-        # Get tools from parent agent if available
-        tools = []
+        # Get tools and trace attributes from parent agent
+        filtered_tools = []
         trace_attributes = {}
+        extra_kwargs = {}
+        model_info = "Using parent agent's model"
+
         parent_agent = kwargs.get("agent")
         if parent_agent:
             trace_attributes = parent_agent.trace_attributes
+            extra_kwargs["callback_handler"] = parent_agent.callback_handler
 
             # If specific tools are provided, filter parent tools; otherwise inherit all tools from parent
             if specified_tools is not None:
                 # Filter parent agent tools to only include specified tool names
-                filtered_tools = []
                 for tool_name in specified_tools:
                     if tool_name in parent_agent.tool_registry.registry:
                         filtered_tools.append(parent_agent.tool_registry.registry[tool_name])
                     else:
                         logger.warning(f"Tool '{tool_name}' not found in parent agent's tool registry")
-                tools = filtered_tools
             else:
-                tools = list(parent_agent.tool_registry.registry.values())
+                filtered_tools = list(parent_agent.tool_registry.registry.values())
 
-        # Initialize the new Agent with provided parameters
-        agent = Agent(messages=[], tools=tools, system_prompt=custom_system_prompt, trace_attributes=trace_attributes)
+        # Determine which model to use
+        selected_model = None
+
+        if model_provider is None:
+            # Use parent agent's model (original behavior)
+            selected_model = parent_agent.model if parent_agent else None
+            model_info = "Using parent agent's model"
+
+        elif model_provider == "env":
+            # Use environment variables to determine model
+            try:
+                env_provider = os.getenv("STRANDS_PROVIDER", "bedrock")
+                selected_model = create_model(provider=env_provider, config=model_settings)
+                model_info = f"Using environment model: {env_provider}"
+                logger.debug(f"🔄 Created model from environment: {env_provider}")
+
+            except Exception as e:
+                logger.warning(f"Failed to create model from environment: {e}")
+                logger.debug("Falling back to parent agent's model")
+                selected_model = parent_agent.model if parent_agent else None
+                model_info = f"Failed to use environment model, using parent's model (Error: {str(e)})"
+
+        else:
+            # Use specified model provider
+            try:
+                selected_model = create_model(provider=model_provider, config=model_settings)
+                model_info = f"Using {model_provider} model"
+                logger.debug(f"🔄 Created {model_provider} model for thinking cycle")
+
+            except Exception as e:
+                logger.warning(f"Failed to create {model_provider} model: {e}")
+                logger.debug("Falling back to parent agent's model")
+                selected_model = parent_agent.model if parent_agent else None
+                model_info = f"Failed to use {model_provider} model, using parent's model (Error: {str(e)})"
+
+        logger.debug(f"--- Model Info ---\n{model_info}\n")
+
+        # Initialize the new Agent with selected model
+        agent = Agent(
+            model=selected_model,
+            messages=[],
+            tools=filtered_tools,
+            system_prompt=custom_system_prompt,
+            trace_attributes=trace_attributes,
+            **extra_kwargs,
+        )
 
         # Run the agent with the provided prompt
         result = agent(prompt)
@@ -144,13 +172,23 @@ Please provide your analysis directly:
 
 
 @tool
-def think(thought: str, cycle_count: int, system_prompt: str, tools: list = None, agent: Any = None) -> Dict[str, Any]:
+def think(
+    thought: str,
+    cycle_count: int,
+    system_prompt: str,
+    tools: Optional[List[str]] = None,
+    model_provider: Optional[str] = None,
+    model_settings: Optional[Dict[str, Any]] = None,
+    thinking_system_prompt: Optional[str] = None,
+    agent: Optional[Any] = None,
+) -> Dict[str, Any]:
     """
-    Recursive thinking tool for sophisticated thought generation, learning, and self-reflection.
+    Recursive thinking tool with model switching support for sophisticated thought generation.
 
     This tool implements a multi-cycle cognitive analysis approach that progressively refines thoughts
-    through iterative processing. Each cycle builds upon insights from the previous cycle,
-    creating a depth of analysis that would be difficult to achieve in a single pass.
+    through iterative processing, with the ability to use different model providers for specialized
+    thinking tasks. Each cycle builds upon insights from the previous cycle, creating a depth of
+    analysis that would be difficult to achieve in a single pass.
 
     How It Works:
     ------------
@@ -159,22 +197,32 @@ def think(thought: str, cycle_count: int, system_prompt: str, tools: list = None
     3. A specialized system prompt guides the thinking process toward specific expertise domains
     4. Each cycle's output is captured and included in the final comprehensive analysis
     5. The tool avoids recursive self-calls and encourages the use of other tools when appropriate
+    6. Optionally uses different model providers for specialized thinking capabilities
 
-    Thinking Process:
-    ---------------
-    - First cycle processes the original thought directly with the provided system prompt
-    - Each subsequent cycle builds upon the previous cycle's output
-    - Cycles are tracked and labeled clearly in the output
-    - The process creates a chain of progressive refinement and deeper insights
-    - Final output includes the complete thought evolution across all cycles
+    Model Selection Process:
+    ----------------------
+    1. If model_provider is None: Uses parent agent's model (original behavior)
+    2. If model_provider is "env": Uses environment variables (STRANDS_PROVIDER, etc.)
+    3. If model_provider is specified: Uses that provider with optional custom config
+    4. Model utilities handle all provider-specific configuration automatically
+
+    System Prompt vs Thinking System Prompt:
+    --------------------------------------
+    - **system_prompt**: Controls the agent's persona, role, and expertise domain
+      Example: "You are a creative AI researcher specializing in educational technology."
+
+    - **thinking_system_prompt**: Controls the thinking methodology and approach
+      Example: "Use design thinking: empathize, define, ideate, prototype, test."
+
+    Together they provide: WHO the agent is (system_prompt) + HOW it thinks (thinking_system_prompt)
 
     Common Usage Scenarios:
     ---------------------
-    - Problem analysis: Breaking down complex problems into manageable components
-    - Idea development: Progressively refining creative concepts
-    - Learning exploration: Generating questions and insights about new domains
-    - Strategic planning: Developing multi-step approaches to challenges
-    - Self-reflection: Analyzing decision processes and potential biases
+    - Creative thinking: Use creative models for brainstorming and ideation
+    - Technical analysis: Use analytical models for code review and system design
+    - Multi-model comparison: Compare thinking approaches across different models
+    - Specialized domains: Use domain-specific models (math, creative writing, etc.)
+    - Cost optimization: Use cheaper models for exploratory thinking cycles
 
     Args:
         thought: The detailed thought or idea to process through multiple thinking cycles.
@@ -187,6 +235,20 @@ def think(thought: str, cycle_count: int, system_prompt: str, tools: list = None
         tools: List of tool names to make available to the nested agent. Tool names must
             exist in the parent agent's tool registry. Examples: ["calculator", "file_read", "retrieve"]
             If not provided, inherits all tools from the parent agent.
+        model_provider: Model provider to use for the thinking cycles.
+            Options: "bedrock", "anthropic", "litellm", "llamaapi", "ollama", "openai", "github"
+            Special values:
+            - None: Use parent agent's model (default, preserves original behavior)
+            - "env": Use environment variables to determine provider
+            Examples: "bedrock", "anthropic", "litellm", "env"
+        model_settings: Optional custom configuration for the model.
+            If not provided, uses default configuration for the provider.
+            Example: {"model_id": "claude-sonnet-4-20250514", "params": {"temperature": 1}}
+        thinking_system_prompt: Optional custom thinking instructions that override the default
+            thinking methodology. This controls HOW the agent thinks about the problem, separate
+            from the system_prompt which controls the agent's persona/role.
+            Example: "Use first principles reasoning. Break down complex problems into fundamental
+            components. Question assumptions at each step."
         agent: The parent agent (automatically passed by Strands framework)
 
     Returns:
@@ -199,12 +261,69 @@ def think(thought: str, cycle_count: int, system_prompt: str, tools: list = None
         Success case: Returns concatenated results from all thinking cycles
         Error case: Returns information about what went wrong during processing
 
+    Environment Variables for Model Switching:
+    ----------------------------------------
+    When model_provider="env", these variables are used:
+    - STRANDS_PROVIDER: Model provider name
+    - STRANDS_MODEL_ID: Specific model identifier
+    - STRANDS_MAX_TOKENS: Maximum tokens to generate
+    - STRANDS_TEMPERATURE: Sampling temperature
+    - Provider-specific keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
+
+    Examples:
+    --------
+    # Use Bedrock for creative thinking
+    result = agent.tool.think(
+        thought="How can we make AI more creative?",
+        cycle_count=3,
+        system_prompt="You are a creative AI researcher.",
+        model_provider="bedrock"
+    )
+
+    # Use Ollama for local processing
+    result = agent.tool.think(
+        thought="Analyze this code architecture",
+        cycle_count=5,
+        system_prompt="You are a software architect.",
+        model_provider="ollama",
+        model_settings={"model_id": "qwen3:4b", "host": "http://localhost:11434"}
+    )
+
+    # Use environment configuration with custom thinking methodology
+    os.environ["STRANDS_PROVIDER"] = "anthropic"
+    os.environ["STRANDS_MODEL_ID"] = "claude-sonnet-4-20250514"
+    result = agent.tool.think(
+        thought="What are the ethical implications?",
+        cycle_count=4,
+        system_prompt="You are an AI ethics expert.",
+        model_provider="env",
+        thinking_system_prompt=Use Socratic questioning method:
+        1. Question fundamental assumptions
+        2. Explore implications through dialogue
+        3. Consider multiple perspectives
+        4. Challenge each conclusion with 'but what if...'
+        5. Build understanding through systematic inquiry
+    )
+
+    # Custom thinking methodology for creative problem solving
+    result = agent.tool.think(
+        thought="How can we revolutionize online education?",
+        cycle_count=3,
+        system_prompt="You are an innovative education technology expert.",
+        thinking_system_prompt='''Apply design thinking methodology:
+        1. Empathize: Understand user pain points deeply
+        2. Define: Clearly articulate the core problem
+        3. Ideate: Generate diverse, unconventional solutions
+        4. Prototype: Outline practical implementation steps
+        5. Test: Consider potential challenges and iterations'''
+    )
+
     Notes:
-        - Higher cycle counts provide deeper analysis but consume more resources
-        - The system_prompt significantly influences the thinking style and domain expertise
-        - For complex topics, more specific system prompts tend to yield better results
-        - The tool is designed to avoid recursive self-calls that could cause infinite loops
-        - Each cycle has visibility into previous cycle outputs to enable building upon insights
+        - Model switching requires the appropriate dependencies (bedrock, anthropic, ollama, etc.)
+        - When model_provider is None, behavior is identical to the original implementation
+        - Custom model_settings overrides default environment-based configuration
+        - Each cycle uses the same model - mixed model cycles not currently supported
+        - Model information is logged for transparency and debugging
     """
     console = console_util.create()
 
@@ -215,6 +334,7 @@ def think(thought: str, cycle_count: int, system_prompt: str, tools: list = None
             custom_system_prompt = (
                 "You are an expert analytical thinker. Process the thought deeply and provide clear insights."
             )
+
         kwargs = {"agent": agent}
         # Create thought processor instance with the available context
         processor = ThoughtProcessor(kwargs, console)
@@ -225,7 +345,7 @@ def think(thought: str, cycle_count: int, system_prompt: str, tools: list = None
 
         # Process through each cycle
         for cycle in range(1, cycle_count + 1):
-            # Process current cycle - need to remove thought from kwargs to prevent duplicate parameters
+            # Process current cycle
             cycle_kwargs = kwargs.copy()
             if "thought" in cycle_kwargs:
                 del cycle_kwargs["thought"]  # Prevent duplicate 'thought' parameter
@@ -236,6 +356,9 @@ def think(thought: str, cycle_count: int, system_prompt: str, tools: list = None
                 cycle_count,
                 custom_system_prompt,
                 specified_tools=tools,
+                model_provider=model_provider,
+                model_settings=model_settings,
+                thinking_system_prompt=thinking_system_prompt,
                 **cycle_kwargs,
             )
 
@@ -245,7 +368,7 @@ def think(thought: str, cycle_count: int, system_prompt: str, tools: list = None
             # Update thought for next cycle based on current response
             current_thought = f"Previous cycle concluded: {cycle_response}\nContinue developing these ideas further."
 
-        # Combine all responses into final output (removing duplicate code)
+        # Combine all responses into final output
         final_output = "\n\n".join([f"Cycle {r['cycle']}/{cycle_count}:\n{r['response']}" for r in all_responses])
 
         # Return combined result

--- a/src/strands_tools/use_llm.py
+++ b/src/strands_tools/use_llm.py
@@ -1,12 +1,11 @@
-"""
-Dynamic LLM instance creation for Strands Agent.
+"""Dynamic LLM instance creation for Strands Agent with model switching support.
 
-This module provides functionality to start new AI event loops with specified prompts,
-allowing you to create isolated agent instances for specific tasks or use cases.
-Each invocation creates a fresh agent with its own context and state.
+This module provides functionality to start new AI event loops with specified prompts
+and optionally different model providers, allowing you to create isolated agent instances
+for specific tasks or use cases with different AI models.
 
-Strands automatically handles the lifecycle of these nested agent instances,
-making them powerful for delegation, specialized processing, or isolated computation.
+Each invocation creates a fresh agent with its own context and state, and can use
+a different model provider than the parent agent.
 
 Usage with Strands Agent:
 ```python
@@ -15,194 +14,272 @@ from strands_tools import use_llm
 
 agent = Agent(tools=[use_llm])
 
-# Basic usage with just a prompt and system prompt (inherits all parent tools)
+# Basic usage with inherited model (original behavior)
 result = agent.tool.use_llm(
     prompt="Tell me about the advantages of tool-building in AI agents",
     system_prompt="You are a helpful AI assistant specializing in AI development concepts."
 )
 
-# Usage with specific tools filtered from parent agent
+# Usage with different model provider
 result = agent.tool.use_llm(
-    prompt="Calculate 2 + 2 and retrieve some information",
-    system_prompt="You are a helpful assistant.",
-    tools=["calculator", "retrieve"]
+    prompt="Calculate 2 + 2 and explain the result",
+    system_prompt="You are a helpful math assistant.",
+    model_provider="bedrock",  # Switch to Bedrock instead of parent's model
+    tools=["calculator"]
 )
 
-# Usage with mixed tool filtering from parent agent
+# Usage with custom model configuration
 result = agent.tool.use_llm(
-    prompt="Analyze this data file",
-    system_prompt="You are a data analyst.",
-    tools=["file_read", "calculator", "python_repl"]
+    prompt="Write a creative story",
+    system_prompt="You are a creative writing assistant.",
+    model_provider="github",
+    model_settings={
+        "model_id": "openai/o4-mini",
+        "params": {"temperature": 1, "max_tokens": 4000}
+    }
 )
 
-# The response is available in the returned object
-print(result["content"][0]["text"])  # Prints the response text
+# Environment-based model switching
+import os
+os.environ["STRANDS_PROVIDER"] = "ollama"
+os.environ["STRANDS_MODEL_ID"] = "qwen3:4b"
+result = agent.tool.use_llm(
+    prompt="Analyze this code",
+    system_prompt="You are a code review assistant.",
+    model_provider="env"  # Use environment variables
+)
 ```
 
 See the use_llm function docstring for more details on configuration options and parameters.
 """
 
 import logging
-from typing import Any
+import os
+from typing import Any, Dict, List, Optional
 
-from strands import Agent
+from strands import Agent, tool
 from strands.telemetry.metrics import metrics_to_string
-from strands.types.tools import ToolResult, ToolUse
+
+from strands_tools.utils.models import create_model
 
 logger = logging.getLogger(__name__)
 
-TOOL_SPEC = {
-    "name": "use_llm",
-    "description": "Start a new AI event loop with a specified prompt",
-    "inputSchema": {
-        "json": {
-            "type": "object",
-            "properties": {
-                "prompt": {
-                    "type": "string",
-                    "description": "What should this AI event loop do?",
-                },
-                "system_prompt": {
-                    "type": "string",
-                    "description": "System prompt for the new event loop",
-                },
-                "tools": {
-                    "type": "array",
-                    "description": "List of tool names to make available to the nested agent"
-                    + "Tool names must exist in the parent agent's tool registry."
-                    + "If not provided, inherits all tools from parent agent.",
-                    "items": {"type": "string"},
-                },
-            },
-            "required": ["prompt", "system_prompt"],
-        }
-    },
-}
 
-
-def use_llm(tool: ToolUse, **kwargs: Any) -> ToolResult:
-    """
-    Create a new LLM instance using the Agent interface.
+@tool
+def use_llm(
+    prompt: str,
+    system_prompt: str,
+    tools: Optional[List[str]] = None,
+    model_provider: Optional[str] = None,
+    model_settings: Optional[Dict[str, Any]] = None,
+    agent: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Start a new AI event loop with a specified prompt and optionally different model.
 
     This function creates a new Strands Agent instance with the provided system prompt,
-    runs it with the specified prompt, and returns the response with performance metrics.
-    It allows for isolated processing in a fresh context separate from the main agent.
+    optionally using a different model provider than the parent agent, runs it with the
+    specified prompt, and returns the response with performance metrics.
 
     How It Works:
     ------------
-    1. The function initializes a new Agent instance with the provided system prompt
-    2. The agent processes the given prompt in its own isolated context
-    3. The response and metrics are captured and returned in a structured format
-    4. The new agent instance exists only for the duration of this function call
+    1. Determines which model to use (parent's model, specified provider, or environment)
+    2. Creates a new Agent instance with the model and system prompt
+    3. The agent processes the given prompt in its own isolated context
+    4. The response and metrics are captured and returned in a structured format
+    5. The new agent instance exists only for the duration of this function call
 
-    Agent Creation Process:
-    ---------------------
-    - A fresh Agent object is created with an empty message history
-    - The provided system prompt configures the agent's behavior and capabilities
-    - The agent processes the prompt in its own isolated context
-    - Response and metrics are captured for return to the caller
-    - The parent agent's callback_handler is used if one is not specified
+    Model Selection Process:
+    ----------------------
+    1. If model_provider is None: Uses parent agent's model (original behavior)
+    2. If model_provider is "env": Uses environment variables (STRANDS_PROVIDER, etc.)
+    3. If model_provider is specified: Uses that provider with optional custom config
+    4. Model utilities handle all provider-specific configuration automatically
 
     Common Use Cases:
     ---------------
-    - Task delegation: Creating specialized agents for specific subtasks
-    - Context isolation: Processing prompts in a clean context without history
-    - Multi-agent systems: Creating multiple agents with different specializations
-    - Learning and reasoning: Using nested agents for complex reasoning chains
+    - Multi-model workflows: Use different models for different tasks
+    - Model comparison: Compare responses from different providers
+    - Cost optimization: Use cheaper models for simple tasks
+    - Specialized models: Use domain-specific models (code, math, creative)
+    - Fallback strategies: Switch to alternative models if primary fails
 
     Args:
-        tool (ToolUse): Tool use object containing the following:
-            - prompt (str): The prompt to process with the new agent instance
-            - system_prompt (str): Custom system prompt for the agent
-            - tools (List[str], optional): List of tool names to make available to the nested agent.
-                Tool names must exist in the parent agent's tool registry.
-                Examples: ["calculator", "file_read", "retrieve"]
-                If not provided, inherits all tools from the parent agent.
-        **kwargs (Any): Additional keyword arguments
+        prompt: The prompt to process with the new agent instance.
+        system_prompt: Custom system prompt for the agent.
+        tools: List of tool names to make available to the nested agent.
+            Tool names must exist in the parent agent's tool registry.
+            Examples: ["calculator", "file_read", "retrieve"]
+            If not provided, inherits all tools from the parent agent.
+        model_provider: Model provider to use for the nested agent.
+            Options: "bedrock", "anthropic", "litellm", "llamaapi", "ollama", "openai", "github"
+            Special values:
+            - None: Use parent agent's model (default, preserves original behavior)
+            - "env": Use environment variables to determine provider
+            Examples: "bedrock", anthropic", "litellm", "env"
+        model_settings: Optional custom configuration for the model.
+            If not provided, uses default configuration for the provider.
+            Example: {"model_id": "claude-sonnet-4-20250514", "params": {"temperature": 1}}
+        agent: The parent agent (automatically passed by Strands framework).
 
     Returns:
-        ToolResult: Dictionary containing status and response content in the format:
+        Dict containing status and response content in the format:
         {
-            "toolUseId": "unique-tool-use-id",
-            "status": "success",
+            "status": "success|error",
             "content": [
                 {"text": "Response: The response text from the agent"},
+                {"text": "Model: Information about the model used"},
                 {"text": "Metrics: Performance metrics information"}
             ]
         }
 
-    Notes:
-        - The agent instance is temporary and will be garbage-collected after use
-        - The agent(prompt) call is synchronous and will block until completion
-        - Performance metrics include token usage and processing latency information
-    """
-    tool_use_id = tool["toolUseId"]
-    tool_input = tool["input"]
+        Success case: Returns the agent response with model info and performance metrics
+        Error case: Returns information about what went wrong during processing
 
-    prompt = tool_input["prompt"]
-    tool_system_prompt = tool_input.get("system_prompt")
-    specified_tools = tool_input.get("tools")
+    Environment Variables for Model Switching:
+    ----------------------------------------
+    When model_provider="env", these variables are used:
+    - STRANDS_PROVIDER: Model provider name
+    - STRANDS_MODEL_ID: Specific model identifier
+    - STRANDS_MAX_TOKENS: Maximum tokens to generate
+    - STRANDS_TEMPERATURE: Sampling temperature
+    - Provider-specific keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
 
-    tools = []
-    trace_attributes = {}
-
-    extra_kwargs = {}
-    parent_agent = kwargs.get("agent")
-    if parent_agent:
-        trace_attributes = parent_agent.trace_attributes
-        extra_kwargs["callback_handler"] = parent_agent.callback_handler
-
-        # If specific tools are provided, filter parent tools; otherwise inherit all tools from parent
-        if specified_tools is not None:
-            # Filter parent agent tools to only include specified tool names
-            filtered_tools = []
-            for tool_name in specified_tools:
-                if tool_name in parent_agent.tool_registry.registry:
-                    filtered_tools.append(parent_agent.tool_registry.registry[tool_name])
-                else:
-                    logger.warning(f"Tool '{tool_name}' not found in parent agent's tool registry")
-            tools = filtered_tools
-        else:
-            tools = list(parent_agent.tool_registry.registry.values())
-
-    if "callback_handler" in kwargs:
-        extra_kwargs["callback_handler"] = kwargs["callback_handler"]
-
-    # Display input prompt
-    logger.debug(f"\n--- Input Prompt ---\n{prompt}\n")
-
-    # Visual indicator for new LLM instance
-    logger.debug("🔄 Creating new LLM instance...")
-
-    # Initialize the new Agent with provided parameters
-    agent = Agent(
-        messages=[],
-        tools=tools,
-        system_prompt=tool_system_prompt,
-        trace_attributes=trace_attributes,
-        **extra_kwargs,
+    Examples:
+    --------
+    # Use Bedrock for creative tasks
+    result = agent.tool.use_llm(
+        prompt="Write a poem about AI",
+        system_prompt="You are a creative poet.",
+        model_provider="bedrock"
     )
-    # Run the agent with the provided prompt
-    result = agent(prompt)
 
-    # Extract response
-    assistant_response = str(result)
+    # Use Ollama for local processing
+    result = agent.tool.use_llm(
+        prompt="Summarize this text",
+        system_prompt="You are a summarization assistant.",
+        model_provider="ollama",
+        model_settings={"model_id": "llama3", "host": "http://localhost:11434"}
+    )
 
-    # Display assistant response
-    logger.debug(f"\n--- Assistant Response ---\n{assistant_response.strip()}\n")
+    # Use environment configuration
+    os.environ["STRANDS_PROVIDER"] = "litellm"
+    os.environ["STRANDS_MODEL_ID"] = "openai/gpt-4o"
+    result = agent.tool.use_llm(
+        prompt="Analyze this data",
+        system_prompt="You are a data analyst.",
+        model_provider="env"
+    )
 
-    # Print metrics if available
-    metrics_text = ""
-    if result.metrics:
-        metrics = result.metrics
-        metrics_text = metrics_to_string(metrics)
-        logger.debug(metrics_text)
+    Notes:
+        - Model switching requires the appropriate dependencies (bedrock, anthropic, ollama, llamaapi, litellm, etc.)
+        - When model_provider is None, behavior is identical to the original implementation
+        - Custom model_settings overrides default environment-based configuration
+        - Performance metrics include token usage for the specific model used
+        - Model information is included in the response for transparency
+    """
+    try:
+        # Get tools and trace attributes from parent agent
+        filtered_tools = []
+        trace_attributes = {}
+        extra_kwargs = {}
+        model_info = "Using parent agent's model"
 
-    return {
-        "toolUseId": tool_use_id,
-        "status": "success",
-        "content": [
-            {"text": f"Response: {assistant_response}"},
-            {"text": f"Metrics: {metrics_text}"},
-        ],
-    }
+        if agent:
+            trace_attributes = agent.trace_attributes
+            extra_kwargs["callback_handler"] = agent.callback_handler
+
+            # If specific tools are provided, filter parent tools; otherwise inherit all tools from parent
+            if tools is not None:
+                # Filter parent agent tools to only include specified tool names
+                for tool_name in tools:
+                    if tool_name in agent.tool_registry.registry:
+                        filtered_tools.append(agent.tool_registry.registry[tool_name])
+                    else:
+                        logger.warning(f"Tool '{tool_name}' not found in parent agent's tool registry")
+            else:
+                filtered_tools = list(agent.tool_registry.registry.values())
+
+        # Determine which model to use
+        selected_model = None
+
+        if model_provider is None:
+            # Use parent agent's model (original behavior)
+            selected_model = agent.model if agent else None
+            model_info = "Using parent agent's model"
+
+        elif model_provider == "env":
+            # Use environment variables to determine model
+            try:
+                env_provider = os.getenv("STRANDS_PROVIDER", "bedrock")
+                selected_model = create_model(provider=env_provider, config=model_settings)
+                model_info = f"Using environment model: {env_provider}"
+                logger.debug(f"🔄 Created model from environment: {env_provider}")
+
+            except Exception as e:
+                logger.warning(f"Failed to create model from environment: {e}")
+                logger.debug("Falling back to parent agent's model")
+                selected_model = agent.model if agent else None
+                model_info = f"Failed to use environment model, using parent's model (Error: {str(e)})"
+
+        else:
+            # Use specified model provider
+            try:
+                selected_model = create_model(provider=model_provider, config=model_settings)
+                model_info = f"Using {model_provider} model"
+                logger.debug(f"🔄 Created {model_provider} model for nested agent")
+
+            except Exception as e:
+                logger.warning(f"Failed to create {model_provider} model: {e}")
+                logger.debug("Falling back to parent agent's model")
+                selected_model = agent.model if agent else None
+                model_info = f"Failed to use {model_provider} model, using parent's model (Error: {str(e)})"
+
+        # Display input prompt
+        logger.debug(f"\n--- Input Prompt ---\n{prompt}\n")
+        logger.debug(f"--- Model Info ---\n{model_info}\n")
+
+        # Visual indicator for new LLM instance
+        logger.debug("🔄 Creating new LLM instance...")
+
+        # Initialize the new Agent with selected model
+        new_agent = Agent(
+            model=selected_model,
+            messages=[],
+            tools=filtered_tools,
+            system_prompt=system_prompt,
+            trace_attributes=trace_attributes,
+            **extra_kwargs,
+        )
+
+        # Run the agent with the provided prompt
+        result = new_agent(prompt)
+
+        # Extract response
+        assistant_response = str(result)
+
+        # Display assistant response
+        logger.debug(f"\n--- Assistant Response ---\n{assistant_response.strip()}\n")
+
+        # Print metrics if available
+        metrics_text = ""
+        if result.metrics:
+            metrics = result.metrics
+            metrics_text = metrics_to_string(metrics)
+            logger.debug(metrics_text)
+
+        return {
+            "status": "success",
+            "content": [
+                {"text": f"Response: {assistant_response}"},
+                {"text": f"Model: {model_info}"},
+                {"text": f"Metrics: {metrics_text}"},
+            ],
+        }
+
+    except Exception as e:
+        error_msg = f"Error in use_llm tool: {str(e)}"
+        logger.error(error_msg)
+        return {
+            "status": "error",
+            "content": [{"text": error_msg}],
+        }

--- a/src/strands_tools/utils/__init__.py
+++ b/src/strands_tools/utils/__init__.py
@@ -1,0 +1,12 @@
+"""Utility modules for strands_tools."""
+
+from . import console_util, data_util, detect_language, generate_schema_util, models, user_input
+
+__all__ = [
+    "console_util",
+    "data_util",
+    "detect_language",
+    "generate_schema_util",
+    "models",
+    "user_input",
+]

--- a/src/strands_tools/utils/models.py
+++ b/src/strands_tools/utils/models.py
@@ -1,0 +1,323 @@
+"""Utilities for loading model providers in strands_tools."""
+
+import importlib
+import json
+import os
+import pathlib
+from typing import Any
+
+from botocore.config import Config
+from strands.types.models import Model
+
+# Default model configuration for Bedrock
+DEFAULT_MODEL_CONFIG = {
+    "model_id": os.getenv("STRANDS_MODEL_ID", "us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    "max_tokens": int(os.getenv("STRANDS_MAX_TOKENS", "10000")),
+    "boto_client_config": Config(
+        read_timeout=int(os.getenv("STRANDS_BOTO_READ_TIMEOUT", "900")),
+        connect_timeout=int(os.getenv("STRANDS_BOTO_CONNECT_TIMEOUT", "900")),
+        retries=dict(max_attempts=int(os.getenv("STRANDS_BOTO_MAX_ATTEMPTS", "3")), mode="adaptive"),
+    ),
+    "additional_request_fields": {},
+    "cache_tools": os.getenv("STRANDS_CACHE_TOOLS", "default"),
+    "cache_prompt": os.getenv("STRANDS_CACHE_PROMPT", "default"),
+}
+
+# Parse additional request fields if provided
+ADDITIONAL_REQUEST_FIELDS = os.getenv("STRANDS_ADDITIONAL_REQUEST_FIELDS", "{}")
+if ADDITIONAL_REQUEST_FIELDS != "{}":
+    try:
+        DEFAULT_MODEL_CONFIG["additional_request_fields"] = json.loads(ADDITIONAL_REQUEST_FIELDS)
+    except json.JSONDecodeError:
+        pass
+
+# Add anthropic beta features if specified
+ANTHROPIC_BETA_FEATURES = os.getenv("STRANDS_ANTHROPIC_BETA", "")
+if len(ANTHROPIC_BETA_FEATURES) > 0:
+    DEFAULT_MODEL_CONFIG["additional_request_fields"]["anthropic_beta"] = ANTHROPIC_BETA_FEATURES.split(",")
+
+# Add thinking configuration if specified
+THINKING_TYPE = os.getenv("STRANDS_THINKING_TYPE", "")
+BUDGET_TOKENS = os.getenv("STRANDS_BUDGET_TOKENS", "")
+if THINKING_TYPE:
+    thinking_config = {"type": THINKING_TYPE}
+    if BUDGET_TOKENS:
+        thinking_config["budget_tokens"] = int(BUDGET_TOKENS)
+    DEFAULT_MODEL_CONFIG["additional_request_fields"]["thinking"] = thinking_config
+
+
+def load_path(name: str) -> pathlib.Path:
+    """Locate the model provider module file path.
+
+    First search "$CWD/.models". If the module file is not found, fall back to the built-in models directory.
+
+    Args:
+        name: Name of the model provider (e.g., bedrock).
+
+    Returns:
+        The file path to the model provider module.
+
+    Raises:
+        ImportError: If the model provider module cannot be found.
+    """
+    path = pathlib.Path.cwd() / ".models" / f"{name}.py"
+    if not path.exists():
+        path = pathlib.Path(__file__).parent / ".." / "models" / f"{name}.py"
+
+    if not path.exists():
+        raise ImportError(f"model_provider=<{name}> | does not exist")
+
+    return path
+
+
+def load_config(config: str) -> dict[str, Any]:
+    """Load model configuration from a JSON string or file.
+
+    Args:
+        config: A JSON string or path to a JSON file containing model configuration.
+            If empty string or '{}', the default config is used.
+
+    Returns:
+        The parsed configuration.
+    """
+    if not config or config == "{}":
+        return DEFAULT_MODEL_CONFIG
+
+    if config.endswith(".json"):
+        with open(config) as fp:
+            return json.load(fp)
+
+    return json.loads(config)
+
+
+def load_model(path: pathlib.Path, config: dict[str, Any]) -> Model:
+    """Dynamically load and instantiate a model provider from a Python module.
+
+    Imports the module at the specified path and calls its 'instance' function
+    with the provided configuration to create a model instance.
+
+    Args:
+        path: Path to the Python module containing the model provider implementation.
+        config: Configuration to pass to the model provider's instance function.
+
+    Returns:
+        An instantiated model provider.
+    """
+    spec = importlib.util.spec_from_file_location(path.stem, str(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.instance(**config)
+
+
+def create_model(provider: str = None, config: dict[str, Any] = None) -> Model:
+    """Create model based on provider configuration.
+
+    Args:
+        provider: Model provider name. If None, uses STRANDS_PROVIDER env var or defaults to 'bedrock'.
+        config: Model configuration dict. If None, uses environment-based config.
+
+    Returns:
+        Configured model instance.
+    """
+    if provider is None:
+        provider = os.getenv("STRANDS_PROVIDER", "bedrock")
+
+    if config is None:
+        config = get_provider_config(provider)
+
+    if provider == "bedrock":
+        from strands.models.bedrock import BedrockModel
+
+        return BedrockModel(**config)
+
+    elif provider == "anthropic":
+        from strands.models.anthropic import AnthropicModel
+
+        return AnthropicModel(**config)
+
+    elif provider == "litellm":
+        from strands.models.litellm import LiteLLMModel
+
+        return LiteLLMModel(**config)
+
+    elif provider == "llamaapi":
+        from strands.models.llamaapi import LlamaAPIModel
+
+        return LlamaAPIModel(**config)
+
+    elif provider == "ollama":
+        from strands.models.ollama import OllamaModel
+
+        return OllamaModel(**config)
+
+    elif provider == "openai":
+        from strands.models.openai import OpenAIModel
+
+        return OpenAIModel(**config)
+
+    elif provider == "github":
+        from strands.models.openai import OpenAIModel
+
+        return OpenAIModel(**config)
+
+    else:
+        # Try to load custom model provider
+        try:
+            path = load_path(provider)
+            return load_model(path, config)
+        except ImportError:
+            raise ValueError(f"Unknown model provider: {provider}") from None
+
+
+def get_provider_config(provider: str) -> dict[str, Any]:
+    """Get configuration for a specific model provider based on environment variables.
+
+    Args:
+        provider: Model provider name.
+
+    Returns:
+        Configuration dictionary for the provider.
+    """
+    if provider == "bedrock":
+        return {
+            "model_id": os.getenv("STRANDS_MODEL_ID", "us.anthropic.claude-sonnet-4-20250514-v1:0"),
+            "max_tokens": int(os.getenv("STRANDS_MAX_TOKENS", "10000")),
+            "boto_client_config": Config(
+                read_timeout=900,
+                connect_timeout=900,
+                retries={"max_attempts": 3, "mode": "adaptive"},
+            ),
+            "additional_request_fields": DEFAULT_MODEL_CONFIG["additional_request_fields"],
+            "cache_prompt": os.getenv("STRANDS_CACHE_PROMPT", "default"),
+            "cache_tools": os.getenv("STRANDS_CACHE_TOOLS", "default"),
+        }
+
+    elif provider == "anthropic":
+        return {
+            "client_args": {
+                "api_key": os.getenv("ANTHROPIC_API_KEY"),
+            },
+            "max_tokens": int(os.getenv("STRANDS_MAX_TOKENS", "10000")),
+            "model_id": os.getenv("STRANDS_MODEL_ID", "claude-sonnet-4-20250514"),
+            "params": {
+                "temperature": float(os.getenv("STRANDS_TEMPERATURE", "1")),
+            },
+        }
+
+    elif provider == "litellm":
+        client_args = {"api_key": os.getenv("LITELLM_API_KEY")}
+        if os.getenv("LITELLM_BASE_URL"):
+            client_args["base_url"] = os.getenv("LITELLM_BASE_URL")
+
+        return {
+            "client_args": client_args,
+            "model_id": os.getenv("STRANDS_MODEL_ID", "anthropic/claude-sonnet-4-20250514"),
+            "params": {
+                "max_tokens": int(os.getenv("STRANDS_MAX_TOKENS", "10000")),
+                "temperature": float(os.getenv("STRANDS_TEMPERATURE", "1")),
+            },
+        }
+
+    elif provider == "llamaapi":
+        return {
+            "client_args": {
+                "api_key": os.getenv("LLAMAAPI_API_KEY"),
+            },
+            "model_id": os.getenv("STRANDS_MODEL_ID", "Llama-4-Maverick-17B-128E-Instruct-FP8"),
+            "params": {
+                "max_completion_tokens": int(os.getenv("STRANDS_MAX_TOKENS", "4096")),
+                "temperature": float(os.getenv("STRANDS_TEMPERATURE", "1")),
+            },
+        }
+
+    elif provider == "ollama":
+        return {
+            "host": os.getenv("OLLAMA_HOST", "http://localhost:11434"),
+            "model_id": os.getenv("STRANDS_MODEL_ID", "qwen3:4b"),
+        }
+
+    elif provider == "openai":
+        return {
+            "client_args": {"api_key": os.getenv("OPENAI_API_KEY")},
+            "model_id": os.getenv("STRANDS_MODEL_ID", "o4-mini"),
+            "params": {"max_completion_tokens": int(os.getenv("STRANDS_MAX_TOKENS", "10000"))},
+        }
+
+    elif provider == "github":
+        return {
+            "client_args": {
+                "api_key": os.getenv("PAT_TOKEN", os.getenv("GITHUB_TOKEN")),
+                "base_url": "https://models.github.ai/inference",
+            },
+            "model_id": os.getenv("STRANDS_MODEL_ID", "openai/o4-mini"),
+            "params": {"max_completion_tokens": int(os.getenv("STRANDS_MAX_TOKENS", "10000"))},
+        }
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
+def get_available_providers() -> list[str]:
+    """Get list of available model providers.
+
+    Returns:
+        List of available model provider names.
+    """
+    return ["bedrock", "anthropic", "litellm", "llamaapi", "ollama", "openai", "github"]
+
+
+def get_provider_info(provider: str) -> dict[str, Any]:
+    """Get information about a specific model provider.
+
+    Args:
+        provider: Model provider name.
+
+    Returns:
+        Dictionary with provider information.
+    """
+    provider_info = {
+        "bedrock": {
+            "name": "Amazon Bedrock",
+            "description": "Amazon's managed foundation model service",
+            "default_model": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+            "env_vars": ["STRANDS_MODEL_ID", "STRANDS_MAX_TOKENS", "AWS_PROFILE", "AWS_REGION"],
+        },
+        "anthropic": {
+            "name": "Anthropic",
+            "description": "Direct access to Anthropic's Claude models",
+            "default_model": "claude-sonnet-4-20250514",
+            "env_vars": ["ANTHROPIC_API_KEY", "STRANDS_MODEL_ID", "STRANDS_MAX_TOKENS", "STRANDS_TEMPERATURE"],
+        },
+        "litellm": {
+            "name": "LiteLLM",
+            "description": "Unified interface for multiple LLM providers",
+            "default_model": "anthropic/claude-sonnet-4-20250514",
+            "env_vars": ["LITELLM_API_KEY", "LITELLM_BASE_URL", "STRANDS_MODEL_ID", "STRANDS_MAX_TOKENS"],
+        },
+        "llamaapi": {
+            "name": "Llama API",
+            "description": "Meta-hosted Llama model API service",
+            "default_model": "llama3.1-405b",
+            "env_vars": ["LLAMAAPI_API_KEY", "STRANDS_MODEL_ID", "STRANDS_MAX_TOKENS"],
+        },
+        "ollama": {
+            "name": "Ollama",
+            "description": "Local model inference server",
+            "default_model": "llama3",
+            "env_vars": ["OLLAMA_HOST", "STRANDS_MODEL_ID"],
+        },
+        "openai": {
+            "name": "OpenAI",
+            "description": "OpenAI's GPT models",
+            "default_model": "o4-mini",
+            "env_vars": ["OPENAI_API_KEY", "STRANDS_MODEL_ID", "STRANDS_MAX_TOKENS"],
+        },
+        "github": {
+            "name": "GitHub Models",
+            "description": "GitHub's model inference service",
+            "default_model": "o4-mini",
+            "env_vars": ["GITHUB_TOKEN", "PAT_TOKEN", "STRANDS_MODEL_ID", "STRANDS_MAX_TOKENS"],
+        },
+    }
+
+    return provider_info.get(provider, {"name": provider, "description": "Custom provider"})

--- a/tests/test_agent_graph.py
+++ b/tests/test_agent_graph.py
@@ -1,5 +1,5 @@
 """
-Tests for the agent_graph tool.
+Tests for the updated agent_graph tool using @tool decorator.
 """
 
 # isort: skip_file
@@ -55,15 +55,12 @@ def mock_thread_pool():
 
 
 @pytest.fixture
-def tool_context():
-    """Create a tool context for testing."""
-    return {
-        "bedrock_client": MagicMock(),
-        "system_prompt": "Test system prompt",
-        "inference_config": {},
-        "messages": [],
-        "tool_config": {},
-    }
+def mock_agent():
+    """Create a mock agent."""
+    agent = MagicMock()
+    agent.trace_attributes = {}
+    agent.callback_handler = None
+    return agent
 
 
 @pytest.fixture
@@ -99,11 +96,22 @@ def test_create_rich_tree(mock_console):
 
 
 def test_create_rich_status_panel(mock_console):
-    """Test the create_rich_status_panel function with all fields present."""
+    """Test the create_rich_status_panel function with new fields."""
     status = {
         "graph_id": "test_graph",
         "topology": "star",
-        "nodes": [{"id": "node1", "role": "test_role", "neighbors": ["node2"], "queue_size": 0}],
+        "default_model_provider": "bedrock",
+        "default_tools_count": 3,
+        "nodes": [
+            {
+                "id": "node1",
+                "role": "test_role",
+                "model_provider": "anthropic",
+                "tools_count": 2,
+                "neighbors": ["node2"],
+                "queue_size": 0,
+            }
+        ],
     }
     result = create_rich_status_panel(mock_console, status)
     mock_console.print.assert_called_once()
@@ -114,14 +122,34 @@ class TestAgentNode:
     """Tests for the AgentNode class."""
 
     def test_init(self):
-        """Test AgentNode initialization."""
+        """Test AgentNode initialization with new parameters."""
+        node = AgentNode(
+            "test_node",
+            "test_role",
+            "Test system prompt",
+            model_provider="bedrock",
+            model_settings={"model_id": "claude-sonnet"},
+            tools=["calculator", "file_read"],
+        )
+        assert node.id == "test_node"
+        assert node.role == "test_role"
+        assert node.system_prompt == "Test system prompt"
+        assert node.model_provider == "bedrock"
+        assert node.model_settings == {"model_id": "claude-sonnet"}
+        assert node.tools == ["calculator", "file_read"]
+        assert node.neighbors == []
+        assert node.input_queue.maxsize == MAX_QUEUE_SIZE
+        assert node.is_running is True
+
+    def test_init_with_defaults(self):
+        """Test AgentNode initialization with default values."""
         node = AgentNode("test_node", "test_role", "Test system prompt")
         assert node.id == "test_node"
         assert node.role == "test_role"
         assert node.system_prompt == "Test system prompt"
-        assert node.neighbors == []
-        assert node.input_queue.maxsize == MAX_QUEUE_SIZE
-        assert node.is_running is True
+        assert node.model_provider is None
+        assert node.model_settings is None
+        assert node.tools is None
 
     def test_add_neighbor(self):
         """Test adding a neighbor to an AgentNode."""
@@ -135,48 +163,87 @@ class TestAgentNode:
         node1.add_neighbor(node2)
         assert len(node1.neighbors) == 1  # Should still be just one instance
 
-    def test_process_messages(self, mock_use_llm, tool_context):
-        """Test processing messages with mocked methods."""
-        node1 = AgentNode("node1", "role1", "System prompt 1")
-        node2 = AgentNode("node2", "role2", "System prompt 2")
+    def test_process_messages(self, mock_use_llm, mock_agent):
+        """Test processing messages with new use_llm call format."""
+        node = AgentNode("node1", "role1", "System prompt 1", model_provider="bedrock", tools=["calculator"])
+        node.input_queue.put({"content": "Test message"})
 
-        node1.add_neighbor(node2)
-        node1.input_queue.put({"content": "Test message"})
-
-        # Mock related functions to avoid actual processing
+        # Mock time to make loop exit quickly
         with (
             patch("time.time", return_value=0),
             patch("time.sleep"),
-            patch.object(node1, "process_messages", return_value=None) as mock_process,
+            patch.object(node, "process_messages", return_value=None) as mock_process,
         ):
-            node1.is_running = False  # To ensure loop exits
-            node1.process_messages(tool_context, "test_channel")
+            node.is_running = False  # To ensure loop exits
+            node.process_messages(mock_agent)
             mock_process.assert_called_once()
 
 
 class TestAgentGraph:
     """Tests for the AgentGraph class."""
 
-    def test_init(self, tool_context):
-        """Test AgentGraph initialization."""
-        graph = AgentGraph("test_graph", "star", tool_context)
+    def test_init(self, mock_agent):
+        """Test AgentGraph initialization with new parameters."""
+        graph = AgentGraph(
+            "test_graph",
+            "star",
+            mock_agent,
+            model_provider="bedrock",
+            model_settings={"model_id": "claude-sonnet"},
+            tools=["calculator", "file_read"],
+        )
         assert graph.graph_id == "test_graph"
         assert graph.topology_type == "star"
+        assert graph.parent_agent == mock_agent
+        assert graph.default_model_provider == "bedrock"
+        assert graph.default_model_settings == {"model_id": "claude-sonnet"}
+        assert graph.default_tools == ["calculator", "file_read"]
         assert graph.nodes == {}
-        assert graph.tool_context == tool_context
         assert graph.channel == "agent_graph_test_graph"
 
-    def test_add_node(self, tool_context):
+    def test_init_with_defaults(self, mock_agent):
+        """Test AgentGraph initialization with default values."""
+        graph = AgentGraph("test_graph", "star", mock_agent)
+        assert graph.graph_id == "test_graph"
+        assert graph.topology_type == "star"
+        assert graph.parent_agent == mock_agent
+        assert graph.default_model_provider is None
+        assert graph.default_model_settings is None
+        assert graph.default_tools is None
+
+    def test_add_node(self, mock_agent):
         """Test adding a node to the graph."""
-        graph = AgentGraph("test_graph", "star", tool_context)
+        graph = AgentGraph("test_graph", "star", mock_agent)
         node = graph.add_node("test_node", "test_role", "Test system prompt")
         assert graph.nodes["test_node"] == node
         assert node.id == "test_node"
         assert node.role == "test_role"
 
-    def test_add_edge(self, tool_context):
+    def test_add_node_with_custom_config(self, mock_agent):
+        """Test adding a node with custom model and tools configuration."""
+        graph = AgentGraph("test_graph", "star", mock_agent, model_provider="bedrock", tools=["default_tool"])
+        node = graph.add_node(
+            "test_node",
+            "test_role",
+            "Test system prompt",
+            model_provider="anthropic",
+            model_settings={"model_id": "claude-opus"},
+            tools=["custom_tool"],
+        )
+        assert node.model_provider == "anthropic"
+        assert node.model_settings == {"model_id": "claude-opus"}
+        assert node.tools == ["custom_tool"]
+
+    def test_add_node_inherits_defaults(self, mock_agent):
+        """Test adding a node that inherits graph defaults."""
+        graph = AgentGraph("test_graph", "star", mock_agent, model_provider="bedrock", tools=["default_tool"])
+        node = graph.add_node("test_node", "test_role", "Test system prompt")
+        assert node.model_provider == "bedrock"
+        assert node.tools == ["default_tool"]
+
+    def test_add_edge(self, mock_agent):
         """Test adding an edge to the graph."""
-        graph = AgentGraph("test_graph", "star", tool_context)
+        graph = AgentGraph("test_graph", "star", mock_agent)
         node1 = graph.add_node("node1", "role1", "prompt1")
         node2 = graph.add_node("node2", "role2", "prompt2")
 
@@ -184,9 +251,9 @@ class TestAgentGraph:
         assert node2 in node1.neighbors
         assert node1 not in node2.neighbors  # In star topology, connection is one-way
 
-    def test_add_edge_mesh_topology(self, tool_context):
+    def test_add_edge_mesh_topology(self, mock_agent):
         """Test adding an edge in a mesh topology (bidirectional)."""
-        graph = AgentGraph("test_graph", "mesh", tool_context)
+        graph = AgentGraph("test_graph", "mesh", mock_agent)
         node1 = graph.add_node("node1", "role1", "prompt1")
         node2 = graph.add_node("node2", "role2", "prompt2")
 
@@ -194,17 +261,16 @@ class TestAgentGraph:
         assert node2 in node1.neighbors
         assert node1 in node2.neighbors  # In mesh topology, connection is bidirectional
 
-    def test_start(self, tool_context, mock_thread_pool):
+    def test_start(self, mock_agent, mock_thread_pool):
         """Test starting the graph."""
-        graph = AgentGraph("test_graph", "star", tool_context)
-        # No need to save the node reference as it's not used in assertions
+        graph = AgentGraph("test_graph", "star", mock_agent)
         graph.add_node("node1", "role1", "prompt1")
         graph.start()
         assert mock_thread_pool.submit.call_count == 1
 
-    def test_stop(self, tool_context, mock_thread_pool):
+    def test_stop(self, mock_agent, mock_thread_pool):
         """Test stopping the graph."""
-        graph = AgentGraph("test_graph", "star", tool_context)
+        graph = AgentGraph("test_graph", "star", mock_agent)
         node1 = graph.add_node("node1", "role1", "prompt1")
         node2 = graph.add_node("node2", "role2", "prompt2")
 
@@ -213,9 +279,9 @@ class TestAgentGraph:
         assert node2.is_running is False
         mock_thread_pool.shutdown.assert_called_once_with(wait=True)
 
-    def test_send_message(self, tool_context):
+    def test_send_message(self, mock_agent):
         """Test sending a message to a node."""
-        graph = AgentGraph("test_graph", "star", tool_context)
+        graph = AgentGraph("test_graph", "star", mock_agent)
         node1 = graph.add_node("node1", "role1", "prompt1")
 
         success = graph.send_message("node1", "Test message")
@@ -223,35 +289,39 @@ class TestAgentGraph:
         assert not node1.input_queue.empty()
         assert node1.input_queue.get()["content"] == "Test message"
 
-    def test_get_status(self, tool_context):
-        """Test getting the graph status."""
-        graph = AgentGraph("test_graph", "star", tool_context)
-        # Add nodes but we don't need to keep references since we access them through status
+    def test_get_status(self, mock_agent):
+        """Test getting the graph status with new fields."""
+        graph = AgentGraph("test_graph", "star", mock_agent, model_provider="bedrock", tools=["tool1"])
         graph.add_node("node1", "role1", "prompt1")
-        graph.add_node("node2", "role2", "prompt2")
+        graph.add_node("node2", "role2", "prompt2", model_provider="anthropic")
         graph.add_edge("node1", "node2")
 
         status = graph.get_status()
         assert status["graph_id"] == "test_graph"
         assert status["topology"] == "star"
+        assert status["default_model_provider"] == "bedrock"
+        assert status["default_tools_count"] == 1
         assert len(status["nodes"]) == 2
 
         node1_status = next(node for node in status["nodes"] if node["id"] == "node1")
         assert node1_status["neighbors"] == ["node2"]
+        assert node1_status["model_provider"] == "bedrock"  # Inherits from graph default
+
+        node2_status = next(node for node in status["nodes"] if node["id"] == "node2")
+        assert node2_status["model_provider"] == "anthropic"  # Has its own override
 
 
 class TestAgentGraphManager:
     """Tests for the AgentGraphManager class."""
 
-    def test_init(self, tool_context):
-        """Test AgentGraphManager initialization."""
-        manager = AgentGraphManager(tool_context)
+    def test_init(self):
+        """Test AgentGraphManager initialization (no longer takes tool_context)."""
+        manager = AgentGraphManager()
         assert manager.graphs == {}
-        assert manager.tool_context == tool_context
 
-    def test_create_graph(self, tool_context):
-        """Test creating a new graph."""
-        manager = AgentGraphManager(tool_context)
+    def test_create_graph(self, mock_agent):
+        """Test creating a new graph with new parameters."""
+        manager = AgentGraphManager()
 
         # Define a simple graph topology
         graph_id = "test_graph"
@@ -274,14 +344,14 @@ class TestAgentGraphManager:
 
         # Mock the AgentGraph.start method
         with patch.object(AgentGraph, "start") as mock_start:
-            result = manager.create_graph(graph_id, topology)
+            result = manager.create_graph(graph_id, topology, mock_agent, model_provider="bedrock", tools=["tool1"])
             assert result["status"] == "success"
             assert graph_id in manager.graphs
             mock_start.assert_called_once()
 
-    def test_stop_graph(self, tool_context):
+    def test_stop_graph(self):
         """Test stopping a graph."""
-        manager = AgentGraphManager(tool_context)
+        manager = AgentGraphManager()
 
         # Add a mock graph
         mock_graph = MagicMock()
@@ -292,9 +362,9 @@ class TestAgentGraphManager:
         assert "test_graph" not in manager.graphs
         mock_graph.stop.assert_called_once()
 
-    def test_send_message(self, tool_context):
+    def test_send_message(self):
         """Test sending a message to a graph."""
-        manager = AgentGraphManager(tool_context)
+        manager = AgentGraphManager()
 
         # Add a mock graph
         mock_graph = MagicMock()
@@ -307,9 +377,9 @@ class TestAgentGraphManager:
         assert result["status"] == "success"
         mock_graph.send_message.assert_called_once_with("node1", "Test message")
 
-    def test_get_graph_status(self, tool_context):
+    def test_get_graph_status(self):
         """Test getting a graph's status."""
-        manager = AgentGraphManager(tool_context)
+        manager = AgentGraphManager()
 
         # Add a mock graph
         mock_graph = MagicMock()
@@ -322,18 +392,31 @@ class TestAgentGraphManager:
         assert "data" in result
         mock_graph.get_status.assert_called_once()
 
-    def test_list_graphs(self, tool_context):
-        """Test listing all graphs."""
-        manager = AgentGraphManager(tool_context)
+    def test_list_graphs(self):
+        """Test listing all graphs with new fields."""
+        manager = AgentGraphManager()
 
         # Add some mock graphs
         graph1 = MagicMock()
         graph1.topology_type = "star"
+        graph1.default_model_provider = "bedrock"
+        graph1.default_tools = ["tool1", "tool2"]
         graph1.nodes = {"node1": MagicMock(), "node2": MagicMock()}
 
         graph2 = MagicMock()
         graph2.topology_type = "mesh"
+        graph2.default_model_provider = None
+        graph2.default_tools = None
         graph2.nodes = {"node3": MagicMock()}
+
+        # Mock the custom model/tools counting
+        graph1.nodes["node1"].model_provider = "anthropic"
+        graph1.nodes["node2"].model_provider = "bedrock"
+        graph1.nodes["node1"].tools = ["custom_tool"]
+        graph1.nodes["node2"].tools = ["tool1", "tool2"]
+
+        graph2.nodes["node3"].model_provider = None
+        graph2.nodes["node3"].tools = None
 
         manager.graphs = {"graph1": graph1, "graph2": graph2}
 
@@ -341,11 +424,17 @@ class TestAgentGraphManager:
 
         assert result["status"] == "success"
         assert len(result["data"]) == 2
-        assert result["data"][0]["graph_id"] in ["graph1", "graph2"]
+
+        # Check that new fields are included
+        graph1_data = next(g for g in result["data"] if g["graph_id"] == "graph1")
+        assert "default_model_provider" in graph1_data
+        assert "default_tools_count" in graph1_data
+        assert "custom_model_nodes" in graph1_data
+        assert "custom_tools_nodes" in graph1_data
 
 
 def test_agent_interface(agent):
-    """Test using agent_graph through the agent interface."""
+    """Test using agent_graph through the agent interface with new format."""
     try:
         result = agent.tool.agent_graph(action="list")
         assert isinstance(result, dict)
@@ -355,198 +444,167 @@ def test_agent_interface(agent):
 
 
 class TestAgentGraphTool:
-    """Tests for the agent_graph function (tool itself)."""
+    """Tests for the agent_graph function with new @tool decorator format."""
 
-    def test_create_action_success(self, mock_console):
-        """Test the create action with valid inputs."""
-        tool_use = {
-            "toolUseId": "test-tool-use-id",
-            "input": {
-                "action": "create",
-                "graph_id": "test_graph",
-                "topology": {
-                    "type": "star",
-                    "nodes": [{"id": "central", "role": "coordinator", "system_prompt": "test"}],
-                },
-            },
-        }
-
-        # Mock the manager
+    def test_create_action_success(self, mock_console, mock_agent):
+        """Test the create action with new parameter format."""
         with patch("strands_tools.agent_graph.get_manager") as mock_get_manager:
             mock_manager = MagicMock()
             mock_manager.create_graph.return_value = {"status": "success", "message": "Graph created"}
             mock_get_manager.return_value = mock_manager
 
-            result = agent_graph(tool=tool_use)
+            result = agent_graph(
+                action="create",
+                graph_id="test_graph",
+                topology={
+                    "type": "star",
+                    "nodes": [{"id": "central", "role": "coordinator", "system_prompt": "test"}],
+                },
+                agent=mock_agent,
+            )
             assert result["status"] == "success"
 
-    def test_stop_action_success(self, mock_console):
-        """Test the stop action with valid inputs."""
-        tool_use = {"toolUseId": "test-id", "input": {"action": "stop", "graph_id": "test_graph"}}
+    def test_create_action_with_model_config(self, mock_console, mock_agent):
+        """Test the create action with model configuration."""
+        with patch("strands_tools.agent_graph.get_manager") as mock_get_manager:
+            mock_manager = MagicMock()
+            mock_manager.create_graph.return_value = {"status": "success", "message": "Graph created"}
+            mock_get_manager.return_value = mock_manager
 
+            result = agent_graph(
+                action="create",
+                graph_id="test_graph",
+                topology={
+                    "type": "star",
+                    "nodes": [{"id": "central", "role": "coordinator", "system_prompt": "test"}],
+                },
+                model_provider="bedrock",
+                model_settings={"model_id": "claude-sonnet"},
+                tools=["calculator"],
+                agent=mock_agent,
+            )
+            assert result["status"] == "success"
+
+            # Verify the manager was called with the correct parameters
+            mock_manager.create_graph.assert_called_once()
+            args = mock_manager.create_graph.call_args[0]
+            assert args[0] == "test_graph"  # graph_id
+            assert args[1]["type"] == "star"  # topology
+            assert args[2] == mock_agent  # agent
+            assert args[3] == "bedrock"  # model_provider
+            assert args[4] == {"model_id": "claude-sonnet"}  # model_settings
+            assert args[5] == ["calculator"]  # tools
+
+    def test_stop_action_success(self, mock_console):
+        """Test the stop action with new parameter format."""
         with patch("strands_tools.agent_graph.get_manager") as mock_get_manager:
             mock_manager = MagicMock()
             mock_manager.stop_graph.return_value = {"status": "success", "message": "Graph stopped"}
             mock_get_manager.return_value = mock_manager
 
-            result = agent_graph(tool=tool_use)
+            result = agent_graph(action="stop", graph_id="test_graph")
             assert result["status"] == "success"
 
     def test_message_action_success(self, mock_console):
-        """Test the message action with valid inputs."""
-        tool_use = {
-            "toolUseId": "test-id",
-            "input": {
-                "action": "message",
-                "graph_id": "test_graph",
-                "message": {"target": "node1", "content": "Test message"},
-            },
-        }
-
+        """Test the message action with new parameter format."""
         with patch("strands_tools.agent_graph.get_manager") as mock_get_manager:
             mock_manager = MagicMock()
             mock_manager.send_message.return_value = {"status": "success", "message": "Message sent"}
             mock_get_manager.return_value = mock_manager
 
-            result = agent_graph(tool=tool_use)
+            result = agent_graph(
+                action="message",
+                graph_id="test_graph",
+                message={"target": "node1", "content": "Test message"},
+            )
             assert result["status"] == "success"
 
     def test_status_action_success(self, mock_console):
-        """Test the status action with valid inputs."""
-        tool_use = {"toolUseId": "test-id", "input": {"action": "status", "graph_id": "test_graph"}}
-
+        """Test the status action with new parameter format."""
         with patch("strands_tools.agent_graph.get_manager") as mock_get_manager:
             mock_manager = MagicMock()
             mock_manager.get_graph_status.return_value = {
                 "status": "success",
-                "data": {"graph_id": "test_graph", "topology": "star", "nodes": []},
+                "data": {
+                    "graph_id": "test_graph",
+                    "topology": "star",
+                    "default_model_provider": "bedrock",
+                    "default_tools_count": 2,
+                    "nodes": [],
+                },
             }
             mock_get_manager.return_value = mock_manager
 
-            result = agent_graph(tool=tool_use)
+            result = agent_graph(action="status", graph_id="test_graph")
             assert result["status"] == "success"
 
     def test_list_action_success(self, mock_console):
-        """Test the list action."""
-        tool_use = {"toolUseId": "test-id", "input": {"action": "list"}}
-
+        """Test the list action with new parameter format."""
         with patch("strands_tools.agent_graph.get_manager") as mock_get_manager:
             mock_manager = MagicMock()
             mock_manager.list_graphs.return_value = {"status": "success", "data": []}
             mock_get_manager.return_value = mock_manager
 
-            result = agent_graph(tool=tool_use)
+            result = agent_graph(action="list")
             assert result["status"] == "success"
 
     def test_unknown_action(self):
         """Test handling an unknown action."""
-        tool_use = {"toolUseId": "test-id", "input": {"action": "unknown_action"}}
-
-        result = agent_graph(tool=tool_use)
+        result = agent_graph(action="unknown_action")
         assert result["status"] == "error"
         assert "Unknown action" in result["content"][0]["text"]
 
     def test_create_action_missing_topology(self):
         """Test the create action with missing topology parameter."""
-        tool_use = {
-            "toolUseId": "test-id",
-            "input": {
-                "action": "create",
-                "graph_id": "test_graph",  # Missing topology
-            },
-        }
-
-        result = agent_graph(tool=tool_use)
+        result = agent_graph(action="create", graph_id="test_graph")
         assert result["status"] == "error"
         assert "topology" in result["content"][0]["text"]
 
     def test_create_action_missing_graph_id(self):
         """Test the create action with missing graph_id parameter."""
-        tool_use = {
-            "toolUseId": "test-id",
-            "input": {
-                "action": "create",
-                "topology": {"type": "star", "nodes": []},  # Missing graph_id
-            },
-        }
-
-        result = agent_graph(tool=tool_use)
+        result = agent_graph(
+            action="create",
+            topology={"type": "star", "nodes": []},
+        )
         assert result["status"] == "error"
         assert "graph_id" in result["content"][0]["text"]
 
     def test_stop_action_missing_graph_id(self):
         """Test the stop action with missing graph_id parameter."""
-        tool_use = {
-            "toolUseId": "test-id",
-            "input": {"action": "stop"},  # Missing graph_id
-        }
-
-        result = agent_graph(tool=tool_use)
+        result = agent_graph(action="stop")
         assert result["status"] == "error"
         assert "graph_id is required" in result["content"][0]["text"]
 
     def test_message_action_missing_params(self):
         """Test the message action with missing parameters."""
-        tool_use = {
-            "toolUseId": "test-id",
-            "input": {"action": "message", "graph_id": "test_graph"},  # Missing message
-        }
-
-        result = agent_graph(tool=tool_use)
+        result = agent_graph(action="message", graph_id="test_graph")
         assert result["status"] == "error"
         assert "message are required" in result["content"][0]["text"]
 
     def test_status_action_missing_graph_id(self):
         """Test the status action with missing graph_id parameter."""
-        tool_use = {
-            "toolUseId": "test-id",
-            "input": {"action": "status"},  # Missing graph_id
-        }
-
-        result = agent_graph(tool=tool_use)
+        result = agent_graph(action="status")
         assert result["status"] == "error"
         assert "graph_id is required" in result["content"][0]["text"]
 
     def test_exception_handling(self):
         """Test exception handling in the tool function."""
-        tool_use = {"toolUseId": "test-id", "input": {"action": "list"}}
-
         # Mock get_manager to raise an exception
         with patch("strands_tools.agent_graph.get_manager", side_effect=Exception("Test exception")):
             with patch("strands_tools.agent_graph.logger.error") as mock_logger:
-                result = agent_graph(tool=tool_use)
+                result = agent_graph(action="list")
                 assert result["status"] == "error"
                 mock_logger.assert_called_once()
 
     def test_manager_error_result(self):
         """Test error result handling from the manager."""
-        tool_use = {"toolUseId": "test-id", "input": {"action": "list"}}
-
         with patch("strands_tools.agent_graph.get_manager") as mock_get_manager:
             mock_manager = MagicMock()
             mock_manager.list_graphs.return_value = {"status": "error", "message": "Test error message"}
             mock_get_manager.return_value = mock_manager
 
             with patch("strands_tools.agent_graph.logger.error") as mock_logger:
-                result = agent_graph(tool=tool_use)
+                result = agent_graph(action="list")
                 assert result["status"] == "error"
                 assert "Test error message" in result["content"][0]["text"]
                 mock_logger.assert_called_once()
-
-    def test_default_tool_use_id(self):
-        """Test generation of default tool_use_id."""
-        tool_use = {
-            # No toolUseId
-            "input": {"action": "list"}
-        }
-
-        with (
-            patch("strands_tools.agent_graph.get_manager") as mock_get_manager,
-            patch("uuid.uuid4", return_value="generated-uuid"),
-        ):
-            mock_manager = MagicMock()
-            mock_manager.list_graphs.return_value = {"status": "success", "data": []}
-            mock_get_manager.return_value = mock_manager
-
-            result = agent_graph(tool=tool_use)
-            assert result["toolUseId"] == "generated-uuid"

--- a/tests/test_swarm.py
+++ b/tests/test_swarm.py
@@ -1,9 +1,10 @@
 """
 Tests for the swarm tool using both direct calls and the Agent interface.
+Updated for the new @tool decorator format.
 """
 
 import io
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from rich.console import Console
@@ -19,9 +20,11 @@ def agent():
 
 
 @pytest.fixture
-def mock_request_state():
-    """Create a mock request state dictionary."""
-    return {}
+def mock_agent():
+    """Create a mock parent agent for testing."""
+    mock_agent = MagicMock()
+    mock_agent.system_prompt = "You are a helpful AI assistant."
+    return mock_agent
 
 
 def extract_result_text(result):
@@ -94,18 +97,22 @@ def test_shared_memory_advance_phase(shared_memory):
 
 
 @patch("strands_tools.swarm.use_llm")
-def test_swarm_agent_process_task(mock_use_llm, shared_memory, mock_llm_response):
+def test_swarm_agent_process_task(mock_use_llm, shared_memory, mock_llm_response, mock_agent):
     """Test swarm agent processing a task."""
     mock_use_llm.return_value = mock_llm_response
 
     # Create a swarm agent
     agent = SwarmAgent("test_agent", "Test system prompt", shared_memory)
 
-    # Process a task
-    result = agent.process_task("Test task", {})
+    # Process a task with mock parent agent
+    result = agent.process_task("Test task", mock_agent)
 
-    # Verify use_llm was called
+    # Verify use_llm was called with new format
     mock_use_llm.assert_called_once()
+    call_args = mock_use_llm.call_args
+    assert call_args[1]["system_prompt"] == "Test system prompt"
+    assert "Test task" in call_args[1]["prompt"]
+    assert call_args[1]["agent"] == mock_agent
 
     # Verify the result
     assert result["status"] == "success"
@@ -121,7 +128,7 @@ def test_swarm_agent_process_task(mock_use_llm, shared_memory, mock_llm_response
 
 
 @patch("strands_tools.swarm.use_llm")
-def test_swarm_agent_error_handling(mock_use_llm, shared_memory):
+def test_swarm_agent_error_handling(mock_use_llm, shared_memory, mock_agent):
     """Test swarm agent error handling."""
     # Mock use_llm to raise an exception
     mock_use_llm.side_effect = Exception("Test exception")
@@ -130,7 +137,7 @@ def test_swarm_agent_error_handling(mock_use_llm, shared_memory):
     agent = SwarmAgent("test_agent", "Test system prompt", shared_memory)
 
     # Process a task
-    result = agent.process_task("Test task", {})
+    result = agent.process_task("Test task", mock_agent)
 
     # Verify the result indicates an error
     assert result["status"] == "error"
@@ -176,7 +183,7 @@ def test_swarm_add_agent():
 
 
 @patch("strands_tools.swarm.use_llm")
-def test_swarm_process_phase(mock_use_llm, mock_llm_response):
+def test_swarm_process_phase(mock_use_llm, mock_llm_response, mock_agent):
     """Test processing a phase in a swarm."""
     mock_use_llm.return_value = mock_llm_response
 
@@ -187,8 +194,8 @@ def test_swarm_process_phase(mock_use_llm, mock_llm_response):
     test_swarm.add_agent("agent1", "System prompt 1")
     test_swarm.add_agent("agent2", "System prompt 2")
 
-    # Process a phase
-    phase_results = test_swarm.process_phase({})
+    # Process a phase with mock parent agent
+    phase_results = test_swarm.process_phase(mock_agent)
 
     # Verify results
     assert len(phase_results) == 2
@@ -227,24 +234,13 @@ def test_create_rich_status_panel():
 
 
 @patch("strands_tools.swarm.Swarm")
-def test_swarm_error_handling(mock_swarm_class, mock_request_state):
+def test_swarm_error_handling(mock_swarm_class, mock_agent):
     """Test error handling in the swarm tool."""
     # Mock Swarm class to raise an exception
     mock_swarm_class.side_effect = Exception("Test exception in swarm")
 
-    tool_use = {
-        "toolUseId": "test-tool-use-id",
-        "input": {"task": "Test swarm task", "swarm_size": 2, "coordination_pattern": "collaborative"},
-    }
-
-    result = swarm.swarm(
-        tool=tool_use,
-        system_prompt="Test system prompt",
-        inference_config={},
-        messages=[],
-        tool_config={},
-        request_state=mock_request_state,
-    )
+    # Call swarm tool with new format
+    result = swarm.swarm(task="Test swarm task", swarm_size=2, coordination_pattern="collaborative", agent=mock_agent)
 
     # Verify error status
     assert result["status"] == "error"
@@ -256,16 +252,16 @@ def test_swarm_via_agent(mock_use_llm, agent, mock_llm_response):
     """Test swarm via the agent interface."""
     mock_use_llm.return_value = mock_llm_response
 
-    # Call the swarm tool via agent
+    # Call the swarm tool via agent using new format
     result = agent.tool.swarm(task="Test task via agent", swarm_size=2, coordination_pattern="hybrid")
 
     # Extract result text
     result_text = extract_result_text(result)
 
     # Verify the result contains expected information
-    assert "Swarm Status" in result_text
-    assert "Test task via agent" in result_text
-    assert "hybrid" in result_text
+    assert "📊 Swarm Results" in result_text
+    assert "Agent agent_1:" in result_text or "Agent agent_2:" in result_text
+    assert "This is a test contribution from the mock LLM." in result_text
 
 
 def test_get_all_knowledge(shared_memory):
@@ -333,3 +329,115 @@ def test_swarm_get_status():
     assert agent1_status["contributions"] == 2
     assert agent2_status["status"] == "processing"
     assert agent2_status["contributions"] == 1
+
+
+@patch("strands_tools.swarm.use_llm")
+def test_swarm_direct_call(mock_use_llm, mock_llm_response, mock_agent):
+    """Test direct swarm function call with new format."""
+    mock_use_llm.return_value = mock_llm_response
+
+    # Call swarm tool directly with new format
+    result = swarm.swarm(
+        task="Direct call test task", swarm_size=3, coordination_pattern="competitive", agent=mock_agent
+    )
+
+    # Verify successful result
+    assert result["status"] == "success"
+    assert "📊 Swarm Results" in result["content"][0]["text"]
+    assert "This is a test contribution from the mock LLM." in result["content"][0]["text"]
+
+    # Verify use_llm was called multiple times (for multiple agents and phases)
+    assert mock_use_llm.call_count >= 3  # At least 3 agents * 2 phases
+
+
+@patch("strands_tools.swarm.use_llm")
+def test_swarm_coordination_patterns(mock_use_llm, mock_llm_response, mock_agent):
+    """Test different coordination patterns."""
+    mock_use_llm.return_value = mock_llm_response
+
+    # Test collaborative pattern
+    result_collab = swarm.swarm(
+        task="Collaborative test", swarm_size=2, coordination_pattern="collaborative", agent=mock_agent
+    )
+    assert result_collab["status"] == "success"
+    assert "📊 Swarm Results" in result_collab["content"][0]["text"]
+    assert "This is a test contribution from the mock LLM." in result_collab["content"][0]["text"]
+
+    # Reset mock
+    mock_use_llm.reset_mock()
+
+    # Test competitive pattern
+    result_comp = swarm.swarm(
+        task="Competitive test", swarm_size=2, coordination_pattern="competitive", agent=mock_agent
+    )
+    assert result_comp["status"] == "success"
+    assert "📊 Swarm Results" in result_comp["content"][0]["text"]
+    assert "This is a test contribution from the mock LLM." in result_comp["content"][0]["text"]
+
+    # Reset mock
+    mock_use_llm.reset_mock()
+
+    # Test hybrid pattern
+    result_hybrid = swarm.swarm(task="Hybrid test", swarm_size=2, coordination_pattern="hybrid", agent=mock_agent)
+    assert result_hybrid["status"] == "success"
+    assert "📊 Swarm Results" in result_hybrid["content"][0]["text"]
+    assert "This is a test contribution from the mock LLM." in result_hybrid["content"][0]["text"]
+
+
+def test_swarm_size_validation(mock_agent):
+    """Test swarm size validation and clamping."""
+    # Test minimum size clamping
+    result_min = swarm.swarm(
+        task="Min size test",
+        swarm_size=0,  # Should be clamped to 1
+        coordination_pattern="collaborative",
+        agent=mock_agent,
+    )
+    # Should not fail due to invalid size
+    assert result_min["status"] in ["success", "error"]  # Error due to no mocking, but not size validation
+
+    # Test maximum size clamping
+    result_max = swarm.swarm(
+        task="Max size test",
+        swarm_size=15,  # Should be clamped to 10
+        coordination_pattern="collaborative",
+        agent=mock_agent,
+    )
+    # Should not fail due to invalid size
+    assert result_max["status"] in ["success", "error"]  # Error due to no mocking, but not size validation
+
+
+@patch("strands_tools.swarm.use_llm")
+def test_swarm_with_parent_agent_system_prompt(mock_use_llm, mock_llm_response):
+    """Test that swarm properly uses parent agent's system prompt."""
+    mock_use_llm.return_value = mock_llm_response
+
+    # Create mock parent agent with custom system prompt
+    mock_parent = MagicMock()
+    mock_parent.system_prompt = "You are a specialized research assistant."
+
+    swarm.swarm(task="Research task", swarm_size=1, coordination_pattern="collaborative", agent=mock_parent)
+
+    # Verify use_llm was called and parent system prompt was incorporated
+    mock_use_llm.assert_called()
+    call_args = mock_use_llm.call_args
+    agent_prompt = call_args[1]["system_prompt"]
+
+    # The agent prompt should include the parent's system prompt
+    assert "You are a specialized research assistant." in agent_prompt
+    assert "Research task" in call_args[1]["prompt"]
+
+
+def test_swarm_without_parent_agent():
+    """Test swarm behavior when no parent agent is provided."""
+    result = swarm.swarm(
+        task="No parent test",
+        swarm_size=1,
+        coordination_pattern="collaborative",
+        agent=None,  # No parent agent
+    )
+
+    # Should handle gracefully (though will likely error due to no mocking)
+    assert result["status"] in ["success", "error"]
+    assert isinstance(result["content"], list)
+    assert len(result["content"]) > 0

--- a/tests/test_use_llm.py
+++ b/tests/test_use_llm.py
@@ -1,5 +1,5 @@
 """
-Tests for the use_llm tool using the Agent interface.
+Tests for the use_llm tool using the new @tool decorator.
 """
 
 from unittest.mock import MagicMock, patch
@@ -29,15 +29,6 @@ def extract_result_text(result):
 
 def test_use_llm_tool_direct(mock_agent_response):
     """Test direct invocation of the use_llm tool."""
-    # Create a tool use dictionary similar to how the agent would call it
-    tool_use = {
-        "toolUseId": "test-tool-use-id",
-        "input": {
-            "prompt": "Test prompt",
-            "system_prompt": "You are a helpful test assistant",
-        },
-    }
-
     # Mock the Agent class to avoid actual LLM calls
     with patch("strands_tools.use_llm.Agent") as MockAgent:
         # Configure the mock agent to return our pre-defined response
@@ -48,44 +39,32 @@ def test_use_llm_tool_direct(mock_agent_response):
             "content": [{"text": "This is a test response from the LLM"}],
         }
 
-        # Suppress print output
-        with patch("builtins.print"):
-            # Call the use_llm function directly
-            result = use_llm.use_llm(tool=tool_use)
+        # Call the use_llm function directly with new signature
+        result = use_llm.use_llm(prompt="Test prompt", system_prompt="You are a helpful test assistant")
 
         # Verify the result has the expected structure
-        assert result["toolUseId"] == "test-tool-use-id"
         assert result["status"] == "success"
         assert "This is a test response from the LLM" in str(result)
 
         # Verify the Agent was created with the correct parameters
         MockAgent.assert_called_once_with(
-            messages=[], tools=[], system_prompt="You are a helpful test assistant", trace_attributes={}
+            model=None, messages=[], tools=[], system_prompt="You are a helpful test assistant", trace_attributes={}
         )
 
 
 def test_use_llm_with_custom_system_prompt(mock_agent_response):
     """Test use_llm with a custom system prompt."""
-    tool_use = {
-        "toolUseId": "test-custom-prompt",
-        "input": {
-            "prompt": "Custom prompt test",
-            "system_prompt": "You are a specialized test assistant",
-        },
-    }
-
     with patch("strands_tools.use_llm.Agent") as MockAgent:
         mock_instance = MockAgent.return_value
         mock_instance.return_value = mock_agent_response
         mock_agent_response.message = {"content": [{"text": "Custom response"}]}
 
-        # Suppress print output
-        with patch("builtins.print"):
-            result = use_llm.use_llm(tool=tool_use)
+        # Call the use_llm function directly with new signature
+        result = use_llm.use_llm(prompt="Custom prompt test", system_prompt="You are a specialized test assistant")
 
         # Verify agent was created with correct system prompt
         MockAgent.assert_called_once_with(
-            messages=[], tools=[], system_prompt="You are a specialized test assistant", trace_attributes={}
+            model=None, messages=[], tools=[], system_prompt="You are a specialized test assistant", trace_attributes={}
         )
 
         assert result["status"] == "success"
@@ -94,11 +73,6 @@ def test_use_llm_with_custom_system_prompt(mock_agent_response):
 
 def test_use_llm_error_handling():
     """Test error handling in the use_llm tool."""
-    tool_use = {
-        "toolUseId": "test-error-handling",
-        "input": {"prompt": "Error test", "system_prompt": "Test system prompt"},
-    }
-
     # Simulate an error in the Agent
     with patch("strands_tools.use_llm.Agent") as MockAgent:
         # First we need to create a mock instance with the right return structure
@@ -106,36 +80,26 @@ def test_use_llm_error_handling():
         # Then make the call to the mock instance raise an exception
         mock_instance.side_effect = Exception("Test error")
 
-        # Add a try/except block to match the function behavior
-        with patch("builtins.print"):  # Suppress print statements
-            try:
-                use_llm.use_llm(tool=tool_use)
-                raise AssertionError("Should have raised an exception")
-            except Exception as e:
-                # This matches the current behavior - the error isn't caught in the function
-                assert str(e) == "Test error"
+        # Call the use_llm function directly and expect it to handle the error
+        result = use_llm.use_llm(prompt="Error test", system_prompt="Test system prompt")
+
+        # The new @tool decorator should catch exceptions and return error format
+        assert result["status"] == "error"
+        assert "Test error" in result["content"][0]["text"]
 
 
 def test_use_llm_metrics_handling(mock_agent_response):
     """Test that metrics from the agent response are properly processed."""
-    tool_use = {
-        "toolUseId": "test-metrics-handling",
-        "input": {"prompt": "Test with metrics", "system_prompt": "Test system prompt"},
-    }
-
     with patch("strands_tools.use_llm.Agent") as MockAgent:
         mock_instance = MockAgent.return_value
         mock_instance.return_value = mock_agent_response
         mock_agent_response.metrics = MagicMock()
-        # Add tool_config attribute to mock
-        mock_instance.tool_config = {"tools": [{"toolSpec": {"name": "test_tool"}}]}
 
         with patch("strands_tools.use_llm.metrics_to_string") as mock_metrics:
             mock_metrics.return_value = "Tokens: 30, Latency: 0.5s"
 
-            # Suppress print output
-            with patch("builtins.print"):
-                result = use_llm.use_llm(tool=tool_use)
+            # Call the use_llm function directly with new signature
+            result = use_llm.use_llm(prompt="Test with metrics", system_prompt="Test system prompt")
 
             # Verify metrics_to_string was called with the correct parameters
             mock_metrics.assert_called_once()
@@ -146,14 +110,6 @@ def test_use_llm_metrics_handling(mock_agent_response):
 
 def test_use_llm_complex_response_handling():
     """Test that complex responses from the nested agent are properly handled."""
-    tool_use = {
-        "toolUseId": "test-complex-response",
-        "input": {
-            "prompt": "Complex response test",
-            "system_prompt": "Test system prompt",
-        },
-    }
-
     # Create a complex response with multiple content items
     complex_response = AgentResult(
         stop_reason="end_turn",
@@ -172,9 +128,8 @@ def test_use_llm_complex_response_handling():
         mock_instance = MockAgent.return_value
         mock_instance.return_value = complex_response
 
-        # Suppress print output
-        with patch("builtins.print"):
-            result = use_llm.use_llm(tool=tool_use)
+        # Call the use_llm function directly with new signature
+        result = use_llm.use_llm(prompt="Complex response test", system_prompt="Test system prompt")
 
         assert result["status"] == "success"
         assert "First part of response\nSecond part of response" in result["content"][0]["text"]
@@ -182,19 +137,12 @@ def test_use_llm_complex_response_handling():
 
 def test_use_llm_with_parent_agent_callback():
     """Test that the parent agent's callback handler is properly passed to the new agent."""
-    tool_use = {
-        "toolUseId": "test-parent-callback",
-        "input": {
-            "prompt": "Test with parent callback",
-            "system_prompt": "Test system prompt",
-        },
-    }
-
     # Create a mock parent agent with a callback handler
     mock_parent_agent = MagicMock()
     mock_parent_agent.tool_registry.registry.values.return_value = []
     mock_parent_agent.trace_attributes = {"test_attribute": "test_value"}
     mock_parent_agent.callback_handler = MagicMock(name="parent_callback_handler")
+    mock_parent_agent.model = MagicMock(name="parent_model")
 
     # Create a mock response
     mock_response = MagicMock()
@@ -207,76 +155,24 @@ def test_use_llm_with_parent_agent_callback():
         mock_instance.return_value = mock_response
 
         # Call use_llm with the parent agent
-        result = use_llm.use_llm(tool=tool_use, agent=mock_parent_agent)
+        result = use_llm.use_llm(
+            prompt="Test with parent callback", system_prompt="Test system prompt", agent=mock_parent_agent
+        )
 
         # Verify the Agent was created with the parent's callback handler
         MockAgent.assert_called_once()
         call_kwargs = MockAgent.call_args.kwargs
         assert call_kwargs["callback_handler"] == mock_parent_agent.callback_handler
         assert call_kwargs["trace_attributes"] == {"test_attribute": "test_value"}
+        assert call_kwargs["model"] == mock_parent_agent.model
 
         # Verify the result
         assert result["status"] == "success"
         assert "Test response with parent callback" in result["content"][0]["text"]
 
 
-def test_use_llm_with_explicit_callback():
-    """Test that an explicitly provided callback handler takes precedence over the parent agent's callback."""
-    tool_use = {
-        "toolUseId": "test-explicit-callback",
-        "input": {
-            "prompt": "Test with explicit callback",
-            "system_prompt": "Test system prompt",
-        },
-    }
-
-    # Create a mock parent agent with a callback handler
-    mock_parent_agent = MagicMock()
-    mock_parent_agent.tool_registry.registry.values.return_value = []
-    mock_parent_agent.trace_attributes = {"test_attribute": "test_value"}
-    mock_parent_agent.callback_handler = MagicMock(name="parent_callback_handler")
-
-    # Create an explicit callback handler that should take precedence
-    explicit_callback_handler = MagicMock(name="explicit_callback_handler")
-
-    # Create a mock response
-    mock_response = MagicMock()
-    mock_response.metrics = None
-    mock_response.__str__.return_value = "Test response with explicit callback"
-
-    with patch("strands_tools.use_llm.Agent") as MockAgent:
-        # Configure the mock agent
-        mock_instance = MockAgent.return_value
-        mock_instance.return_value = mock_response
-
-        # Call use_llm with both parent agent and explicit callback handler
-        result = use_llm.use_llm(tool=tool_use, agent=mock_parent_agent, callback_handler=explicit_callback_handler)
-
-        # Verify the Agent was created with the explicit callback handler, not the parent's
-        MockAgent.assert_called_once()
-        call_kwargs = MockAgent.call_args.kwargs
-        assert call_kwargs["callback_handler"] == explicit_callback_handler
-        assert call_kwargs["callback_handler"] != mock_parent_agent.callback_handler
-
-        # Verify other parameters were still passed correctly
-        assert call_kwargs["trace_attributes"] == {"test_attribute": "test_value"}
-
-        # Verify the result
-        assert result["status"] == "success"
-        assert "Test response with explicit callback" in result["content"][0]["text"]
-
-
 def test_use_llm_with_tool_filtering():
     """Test use_llm with specific tools filtering from parent agent."""
-    tool_use = {
-        "toolUseId": "test-tool-filtering",
-        "input": {
-            "prompt": "Test with tool filtering",
-            "system_prompt": "Test system prompt",
-            "tools": ["calculator", "file_read"],
-        },
-    }
-
     # Create mock tools for the parent agent
     mock_calculator_tool = MagicMock(name="calculator_tool")
     mock_file_read_tool = MagicMock(name="file_read_tool")
@@ -291,6 +187,7 @@ def test_use_llm_with_tool_filtering():
     }
     mock_parent_agent.trace_attributes = {}
     mock_parent_agent.callback_handler = MagicMock()
+    mock_parent_agent.model = MagicMock()
 
     # Create a mock response
     mock_response = MagicMock()
@@ -303,7 +200,12 @@ def test_use_llm_with_tool_filtering():
         mock_instance.return_value = mock_response
 
         # Call use_llm with tool filtering
-        result = use_llm.use_llm(tool=tool_use, agent=mock_parent_agent)
+        result = use_llm.use_llm(
+            prompt="Test with tool filtering",
+            system_prompt="Test system prompt",
+            tools=["calculator", "file_read"],
+            agent=mock_parent_agent,
+        )
 
         # Verify the Agent was created with only the specified tools
         MockAgent.assert_called_once()
@@ -323,15 +225,6 @@ def test_use_llm_with_tool_filtering():
 
 def test_use_llm_with_nonexistent_tool_filtering():
     """Test use_llm with tool filtering that includes non-existent tools."""
-    tool_use = {
-        "toolUseId": "test-nonexistent-tool",
-        "input": {
-            "prompt": "Test with non-existent tool",
-            "system_prompt": "Test system prompt",
-            "tools": ["calculator", "nonexistent_tool", "file_read"],
-        },
-    }
-
     # Create mock tools for the parent agent (missing nonexistent_tool)
     mock_calculator_tool = MagicMock(name="calculator_tool")
     mock_file_read_tool = MagicMock(name="file_read_tool")
@@ -341,6 +234,7 @@ def test_use_llm_with_nonexistent_tool_filtering():
     mock_parent_agent.tool_registry.registry = {"calculator": mock_calculator_tool, "file_read": mock_file_read_tool}
     mock_parent_agent.trace_attributes = {}
     mock_parent_agent.callback_handler = MagicMock()
+    mock_parent_agent.model = MagicMock()
 
     # Create a mock response
     mock_response = MagicMock()
@@ -353,7 +247,12 @@ def test_use_llm_with_nonexistent_tool_filtering():
         mock_instance.return_value = mock_response
 
         # Call use_llm with tool filtering including non-existent tool
-        result = use_llm.use_llm(tool=tool_use, agent=mock_parent_agent)
+        result = use_llm.use_llm(
+            prompt="Test with non-existent tool",
+            system_prompt="Test system prompt",
+            tools=["calculator", "nonexistent_tool", "file_read"],
+            agent=mock_parent_agent,
+        )
 
         # Verify warning was logged for non-existent tool
         mock_logger.warning.assert_called_once_with("Tool 'nonexistent_tool' not found in parent agent's tool registry")
@@ -374,16 +273,12 @@ def test_use_llm_with_nonexistent_tool_filtering():
 
 def test_use_llm_with_empty_tool_filtering():
     """Test use_llm with empty tools list (should result in no tools)."""
-    tool_use = {
-        "toolUseId": "test-empty-tools",
-        "input": {"prompt": "Test with empty tools list", "system_prompt": "Test system prompt", "tools": []},
-    }
-
     # Create a mock parent agent with tools
     mock_parent_agent = MagicMock()
     mock_parent_agent.tool_registry.registry = {"calculator": MagicMock(), "file_read": MagicMock()}
     mock_parent_agent.trace_attributes = {}
     mock_parent_agent.callback_handler = MagicMock()
+    mock_parent_agent.model = MagicMock()
 
     # Create a mock response
     mock_response = MagicMock()
@@ -396,7 +291,9 @@ def test_use_llm_with_empty_tool_filtering():
         mock_instance.return_value = mock_response
 
         # Call use_llm with empty tools list
-        result = use_llm.use_llm(tool=tool_use, agent=mock_parent_agent)
+        result = use_llm.use_llm(
+            prompt="Test with empty tools list", system_prompt="Test system prompt", tools=[], agent=mock_parent_agent
+        )
 
         # Verify the Agent was created with no tools
         MockAgent.assert_called_once()
@@ -412,15 +309,6 @@ def test_use_llm_with_empty_tool_filtering():
 
 def test_use_llm_without_tool_filtering_inherits_all():
     """Test use_llm without tools parameter inherits all parent tools."""
-    tool_use = {
-        "toolUseId": "test-inherit-all-tools",
-        "input": {
-            "prompt": "Test inheriting all tools",
-            "system_prompt": "Test system prompt",
-            # No tools parameter - should inherit all
-        },
-    }
-
     # Create mock tools for the parent agent
     mock_calculator_tool = MagicMock(name="calculator_tool")
     mock_file_read_tool = MagicMock(name="file_read_tool")
@@ -435,6 +323,7 @@ def test_use_llm_without_tool_filtering_inherits_all():
     ]
     mock_parent_agent.trace_attributes = {}
     mock_parent_agent.callback_handler = MagicMock()
+    mock_parent_agent.model = MagicMock()
 
     # Create a mock response
     mock_response = MagicMock()
@@ -447,7 +336,9 @@ def test_use_llm_without_tool_filtering_inherits_all():
         mock_instance.return_value = mock_response
 
         # Call use_llm without tools parameter
-        result = use_llm.use_llm(tool=tool_use, agent=mock_parent_agent)
+        result = use_llm.use_llm(
+            prompt="Test inheriting all tools", system_prompt="Test system prompt", agent=mock_parent_agent
+        )
 
         # Verify the Agent was created with all parent tools
         MockAgent.assert_called_once()
@@ -462,3 +353,45 @@ def test_use_llm_without_tool_filtering_inherits_all():
 
         # Verify the result
         assert result["status"] == "success"
+
+
+def test_use_llm_with_model_provider_and_settings():
+    """Test use_llm with model provider and settings parameters."""
+    # Create a mock response
+    mock_response = MagicMock()
+    mock_response.metrics = None
+    mock_response.__str__.return_value = "Test response with custom model"
+
+    with patch("strands_tools.use_llm.create_model") as mock_create_model:
+        with patch("strands_tools.use_llm.Agent") as MockAgent:
+            # Configure the mocks
+            mock_custom_model = MagicMock()
+            mock_create_model.return_value = mock_custom_model
+            mock_instance = MockAgent.return_value
+            mock_instance.return_value = mock_response
+
+            # Call use_llm with model configuration
+            result = use_llm.use_llm(
+                prompt="Test with custom model",
+                system_prompt="Test system prompt",
+                model_provider="bedrock",
+                model_settings={"model_id": "claude-3-sonnet", "temperature": 0.7},
+            )
+
+            # Verify create_model was called with correct parameters
+            mock_create_model.assert_called_once_with(
+                provider="bedrock", config={"model_id": "claude-3-sonnet", "temperature": 0.7}
+            )
+
+            # Verify Agent was created with the custom model
+            MockAgent.assert_called_once()
+            call_kwargs = MockAgent.call_args.kwargs
+            assert call_kwargs["model"] == mock_custom_model
+
+            # Verify the result
+            assert result["status"] == "success"
+            assert "Test response with custom model" in result["content"][0]["text"]
+
+            # Verify the result
+            assert result["status"] == "success"
+            assert "Test response with custom model" in result["content"][0]["text"]


### PR DESCRIPTION
### Summary

This PR adds model provider switching capabilities to `think`, `use_llm`, `agent_graph`, and `swarm` tools while migrating them from TOOL_SPEC to @tool decorator pattern.

### Changes Made

**New Model Provider System:**
- Added 6 model provider modules: `bedrock`, `anthropic`, `litellm`, `llamaapi`, `ollama`, `openai`
- Created `utils/models.py` for dynamic model creation and configuration
- Environment-based model configuration with sensible defaults

**Tool Enhancements:**
- `think`: Added `model_provider`, `model_settings`, `thinking_system_prompt` parameters
- `use_llm`: Migrated to @tool decorator, added model switching
- `agent_graph`: Migrated to @tool decorator, added per-node model configuration  
- `swarm`: Migrated to @tool decorator, added swarm-wide model control

**Security & Access Control:**
- Added `tools` parameter to all enhanced tools for security isolation
- Granular control over which tools nested agents can access

### Technical Details

All new parameters are optional with backward-compatible defaults:
```python
# Existing calls continue to work
agent.tool.think("analyze this", 3, "You are an analyst")

# New model switching available  
agent.tool.think(
    "analyze this", 
    3, 
    "You are an analyst",
    model_provider="anthropic",
    model_settings={"model": "claude-3-sonnet", "temperature": 0.5}
)
```

Model providers are loaded dynamically based on the `model_provider` parameter. Configuration can be set via environment variables or passed directly in `model_settings`.

### Use Cases

- Route different reasoning tasks to specialized models
- Cost optimization by using appropriate models per task  
- Environment-specific model selection for deployments
- Multi-model workflows within single agent sessions

### Testing

- All existing tests pass (560+ tests)
- Added comprehensive test coverage for new functionality
- Manual testing of all model provider integrations
- Backward compatibility verified across all tools

### Files Changed

- `src/strands_tools/models/` - New model provider modules (6 files)
- `src/strands_tools/utils/models.py` - Model factory and utilities
- `src/strands_tools/think.py` - Enhanced with model switching  
- `src/strands_tools/use_llm.py` - Migrated to @tool + model switching
- `src/strands_tools/agent_graph.py` - Migrated to @tool + per-node models
- `src/strands_tools/swarm.py` - Migrated to @tool + swarm models
- Updated corresponding test files

### Backward Compatibility

100% backward compatible. All existing tool calls work unchanged. New parameters are optional and use environment-based defaults.

### Related

Addresses issues;
#74 - Multi-model support request
#20 - Unable to use custom LLM providers with tools like swarm, agent_graph, workflow

PS: Workflow tool is not in this list of changes.

Previous PR closed due messy git history, https://github.com/strands-agents/tools/pull/110