### PR TITLE
fix: Fixing optional dependencies for use_browser tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pip install strands-agents-tools
 To install the dependencies for optional tools:
 
 ```bash
-pip install strands-agents-tools[mem0_memory]
+pip install strands-agents-tools[mem0_memory, use_browser]
 ```
 
 ### Development Install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,6 @@ dev = [
     "responses>=0.6.1,<1.0.0",
     "mem0ai>=0.1.104,<1.0.0",
     "opensearch-py>=2.8.0,<3.0.0",
-    "nest-asyncio>=1.5.0,<2.0.0",
-    "playwright>=1.42.0,<2.0.0",
 ]
 docs = [
     "sphinx>=5.0.0,<6.0.0",
@@ -80,6 +78,10 @@ mem0_memory = [
     # Need to be optional as a fix for https://github.com/strands-agents/docs/issues/19
     "mem0ai>=0.1.99,<1.0.0",
     "opensearch-py>=2.8.0,<3.0.0",
+]
+use_browser = [
+    "nest-asyncio>=1.5.0,<2.0.0",
+    "playwright>=1.42.0,<2.0.0",
 ]
 
 [tool.hatch.envs.hatch-static-analysis]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ dev = [
     "responses>=0.6.1,<1.0.0",
     "mem0ai>=0.1.104,<1.0.0",
     "opensearch-py>=2.8.0,<3.0.0",
+    "nest-asyncio>=1.5.0,<2.0.0",
+    "playwright>=1.42.0,<2.0.0",
 ]
 docs = [
     "sphinx>=5.0.0,<6.0.0",
@@ -85,7 +87,7 @@ use_browser = [
 ]
 
 [tool.hatch.envs.hatch-static-analysis]
-features = ["mem0_memory"]
+features = ["mem0_memory", "use_browser"]
 dependencies = [
     "strands-agents>=0.1.0,<1.0.0",
     "mypy>=0.981,<1.0.0",
@@ -110,7 +112,7 @@ lint-fix = [
 ]
 
 [tool.hatch.envs.hatch-test]
-features = ["mem0_memory"]
+features = ["mem0_memory", "use_browser"]
 extra-dependencies = [
     "moto>=5.1.0,<6.0.0",
     "pytest>=8.0.0,<9.0.0",
@@ -118,8 +120,6 @@ extra-dependencies = [
     "pytest-xdist>=3.0.0,<4.0.0",
     "responses>=0.6.1,<1.0.0",
     "pytest_asyncio>=0.23.0,<1.0.0",
-    "nest-asyncio>=1.5.0,<2.0.0",
-    "playwright>=1.42.0,<2.0.0"
 ]
 extra-args = [
     "-n",


### PR DESCRIPTION
## Description
The dependencies for use_browser needed to be added to the `pyproject.toml` file a different way. 

## Related Issues
Fix related to the following issue: https://github.com/strands-agents/tools/issues/116

## Documentation PR
[Link to related associated PR in the agent-docs repo]

## Type of Change
- [x] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
