### PR TITLE
feat(tools): add diagram tool to Strands tools repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Strands Agents Tools is a community-driven project that provides a powerful set 
 - 🐝 **Swarm Intelligence** - Coordinate multiple AI agents for parallel problem solving with shared memory
 - 🔄 **Multiple tools in Parallel**  - Call multiple other tools at the same time in parallel with Batch Tool
 - 🔍 **Browser Tool** - Tool giving an agent access to perform automated actions on a browser (chromium)
+- 📈 **Diagram** - Create AWS cloud diagrams, basic diagrams, or UML diagrams using python libraries
 
 ## 📦 Installation
 
@@ -128,6 +129,7 @@ Below is a comprehensive table of all available tools, how to use them with an a
 | workflow | `agent.tool.workflow(action="create", name="data_pipeline", steps=[{"tool": "file_read"}, {"tool": "python_repl"}])` | Define, execute, and manage multi-step automated workflows |
 | batch| `agent.tool.batch(invocations=[{"name": "current_time", "arguments": {"timezone": "Europe/London"}}, {"name": "stop", "arguments": {}}])` | Call multiple other tools in parallel. |
 | browser | `browser = LocalChromiumBrowser(); agent = Agent(tools=[browser.browser])` | Web scraping, automated testing, form filling, web automation tasks |
+| diagram | `agent.tool.diagram(diagram_type="cloud", nodes=[{"id": "s3", "type": "S3"}], edges=[])` | Create AWS cloud architecture diagrams, network diagrams, graphs, and UML diagrams (all 14 types) |
 
 \* *These tools do not work on windows*
 
@@ -448,6 +450,55 @@ response = agent("discover available agents and send a greeting message")
 # - discover_agent(url) to find agents
 # - list_discovered_agents() to see all discovered agents
 # - send_message(message_text, target_agent_url) to communicate
+```
+
+### Diagram
+
+```python
+from strands import Agent
+from strands_tools import diagram
+
+agent = Agent(tools=[diagram])
+
+# Create an AWS cloud architecture diagram
+result = agent.tool.diagram(
+    diagram_type="cloud",
+    nodes=[
+        {"id": "users", "type": "Users", "label": "End Users"},
+        {"id": "cloudfront", "type": "CloudFront", "label": "CDN"},
+        {"id": "s3", "type": "S3", "label": "Static Assets"},
+        {"id": "api", "type": "APIGateway", "label": "API Gateway"},
+        {"id": "lambda", "type": "Lambda", "label": "Backend Service"}
+    ],
+    edges=[
+        {"from": "users", "to": "cloudfront"},
+        {"from": "cloudfront", "to": "s3"},
+        {"from": "users", "to": "api"},
+        {"from": "api", "to": "lambda"}
+    ],
+    title="Web Application Architecture"
+)
+
+# Create a UML class diagram
+result = agent.tool.diagram(
+    diagram_type="class",
+    elements=[
+        {
+            "name": "User",
+            "attributes": ["+id: int", "-name: string", "#email: string"],
+            "methods": ["+login(): bool", "+logout(): void"]
+        },
+        {
+            "name": "Order",
+            "attributes": ["+id: int", "-items: List", "-total: float"],
+            "methods": ["+addItem(item): void", "+calculateTotal(): float"]
+        }
+    ],
+    relationships=[
+        {"from": "User", "to": "Order", "type": "association", "multiplicity": "1..*"}
+    ],
+    title="E-commerce Domain Model"
+)
 ```
 
 ## 🌍 Environment Variables Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,9 +91,15 @@ agent_core_code_interpreter = [
     "bedrock-agentcore==0.1.0"
 ]
 a2a_client = ["a2a-sdk[sql]>=0.2.11"]
+diagram = [
+    "matplotlib>=3.5.0,<4.0.0",
+    "graphviz>=0.20.0,<1.0.0",
+    "networkx>=2.8.0,<4.0.0",
+    "diagrams>=0.23.0,<1.0.0",
+]
 
 [tool.hatch.envs.hatch-static-analysis]
-features = ["mem0_memory", "local_chromium_browser", "agent_core_browser", "agent_core_code_interpreter", "a2a_client"]
+features = ["mem0_memory", "local_chromium_browser", "agent_core_browser", "agent_core_code_interpreter", "a2a_client", "diagram"]
 dependencies = [
     "strands-agents>=1.0.0",
     "mypy>=0.981,<1.0.0",
@@ -112,7 +118,7 @@ lint-check = [
 lint-fix = ["ruff check --fix"]
 
 [tool.hatch.envs.hatch-test]
-features = ["mem0_memory", "local_chromium_browser",  "agent_core_browser", "agent_core_code_interpreter", "a2a_client"]
+features = ["mem0_memory", "local_chromium_browser",  "agent_core_browser", "agent_core_code_interpreter", "a2a_client", "diagram"]
 extra-dependencies = [
     "moto>=5.1.0,<6.0.0",
     "pytest>=8.0.0,<9.0.0",

--- a/src/strands_tools/diagram.py
+++ b/src/strands_tools/diagram.py
@@ -1,0 +1,1189 @@
+import matplotlib
+
+matplotlib.use("Agg")  # Add this line before other imports
+import importlib
+import logging
+import os
+import platform
+import subprocess
+from typing import Any, Dict, List, Union
+
+import graphviz
+import matplotlib.pyplot as plt
+import networkx as nx
+from diagrams import Diagram as CloudDiagram
+from strands import tool
+
+# AWS service categories - comprehensive list
+AWS_CATEGORIES = [
+    "analytics",
+    "compute",
+    "database",
+    "network",
+    "storage",
+    "security",
+    "integration",
+    "management",
+    "ml",
+    "general",
+    "mobile",
+    "migration",
+    "devtools",
+    "blockchain",
+    "business",
+    "cost",
+    "customer",
+    "game",
+    "iot",
+    "media",
+    "quantum",
+    "robotics",
+    "satellite",
+]
+
+# Common aliases for AWS components
+COMMON_ALIASES = {
+    # Non-AWS components
+    "users": "Users",
+    "user": "Users",
+    "client": "Users",
+    "clients": "Users",
+    "internet": "Internet",
+    "web": "Internet",
+    # Common AWS aliases
+    "api_gateway": "APIGateway",
+    "apigateway": "APIGateway",
+    "api-gateway": "APIGateway",
+    "dynamo": "Dynamodb",
+    "ddb": "Dynamodb",
+    "ec2": "EC2",
+    "instance": "EC2",
+    "server": "EC2",
+    "ecr": "EC2ContainerRegistry",
+    "registry": "EC2ContainerRegistry",
+    "ecs": "ElasticContainerService",
+    "container": "ElasticContainerService",
+    "eks": "ElasticKubernetesService",
+    "kubernetes": "ElasticKubernetesService",
+    "k8s": "ElasticKubernetesService",
+    "redis": "Elasticache",
+    "memcached": "Elasticache",
+    "es": "Elasticsearch",
+    "elb": "ElasticLoadBalancing",
+    "loadbalancer": "ElasticLoadBalancing",
+    "alb": "ApplicationLoadBalancer",
+    "nlb": "NetworkLoadBalancer",
+    "events": "Eventbridge",
+    "identity": "IAM",
+    "streaming": "Kinesis",
+    "encryption": "KMS",
+    "function": "Lambda",
+    "serverless": "Lambda",
+    "mysql": "RDS",
+    "postgres": "RDS",
+    "warehouse": "Redshift",
+    "dns": "Route53",
+    "r53": "Route53",
+    "bucket": "SimpleStorageServiceS3",
+    "storage": "SimpleStorageServiceS3",
+    "secrets": "SecretsManager",
+    "notification": "SimpleNotificationServiceSns",
+    "topic": "SimpleNotificationServiceSns",
+    "queue": "SimpleQueueServiceSqs",
+    "messaging": "SimpleQueueServiceSqs",
+    "workflow": "StepFunctions",
+    "firewall": "WAF",
+}
+
+# Cache for discovered components
+_aws_component_cache = {}
+
+
+def get_aws_node(node_type: str) -> Any:
+    """Dynamically discover and return AWS component - supports all 532+ components"""
+    # Check cache first
+    if node_type in _aws_component_cache:
+        return _aws_component_cache[node_type]
+
+    # Normalize input
+    normalized = node_type.lower().replace("-", "_").replace(" ", "_")
+
+    # Try common aliases first
+    canonical_name = COMMON_ALIASES.get(normalized, node_type)
+
+    # Try non-AWS components (Users, Internet, etc.)
+    if canonical_name in ["Users", "Internet", "Mobile"]:
+        # Try main diagrams module first
+        try:
+            module = importlib.import_module("diagrams")
+            if hasattr(module, canonical_name):
+                component = getattr(module, canonical_name)
+                _aws_component_cache[node_type] = component
+                return component
+        except ImportError:
+            pass
+
+        # Try onprem.network for Internet
+        if canonical_name == "Internet":
+            try:
+                module = importlib.import_module("diagrams.onprem.network")
+                if hasattr(module, canonical_name):
+                    component = getattr(module, canonical_name)
+                    _aws_component_cache[node_type] = component
+                    return component
+            except ImportError:
+                pass
+
+    # Search all AWS categories for the component
+    for category in AWS_CATEGORIES:
+        try:
+            module = importlib.import_module(f"diagrams.aws.{category}")
+            # Try exact match first
+            if hasattr(module, canonical_name):
+                component = getattr(module, canonical_name)
+                _aws_component_cache[node_type] = component
+                return component
+            # Try case-insensitive match
+            for attr in dir(module):
+                if attr.lower() == canonical_name.lower() and not attr.startswith("_"):
+                    component = getattr(module, attr)
+                    _aws_component_cache[node_type] = component
+                    return component
+        except ImportError:
+            continue
+
+    # Try original input as-is
+    for category in AWS_CATEGORIES:
+        try:
+            module = importlib.import_module(f"diagrams.aws.{category}")
+            if hasattr(module, node_type):
+                component = getattr(module, node_type)
+                _aws_component_cache[node_type] = component
+                return component
+        except ImportError:
+            continue
+
+    raise ValueError(f"Component '{node_type}' not found. Try: {list(COMMON_ALIASES.keys())[:10]}...")
+
+
+# These functions have been removed as the agent can generate mermaid/ascii directly
+
+
+class DiagramBuilder:
+    """Unified diagram builder that handles all diagram types and formats"""
+
+    def __init__(self, nodes, edges=None, title="diagram", style=None):
+        self.nodes = nodes
+        self.edges = edges or []
+        self.title = title
+        self.style = style or {}
+
+    def render(self, diagram_type: str, output_format: str) -> str:
+        """Main render method that delegates to specific renderers"""
+        if output_format in ["mermaid", "ascii"]:
+            raise NotImplementedError(
+                "Mermaid and ASCII rendering has been removed. "
+                "Use the agent's LLM capabilities to generate mermaid code directly."
+            )
+
+        # Delegate to specific diagram type methods
+        method_map = {
+            "cloud": self._render_cloud,
+            "graph": self._render_graph,
+            "network": self._render_network,
+        }
+
+        if diagram_type not in method_map:
+            raise ValueError(f"Unsupported diagram type: {diagram_type}")
+
+        return method_map[diagram_type](output_format)
+
+    def _render_text(self, output_format: str) -> str:
+        """Handle text formats (mermaid/ascii) - unified for all diagram types"""
+        raise NotImplementedError(
+            "Mermaid and ASCII rendering has been removed. "
+            "Use the agent's LLM capabilities to generate mermaid code directly."
+        )
+
+    def _render_cloud(self, output_format: str) -> str:
+        """Create AWS architecture diagram"""
+        if not self.nodes:
+            raise ValueError("At least one node is required for cloud diagram")
+
+        # Pre-validate all node types before creating diagram
+        invalid_nodes = []
+        for node in self.nodes:
+            if "id" not in node:
+                raise ValueError(f"Node missing required 'id' field: {node}")
+
+            node_type = node.get("type", "EC2")
+            try:
+                get_aws_node(node_type)
+            except ValueError:
+                invalid_nodes.append((node["id"], node_type))
+
+        if invalid_nodes:
+            suggestions = []
+            for node_id, node_type in invalid_nodes:
+                # Find close matches
+                close_matches = [k for k in COMMON_ALIASES.keys() if node_type.lower() in k or k in node_type.lower()]
+                if close_matches:
+                    suggestions.append(f"  - '{node_id}' (type: '{node_type}') -> try: {close_matches[:3]}")
+                else:
+                    suggestions.append(f"  - '{node_id}' (type: '{node_type}') -> no close matches found")
+
+            common_types = ["ec2", "s3", "lambda", "rds", "api_gateway", "cloudfront", "route53", "elb"]
+            error_msg = (
+                f"Invalid AWS component types found:\n{chr(10).join(suggestions)}\n\n"
+                f"Common types: {common_types}\nNote: "
+                f"All 532+ AWS components are supported - try the exact AWS service name"
+            )
+            raise ValueError(error_msg)
+
+        nodes_dict = {}
+        output_path = save_diagram_to_directory(self.title, "")
+
+        try:
+            with CloudDiagram(name=self.title, filename=output_path, outformat=output_format):
+                for node in self.nodes:
+                    node_type = node.get("type", "EC2")
+                    node_class = get_aws_node(node_type)
+                    node_label = node.get("label", node["id"])
+                    nodes_dict[node["id"]] = node_class(node_label)
+
+                for edge in self.edges:
+                    if "from" not in edge or "to" not in edge:
+                        logging.warning(f"Edge missing 'from' or 'to' field, skipping: {edge}")
+                        continue
+
+                    from_node = nodes_dict.get(edge["from"])
+                    to_node = nodes_dict.get(edge["to"])
+
+                    if not from_node:
+                        logging.warning(f"Source node '{edge['from']}' not found for edge")
+                    elif not to_node:
+                        logging.warning(f"Target node '{edge['to']}' not found for edge")
+                    else:
+                        from_node >> to_node
+
+            output_file = f"{output_path}.{output_format}"
+            open_diagram(output_file)
+            return output_file
+        except Exception as e:
+            logging.error(f"Failed to create cloud diagram: {e}")
+            raise
+
+    def _render_graph(self, output_format: str) -> str:
+        """Create Graphviz diagram with optional AWS icons"""
+        dot = graphviz.Digraph(comment=self.title)
+        dot.attr(rankdir=self.style.get("rankdir", "LR"))
+
+        for node in self.nodes:
+            node_id = node["id"]
+            node_label = node.get("label", node_id)
+
+            # Add AWS service type as tooltip if specified
+            if "type" in node:
+                try:
+                    get_aws_node(node["type"])  # Validate AWS component exists
+                    dot.node(node_id, node_label, tooltip=f"AWS {node['type']}")
+                except ValueError:
+                    dot.node(node_id, node_label)
+            else:
+                dot.node(node_id, node_label)
+
+        for edge in self.edges:
+            dot.edge(edge["from"], edge["to"], edge.get("label", ""))
+
+        output_path = save_diagram_to_directory(self.title, "")
+        rendered_path = dot.render(filename=output_path, format=output_format, cleanup=False)
+        open_diagram(rendered_path)
+        return rendered_path
+
+    def _render_network(self, output_format: str) -> str:
+        """Create NetworkX diagram with AWS-aware coloring"""
+        G = nx.Graph()
+        node_colors = []
+        aws_color_map = {
+            "compute": "orange",
+            "database": "green",
+            "network": "blue",
+            "storage": "purple",
+            "security": "red",
+        }
+
+        for node in self.nodes:
+            G.add_node(node["id"], label=node.get("label", node["id"]))
+
+            # Color nodes based on AWS service category
+            if "type" in node:
+                try:
+                    get_aws_node(node["type"])  # Validate AWS component exists
+                    # Simple category detection based on common patterns
+                    node_type = node["type"].lower()
+                    if any(x in node_type for x in ["ec2", "lambda", "fargate", "ecs", "eks"]):
+                        node_colors.append(aws_color_map["compute"])
+                    elif any(x in node_type for x in ["rds", "dynamo", "aurora", "redshift"]):
+                        node_colors.append(aws_color_map["database"])
+                    elif any(x in node_type for x in ["vpc", "elb", "api_gateway", "cloudfront"]):
+                        node_colors.append(aws_color_map["network"])
+                    elif any(x in node_type for x in ["s3", "efs", "fsx"]):
+                        node_colors.append(aws_color_map["storage"])
+                    elif any(x in node_type for x in ["iam", "kms", "cognito", "waf"]):
+                        node_colors.append(aws_color_map["security"])
+                    else:
+                        node_colors.append("lightblue")
+                except ValueError:
+                    node_colors.append("lightblue")
+            else:
+                node_colors.append("lightblue")
+
+        edge_list = [(edge["from"], edge["to"]) for edge in self.edges]
+        G.add_edges_from(edge_list)
+
+        plt.figure(figsize=(10, 8))
+        pos = nx.spring_layout(G)
+
+        nx.draw_networkx_nodes(G, pos, node_color=node_colors, node_size=1500)
+        nx.draw_networkx_edges(G, pos)
+
+        labels = {node["id"]: node.get("label", node["id"]) for node in self.nodes}
+        nx.draw_networkx_labels(G, pos, labels, font_size=10, font_weight="bold")
+
+        edge_labels = {(edge["from"], edge["to"]): edge.get("label", "") for edge in self.edges if "label" in edge}
+        if edge_labels:
+            nx.draw_networkx_edge_labels(G, pos, edge_labels)
+
+        plt.title(self.title)
+        output_path = save_diagram_to_directory(self.title, output_format)
+        plt.savefig(output_path, bbox_inches="tight")
+        plt.close()
+        open_diagram(output_path)
+        return output_path
+
+
+class UMLDiagramBuilder:
+    """Builder for all 14 types of UML diagrams with proper notation"""
+
+    def __init__(
+        self,
+        diagram_type: str,
+        elements: List[Dict],
+        relationships: List[Dict] = None,
+        title: str = "UML_Diagram",
+        style: Dict = None,
+    ):
+        self.diagram_type = diagram_type.lower().replace(" ", "_").replace("-", "_")
+        self.elements = elements
+        self.relationships = relationships or []
+        self.title = title
+        self.style = style or {}
+
+    def render(self, output_format: str = "png") -> str:
+        """Render the UML diagram based on type"""
+        # Handle text formats (mermaid/ascii) for UML diagrams
+        if output_format in ["mermaid", "ascii"]:
+            raise NotImplementedError(
+                "Mermaid and ASCII rendering has been removed. "
+                "Use the agent's LLM capabilities to generate mermaid code directly."
+            )
+
+        method_map = {
+            # Structural diagrams
+            "class": self._render_class,
+            "object": self._render_object,
+            "component": self._render_component,
+            "deployment": self._render_deployment,
+            "package": self._render_package,
+            "profile": self._render_profile,
+            "composite_structure": self._render_composite_structure,
+            # Behavioral diagrams
+            "use_case": self._render_use_case,
+            "activity": self._render_activity,
+            "state_machine": self._render_state_machine,
+            "sequence": self._render_sequence,
+            "communication": self._render_communication,
+            "interaction_overview": self._render_interaction_overview,
+            "timing": self._render_timing,
+        }
+
+        if self.diagram_type not in method_map:
+            raise ValueError(f"Unsupported UML diagram type: {self.diagram_type}")
+
+        return method_map[self.diagram_type](output_format)
+
+    def _create_dot_graph(self):
+        dot = graphviz.Digraph()
+        dot.attr(rankdir="TB")
+        dot.attr("node", shape="record", fontname="Arial")
+        dot.attr("edge", fontname="Arial", fontsize="10")
+        dot.attr("graph", ranksep="0.5")
+        return dot
+
+    # STRUCTURAL DIAGRAMS
+
+    def _render_class(self, output_format: str) -> str:
+        dot = self._create_dot_graph()
+
+        for element in self.elements:
+            class_name = element["name"]
+            # Handle both list and string formats for attributes and methods
+            attributes = element.get("attributes", [])
+            if isinstance(attributes, str):
+                attributes = [attr.strip() for attr in attributes.split("\n") if attr.strip()]
+
+            methods = element.get("methods", [])
+            if isinstance(methods, str):
+                methods = [method.strip() for method in methods.split("\n") if method.strip()]
+
+            label_parts = [class_name]
+
+            if attributes:
+                attr_text = "\\n".join([self._format_visibility(attr) for attr in attributes])
+                label_parts.append(attr_text)
+
+            if methods:
+                method_text = "\\n".join([self._format_visibility(method) for method in methods])
+                label_parts.append(method_text)
+
+            label = "{{{}}}".format("|".join(label_parts))
+
+            dot.node(class_name, label, shape="record")
+
+        for rel in self.relationships:
+            self._add_class_relationship(dot, rel)
+
+        return self._save_diagram(dot, output_format)
+
+    def _render_component(self, output_format: str) -> str:
+        """Component Diagram: Software components and interfaces with proper UML notation"""
+        dot = self._create_dot_graph()
+        dot.attr("node", shape="none")
+
+        with dot.subgraph(name="cluster_0") as c:
+            c.attr(label=self.title, style="rounded", bgcolor="white")
+
+            # First pass: Create components and interfaces
+            for element in self.elements:
+                name = element["name"]
+                elem_type = element.get("type", "component")
+
+                if elem_type == "component":
+                    # Improved component notation with stereotype and ports
+                    ports = element.get("ports", [])
+                    port_cells = ""
+
+                    # Add port definitions if present
+                    for port in ports:
+                        port_id = port.get("id", "")
+                        port_cells += f'<TR><TD PORT="{port_id}" BORDER="0">●</TD></TR>'
+
+                    label = f"""<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0">
+                        <TR>
+                            <TD>
+                                <TABLE BORDER="1" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+                                    <TR>
+                                        <TD>
+                                            <TABLE BORDER="0" CELLSPACING="0">
+                                                <TR>
+                                                    <TD ALIGN="RIGHT" WIDTH="20">
+                                                        <TABLE BORDER="1" CELLSPACING="0" CELLPADDING="0">
+                                                            <TR><TD WIDTH="15" HEIGHT="7"></TD></TR>
+                                                            <TR><TD WIDTH="15" HEIGHT="7"></TD></TR>
+                                                        </TABLE>
+                                                    </TD>
+                                                    <TD ALIGN="LEFT" CELLPADDING="4">
+                                                        <TABLE BORDER="0" CELLSPACING="0">
+                                                            <TR><TD ALIGN="CENTER">«component»</TD></TR>
+                                                            <TR><TD ALIGN="CENTER">{name}</TD></TR>
+                                                        </TABLE>
+                                                    </TD>
+                                                </TR>
+                                            </TABLE>
+                                        </TD>
+                                    </TR>
+                                    {port_cells}
+                                </TABLE>
+                            </TD>
+                        </TR>
+                    </TABLE>>"""
+                    dot.node(name, label, margin="0", style="rounded")
+
+                elif elem_type == "interface":
+                    interface_name = element.get("name", "")
+                    stereotype = "«interface»"
+
+                    if element.get("provided", False):
+                        # Ball notation (provided interface)
+                        dot.node(
+                            f"{name}_provided",
+                            f"""<<TABLE BORDER="0" CELLSPACING="0">
+                                    <TR><TD>◯</TD></TR>
+                                    <TR><TD>{stereotype}</TD></TR>
+                                    <TR><TD>{interface_name}</TD></TR>
+                                </TABLE>>""",
+                            shape="none",
+                        )
+
+                    if element.get("required", False):
+                        # Socket notation (required interface)
+                        dot.node(
+                            f"{name}_required",
+                            f"""<<TABLE BORDER="0" CELLSPACING="0">
+                                    <TR><TD>◐</TD></TR>
+                                    <TR><TD>{stereotype}</TD></TR>
+                                    <TR><TD>{interface_name}</TD></TR>
+                                </TABLE>>""",
+                            shape="none",
+                        )
+
+                elif elem_type == "port":
+                    # Standard UML port notation
+                    dot.node(name, "□", shape="none", fontsize="14")
+
+        # Second pass: Create relationships with proper UML notation
+        for rel in self.relationships:
+            rel_type = rel.get("type", "connection")
+
+            edge_attrs = {
+                "dependency": {"style": "dashed", "arrowhead": "vee", "dir": "forward"},
+                "realization": {"style": "dashed", "arrowhead": "empty", "dir": "forward"},
+                "assembly": {"style": "solid", "arrowhead": "none", "dir": "both"},
+                "delegation": {"style": "dashed", "arrowhead": "vee", "dir": "forward"},
+                "connection": {"style": "solid", "arrowhead": "none"},
+            }
+
+            attrs = edge_attrs.get(rel_type, edge_attrs["connection"])
+
+            # Add proper UML notation for multiplicity and constraints
+            if "multiplicity" in rel:
+                attrs["label"] = rel["multiplicity"]
+                attrs["fontsize"] = "10"
+
+            if "constraint" in rel:
+                constraint = rel["constraint"]
+                attrs["label"] = f"{{{constraint}}}"
+
+            # Add standard label if present
+            if "label" in rel:
+                current_label = attrs.get("label", "")
+                attrs["label"] = f"{current_label}\n{rel['label']}" if current_label else rel["label"]
+
+            # Create the edge with proper attributes
+            dot.edge(rel["from"], rel["to"], **attrs)
+
+        # Set diagram-wide attributes for better UML compliance
+        dot.attr(rankdir="LR")  # Standard left-to-right layout for component diagrams
+        dot.attr(splines="ortho")  # Orthogonal lines for clearer relationships
+        dot.attr(nodesep="1.0")  # Increased spacing between nodes
+        dot.attr(ranksep="1.0")  # Increased spacing between ranks
+
+        return self._save_diagram(dot, output_format)
+
+    def _render_deployment(self, output_format: str) -> str:
+        """Deployment Diagram: Hardware nodes and software artifacts"""
+        dot = self._create_dot_graph()
+
+        for element in self.elements:
+            name = element["name"]
+            elem_type = element.get("type", "node")
+
+            if elem_type == "node":
+                dot.node(name, f"<<device>>\\n{name}", shape="box3d", style="filled", fillcolor="lightyellow")
+            elif elem_type == "artifact":
+                dot.node(name, f"<<artifact>>\\n{name}", shape="note", style="filled", fillcolor="lightcyan")
+
+        for rel in self.relationships:
+            dot.edge(rel["from"], rel["to"], label=rel.get("label", ""))
+
+        return self._save_diagram(dot, output_format)
+
+    def _render_use_case(self, output_format: str) -> str:
+        """Use Case Diagram: Actors, use cases, and system boundary"""
+        dot = self._create_dot_graph()
+
+        for element in self.elements:
+            name = element["name"]
+            elem_type = element.get("type", "use_case")
+
+            if elem_type == "actor":
+                dot.node(name, f"&lt;&lt;actor&gt;&gt;\\n{name}", shape="plaintext")
+            elif elem_type == "use_case":
+                dot.node(name, name, shape="ellipse", style="filled", fillcolor="lightblue")
+            elif elem_type == "system":
+                dot.node(name, name, shape="box", style="dashed")
+
+        for rel in self.relationships:
+            rel_type = rel.get("type", "association")
+            if rel_type == "include":
+                dot.edge(rel["from"], rel["to"], style="dashed", label="&lt;&lt;include&gt;&gt;")
+            elif rel_type == "extend":
+                dot.edge(rel["from"], rel["to"], style="dashed", label="&lt;&lt;extend&gt;&gt;")
+            else:
+                dot.edge(rel["from"], rel["to"])
+
+        return self._save_diagram(dot, output_format)
+
+    def _render_sequence(self, output_format: str) -> str:
+        """Sequence Diagram: Objects and message exchanges over time"""
+        if not self.elements:
+            raise ValueError("At least one element is required for sequence diagram")
+
+        fig, ax = plt.subplots(figsize=(12, 8))
+        sorted_msgs = sorted(self.relationships, key=lambda x: x.get("sequence", 0))
+        participant_positions = {element["name"]: i for i, element in enumerate(self.elements)}
+        participant_labels = {element["name"]: element.get("label", element["name"]) for element in self.elements}
+
+        # Draw participant boxes and lifelines
+        for i, element in enumerate(self.elements):
+            if "name" not in element:
+                raise ValueError(f"Element missing required 'name' field: {element}")
+
+            ax.add_patch(
+                plt.Rectangle((i - 0.3, len(sorted_msgs) + 0.2), 0.6, 0.6, facecolor="lightblue", edgecolor="black")
+            )
+            ax.text(
+                i,
+                len(sorted_msgs) + 0.5,
+                participant_labels[element["name"]],
+                ha="center",
+                va="center",
+                fontweight="bold",
+                fontsize=10,
+            )
+            ax.axvline(
+                x=i,
+                ymin=0,
+                ymax=(len(sorted_msgs) + 0.2) / (len(sorted_msgs) + 1),
+                color="gray",
+                linestyle="--",
+                alpha=0.7,
+            )
+
+        # Draw message interactions
+        for i, msg in enumerate(sorted_msgs):
+            if "from" not in msg or "to" not in msg:
+                logging.warning(f"Message missing 'from' or 'to' field, skipping: {msg}")
+                continue
+
+            if msg["from"] not in participant_positions or msg["to"] not in participant_positions:
+                logging.warning("Participant not found, skipping message")
+                continue
+
+            from_pos = participant_positions[msg["from"]]
+            to_pos = participant_positions[msg["to"]]
+            y_pos = len(sorted_msgs) - i - 0.5
+
+            ax.annotate(
+                "", xy=(to_pos, y_pos), xytext=(from_pos, y_pos), arrowprops=dict(arrowstyle="->", color="blue", lw=1.5)
+            )
+
+            mid_pos = (from_pos + to_pos) / 2 if from_pos != to_pos else from_pos + 0.3
+            sequence_num = msg.get("sequence", i + 1)
+            # Use 'label' field first, then fall back to 'message' for backward compatibility
+            message_text = msg.get("label", msg.get("message", ""))
+            label = f"{sequence_num}. {message_text}" if message_text else str(sequence_num)
+
+            ax.text(
+                mid_pos,
+                y_pos + 0.1,
+                label,
+                ha="center",
+                va="bottom",
+                fontsize=9,
+                bbox=dict(boxstyle="round,pad=0.3", facecolor="white", alpha=0.8),
+            )
+
+        ax.set_xlim(-0.5, len(self.elements) - 0.5)
+        ax.set_ylim(-0.5, len(sorted_msgs) + 1)
+        ax.set_title(self.title, fontsize=14, fontweight="bold")
+        ax.set_xticks([])
+        ax.set_yticks([])
+        for spine in ax.spines.values():
+            spine.set_visible(False)
+
+        output_path = save_diagram_to_directory(self.title, output_format)
+        plt.tight_layout()
+        plt.savefig(output_path, bbox_inches="tight", dpi=300)
+        plt.close()
+        open_diagram(output_path)
+        return output_path
+
+    # Simplified implementations for other UML types
+    def _render_object(self, output_format: str) -> str:
+        """Object Diagram: Instance objects with their attribute values"""
+        dot = self._create_dot_graph()
+
+        for element in self.elements:
+            name = element["name"]
+            class_name = element.get("class", "Object")
+            attributes = element.get("attributes", "")
+
+            # Build object label with object name and attributes
+            label_parts = [f"{name}:{class_name}"]
+
+            if attributes:
+                if isinstance(attributes, str):
+                    attr_lines = [attr.strip() for attr in attributes.split("\n") if attr.strip()]
+                else:
+                    attr_lines = [f"{key} = {value}" for key, value in attributes.items()]
+                label_parts.extend(attr_lines)
+
+            label = "{{{}}}".format("|".join(label_parts))
+            dot.node(name, label, shape="record", style="filled", fillcolor="lightblue")
+
+        for rel in self.relationships:
+            dot.edge(rel["from"], rel["to"], label=rel.get("label", ""))
+        return self._save_diagram(dot, output_format)
+
+    def _render_deployment(self, output_format: str) -> str:
+        dot = self._create_dot_graph()
+        for element in self.elements:
+            name = element["name"]
+            elem_type = element.get("type", "node")
+            if elem_type == "node":
+                dot.node(name, f"<<device>>\\n{name}", shape="box3d", style="filled", fillcolor="lightyellow")
+            elif elem_type == "artifact":
+                dot.node(name, f"<<artifact>>\\n{name}", shape="note", style="filled", fillcolor="lightcyan")
+        for rel in self.relationships:
+            dot.edge(rel["from"], rel["to"], label=rel.get("label", ""))
+        return self._save_diagram(dot, output_format)
+
+    def _render_package(self, output_format: str) -> str:
+        dot = self._create_dot_graph()
+        for element in self.elements:
+            dot.node(element["name"], element["name"], shape="folder", style="filled", fillcolor="lightgray")
+        for rel in self.relationships:
+            style = "dashed" if rel.get("type") == "dependency" else "solid"
+            dot.edge(rel["from"], rel["to"], style=style, arrowhead="open")
+        return self._save_diagram(dot, output_format)
+
+    def _render_profile(self, output_format: str) -> str:
+        dot = self._create_dot_graph()
+        for element in self.elements:
+            name = element["name"]
+            stereotype = element.get("stereotype", "")
+            label = f"<<{stereotype}>>\\n{name}" if stereotype else name
+            dot.node(name, label, shape="box", style="dashed")
+        for rel in self.relationships:
+            dot.edge(rel["from"], rel["to"], style="dashed", arrowhead="empty")
+        return self._save_diagram(dot, output_format)
+
+    def _render_composite_structure(self, output_format: str) -> str:
+        """Composite Structure Diagram: Internal structure with parts and ports"""
+        dot = self._create_dot_graph()
+        dot.attr("node", shape="none")
+
+        # Create main component boundary
+        with dot.subgraph(name="cluster_main") as c:
+            c.attr(label=self.title, style="rounded", bgcolor="lightgray")
+
+            # Track ports by their owners for proper placement
+            port_by_owner = {}
+
+            # First pass: Create parts
+            for element in self.elements:
+                name = element["name"]
+                elem_type = element.get("type", "part")
+
+                if elem_type == "part":
+                    # Add multiplicity if specified
+                    multiplicity = element.get("multiplicity", "")
+                    multiplicity_str = f"[{multiplicity}]" if multiplicity else ""
+
+                    # Add proper UML part notation with type and name
+                    label = f"""<<TABLE BORDER="1" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+                            <TR><TD>{name}{multiplicity_str}</TD></TR>
+                            </TABLE>>"""
+                    c.node(name, label, margin="0")
+                elif elem_type == "port":
+                    owner = element.get("owner")
+                    if owner not in port_by_owner:
+                        port_by_owner[owner] = []
+                    port_by_owner[owner].append(element)
+
+            # Second pass: Add ports with proper placement
+            for _, ports in port_by_owner.items():
+                for port in ports:
+                    port_name = port["name"]
+                    port_type = port.get("interface_type", "")
+                    is_provided = port.get("is_provided", True)
+
+                    # Position port on boundary
+                    if is_provided:
+                        # Provided interface (lollipop notation)
+                        port_label = f"""<<TABLE BORDER="0" CELLBORDER="0">
+                                    <TR><TD>○</TD></TR>
+                                    <TR><TD>{port_type}</TD></TR>
+                                    </TABLE>>"""
+                    else:
+                        # Required interface (socket notation)
+                        port_label = f"""<<TABLE BORDER="0" CELLBORDER="0">
+                                    <TR><TD>◑</TD></TR>
+                                    <TR><TD>{port_type}</TD></TR>
+                                    </TABLE>>"""
+
+                    dot.node(port_name, port_label)
+
+            # Add relationships with proper UML notation
+            for rel in self.relationships:
+                rel_type = rel.get("type", "connector")
+                label = rel.get("label", "")
+                multiplicity_source = rel.get("multiplicity_source", "")
+                multiplicity_target = rel.get("multiplicity_target", "")
+
+                if multiplicity_source or multiplicity_target:
+                    label = f"{multiplicity_source} {label} {multiplicity_target}"
+
+                if rel_type == "assembly":
+                    # Assembly connector (between parts)
+                    dot.edge(rel["from"], rel["to"], arrowhead="none", style="solid", label=label)
+                elif rel_type == "delegation":
+                    # Delegation connector (typically to/from ports)
+                    dot.edge(rel["from"], rel["to"], style="dashed", arrowhead="none", label=label)
+                elif rel_type == "composition":
+                    # Composition relationship
+                    dot.edge(rel["from"], rel["to"], arrowhead="diamond", arrowsize="1.5", label=label)
+                else:
+                    # Default connector
+                    dot.edge(rel["from"], rel["to"], arrowhead="none", label=label)
+
+        return self._save_diagram(dot, output_format)
+
+    def _render_activity(self, output_format: str) -> str:
+        dot = self._create_dot_graph()
+        for element in self.elements:
+            name = element["name"]
+            elem_type = element.get("type", "activity")
+            if elem_type == "start":
+                dot.node(name, "", shape="circle", style="filled", fillcolor="black", width="0.3")
+            elif elem_type == "end":
+                dot.node(name, "", shape="doublecircle", style="filled", fillcolor="black", width="0.3")
+            elif elem_type == "activity":
+                dot.node(name, name, shape="box", style="rounded,filled", fillcolor="lightblue")
+            elif elem_type == "decision":
+                dot.node(name, name, shape="diamond", style="filled", fillcolor="yellow")
+        for rel in self.relationships:
+            dot.edge(rel["from"], rel["to"], label=rel.get("label", ""))
+        return self._save_diagram(dot, output_format)
+
+    def _render_state_machine(self, output_format: str) -> str:
+        dot = self._create_dot_graph()
+        for element in self.elements:
+            name = element["name"]
+            elem_type = element.get("type", "state")
+            if elem_type == "initial":
+                dot.node(name, "", shape="circle", style="filled", fillcolor="black", width="0.3")
+            elif elem_type == "final":
+                dot.node(name, "", shape="doublecircle", style="filled", fillcolor="black", width="0.3")
+            elif elem_type == "state":
+                dot.node(name, name, shape="box", style="rounded,filled", fillcolor="lightgreen")
+        for rel in self.relationships:
+            label = rel.get("event", "")
+            if rel.get("action"):
+                label += f" / {rel['action']}"
+            dot.edge(rel["from"], rel["to"], label=label)
+        return self._save_diagram(dot, output_format)
+
+    def _render_communication(self, output_format: str) -> str:
+        dot = self._create_dot_graph()
+        dot.attr(rankdir="LR")
+        for element in self.elements:
+            dot.node(element["name"], element["name"], shape="box", style="filled", fillcolor="lightblue")
+        for rel in self.relationships:
+            seq = rel.get("sequence", "")
+            msg = rel.get("message", "")
+            label = f"{seq}: {msg}" if seq else msg
+            dot.edge(rel["from"], rel["to"], label=label, dir="both")
+        return self._save_diagram(dot, output_format)
+
+    def _render_interaction_overview(self, output_format: str) -> str:
+        """Interaction Overview Diagram: High-level interaction flow"""
+        dot = self._create_dot_graph()
+
+        # Add UML frame around the diagram
+        dot.attr("graph", compound="true")
+
+        for element in self.elements:
+            name = element["name"]
+            elem_type = element.get("type", "interaction")
+
+            if elem_type == "initial":
+                # Initial node - solid black circle
+                dot.node(name, "", shape="circle", style="filled", fillcolor="black", width="0.3")
+            elif elem_type == "final":
+                # Final node - circle with dot inside
+                dot.node(
+                    name, "", shape="doublecircle", style="filled,bold", fillcolor="white", color="black", width="0.3"
+                )
+            elif elem_type == "interaction":
+                # Interaction frame with proper UML notation
+                label = f"""<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+                        <TR><TD BGCOLOR="lightgrey">sd {name}</TD></TR>
+                        </TABLE>>"""
+                dot.node(name, label, shape="none", margin="0")
+            elif elem_type == "decision":
+                # Decision node with proper diamond shape
+                dot.node(
+                    name,
+                    name,
+                    shape="diamond",
+                    style="filled",
+                    fillcolor="white",
+                    color="black",
+                    width="1.5",
+                    height="1.5",
+                )
+            elif elem_type == "fork":
+                # Fork/join node
+                dot.node(name, "", shape="rect", style="filled", fillcolor="black", width="0.1", height="0.02")
+
+        for rel in self.relationships:
+            # Add proper UML guard conditions and labels
+            label = rel.get("label", "")
+            guard = rel.get("guard", "")
+            if guard:
+                label = f"[{guard}]" if not label else f"[{guard}] {label}"
+
+            # Add proper arrow styling based on relationship type
+            attrs = {"label": label, "fontsize": "10", "arrowhead": "vee", "arrowsize": "0.8"}
+
+            # Special handling for different relationship types
+            rel_type = rel.get("type", "sequence")
+            if rel_type == "concurrent":
+                attrs["style"] = "bold"
+            elif rel_type == "alternative":
+                attrs["style"] = "dashed"
+
+            dot.edge(rel["from"], rel["to"], **attrs)
+
+        # Set diagram-wide attributes for better UML compliance
+        dot.attr(rankdir="TB")  # Top to bottom layout is standard for IODs
+        dot.attr(splines="ortho")  # Orthogonal lines for clearer flow
+        dot.attr(nodesep="0.5")
+        dot.attr(ranksep="0.7")
+
+        return self._save_diagram(dot, output_format)
+
+    def _render_timing(self, output_format: str) -> str:
+        if not self.elements:
+            raise ValueError("At least one element is required for timing diagram")
+        fig, ax = plt.subplots(figsize=(12, len(self.elements) * 1.5))
+        y_ticks, y_labels = [], []
+        for idx, element in enumerate(self.elements):
+            name = element["name"]
+            states = element.get("states", [])
+
+            # Handle string format: "state1:0-10,state2:10-20"
+            if isinstance(states, str):
+                parsed_states = []
+                for state_str in states.split(","):
+                    if ":" in state_str and "-" in state_str:
+                        state_name, time_range = state_str.strip().split(":")
+                        start_str, end_str = time_range.split("-")
+                        parsed_states.append(
+                            {"state": state_name.strip(), "start": int(start_str.strip()), "end": int(end_str.strip())}
+                        )
+                states = parsed_states
+
+            color_cycle = plt.cm.tab20.colors
+            for state_idx, state in enumerate(states):
+                start, end = state.get("start"), state.get("end")
+                label = state.get("state", "")
+                if start is None or end is None:
+                    continue
+                ax.broken_barh(
+                    [(start, end - start)],
+                    (idx - 0.4, 0.8),
+                    facecolors=color_cycle[state_idx % len(color_cycle)],
+                    edgecolor="black",
+                )
+                ax.text(start + (end - start) / 2, idx, label, ha="center", va="center", fontsize=9)
+            y_ticks.append(idx)
+            y_labels.append(name)
+        ax.set_xlabel("Time")
+        ax.set_yticks(y_ticks)
+        ax.set_yticklabels(y_labels)
+        ax.set_title(self.title, fontsize=14, fontweight="bold")
+        ax.grid(True, axis="x", linestyle="--", alpha=0.5)
+        output_path = save_diagram_to_directory(self.title, output_format)
+        plt.tight_layout()
+        plt.savefig(output_path, dpi=300, bbox_inches="tight")
+        plt.close()
+        open_diagram(output_path)
+        return output_path
+
+    # Helper methods for UML diagrams
+
+    def _format_visibility(self, member: Union[str, Dict]) -> str:
+        if isinstance(member, str):
+            return member
+        visibility = member.get("visibility", "public")
+        name = member.get("name", "")
+        member_type = member.get("type", "")
+        marker = {"public": "+", "private": "-", "protected": "#", "package": "~"}.get(visibility, "+")
+        if member_type:
+            return f"{marker} {name}: {member_type}"
+        return f"{marker} {name}"
+
+    def _add_class_relationship(self, dot: graphviz.Digraph, rel: Dict):
+        """Add class diagram relationships with proper notation"""
+        rel_type = rel.get("type", "association")
+        if rel_type == "inheritance":
+            dot.edge(rel["from"], rel["to"], arrowhead="empty")
+        elif rel_type == "composition":
+            dot.edge(rel["from"], rel["to"], arrowhead="diamond", style="filled")
+        elif rel_type == "aggregation":
+            dot.edge(rel["from"], rel["to"], arrowhead="diamond")
+        elif rel_type == "dependency":
+            dot.edge(rel["from"], rel["to"], style="dashed", arrowhead="open")
+        else:  # association
+            multiplicity = rel.get("multiplicity", "")
+            dot.edge(rel["from"], rel["to"], label=multiplicity)
+
+    def _render_text(self, output_format: str) -> str:
+        """Handle text formats (mermaid/ascii) for UML diagrams"""
+        raise NotImplementedError(
+            "Mermaid and ASCII rendering has been removed. "
+            "Use the agent's LLM capabilities to generate mermaid code directly."
+        )
+
+    def _save_diagram(self, dot: graphviz.Digraph, output_format: str) -> str:
+        """Save diagram and return file path"""
+        output_path = save_diagram_to_directory(self.title, "")
+        rendered_path = dot.render(filename=output_path, format=output_format, cleanup=False)
+        open_diagram(rendered_path)
+        return rendered_path
+
+
+def save_diagram_to_directory(title: str, extension: str, content: str = None) -> str:
+    """Helper function to save diagrams to the diagrams directory
+
+    Args:
+        title: Base filename for the diagram
+        extension: File extension (with or without dot)
+        content: Text content to write (for text-based formats)
+
+    Returns:
+        Full path to the saved file
+    """
+    diagrams_dir = os.path.join(os.getcwd(), "diagrams")
+    os.makedirs(diagrams_dir, exist_ok=True)
+
+    # Ensure extension starts with dot
+    if not extension.startswith("."):
+        extension = "." + extension
+
+    output_path = os.path.join(diagrams_dir, f"{title}{extension}")
+
+    # Write content if provided (for text-based formats)
+    if content is not None:
+        with open(output_path, "w") as f:
+            f.write(content)
+
+    return output_path
+
+
+def open_diagram(file_path: str) -> None:
+    """Helper function to open diagram files across different operating systems"""
+    if not os.path.exists(file_path):
+        logging.error(f"Cannot open diagram: file does not exist: {file_path}")
+        return
+
+    try:
+        system = platform.system()
+        if system == "Darwin":
+            subprocess.Popen(["open", file_path], start_new_session=True)
+        elif system == "Windows":
+            os.startfile(file_path)
+        else:
+            subprocess.Popen(["xdg-open", file_path], start_new_session=True)
+        logging.info(f"Opened diagram: {file_path}")
+    except FileNotFoundError:
+        logging.error(f"System command not found for opening files on {system}")
+    except subprocess.SubprocessError as e:
+        logging.error(f"Failed to open diagram {file_path}: {e}")
+    except Exception as e:
+        logging.error(f"Unexpected error opening diagram {file_path}: {e}")
+
+
+@tool
+def diagram(
+    diagram_type: str,
+    nodes: List[Dict[str, str]] = None,
+    edges: List[Dict[str, Union[str, int]]] = None,
+    output_format: str = "png",
+    title: str = "diagram",
+    style: Dict[str, str] = None,
+    elements: List[Dict[str, str]] = None,
+    relationships: List[Dict[str, Union[str, int]]] = None,
+) -> str:
+    """Create diagrams including AWS cloud diagrams and all 14 UML diagram types.
+
+    Args:
+        diagram_type: Type of diagram - Basic: "cloud", "graph", "network" | UML: "class", "object", "component",
+                     "deployment", "package", "profile", "composite_structure", "use_case", "activity",
+                     "state_machine", "sequence", "communication", "interaction_overview", "timing"
+        nodes: For basic diagrams - List of node objects with "id" (required), "label", and "type" (AWS service name)
+        edges: For basic diagrams - List of edge objects with "from", "to", optional "label", "order" (int)
+        elements: For UML diagrams - List of UML elements with "name" (required), "type", and type-specific properties
+        relationships: For UML diagrams - List of UML relationships between elements
+        output_format: Output format ("png", "svg", "pdf")
+            - For mermaid diagrams, use the agent's LLM capabilities to generate mermaid code directly
+            - Example: "Generate mermaid code for a class diagram with User and Order classes"
+        title: Title of the diagram
+        style: Style parameters (e.g., {"rankdir": "LR"} for left-to-right layout)
+
+    Note:
+        For STATE MACHINE diagrams: Include an initial state (start point) and final state(s) (end points)
+        in your elements to create proper UML state machine notation.
+
+        For ACTIVITY diagrams: Include a start node (initial) and end node (final) in your elements
+        to show the complete workflow process from beginning to completion.
+
+        For COMPOSITE STRUCTURE diagrams: Add "multiplicity" field to elements and
+        "multiplicity_source"/"multiplicity_target" to relationships for proper UML notation
+        (e.g., "1", "*", "0..1").
+
+        For OBJECT diagrams: Use "class" field for object type and "attributes" string for attribute values
+        (e.g., {"name": "john", "class": "Customer", "attributes": "name = John Doe\nID = 12345"}).
+
+        For TIMING diagrams: Use "states" string with format "state1:start-end,state2:start-end"
+        (e.g., {"name": "microwave", "states": "Idle:0-10,Opening:10-15,Heating:15-30"}).
+
+    Returns:
+        Path to the created diagram file
+    """
+    try:
+        # UML diagram types
+        uml_types = [
+            "class",
+            "object",
+            "component",
+            "deployment",
+            "package",
+            "profile",
+            "composite_structure",
+            "use_case",
+            "activity",
+            "state_machine",
+            "sequence",
+            "communication",
+            "interaction_overview",
+            "timing",
+        ]
+
+        if diagram_type in uml_types:
+            if not elements:
+                return "Error: 'elements' parameter is required for UML diagrams"
+            builder = UMLDiagramBuilder(diagram_type, elements, relationships, title, style)
+            output_path = builder.render(output_format)
+            return f"Created {diagram_type} UML diagram: {output_path}"
+        else:
+            if not nodes:
+                return "Error: 'nodes' parameter is required for basic diagrams"
+            builder = DiagramBuilder(nodes, edges, title, style)
+            output_path = builder.render(diagram_type, output_format)
+            return f"Created {diagram_type} diagram: {output_path}"
+    except Exception as e:
+        return f"Error creating diagram: {str(e)}"

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -17,27 +17,6 @@ from strands_tools.diagram import (
 class TestGetAwsNode:
     """Tests for the get_aws_node function."""
 
-    def test_get_aws_node_internet_component(self):
-        """Test retrieving the Internet component from onprem.network."""
-        with patch("importlib.import_module") as mock_import:
-            # First mock the main diagrams module (which fails)
-            main_module = MagicMock(spec=[])
-            # Then mock the onprem.network module (which succeeds)
-            onprem_module = MagicMock()
-            onprem_module.Internet = "InternetClass"
-
-            def side_effect(module_name):
-                if module_name == "diagrams":
-                    return main_module
-                elif module_name == "diagrams.onprem.network":
-                    return onprem_module
-                raise ImportError(f"Mock import error: {module_name}")
-
-            mock_import.side_effect = side_effect
-
-            result = get_aws_node("Internet")
-            assert result == "InternetClass"
-
     def test_get_aws_node_case_insensitive_match(self):
         """Test retrieving a node with case-insensitive matching."""
         with patch("importlib.import_module") as mock_import:
@@ -149,12 +128,6 @@ class TestDiagramBuilder:
         with pytest.raises(ValueError) as excinfo:
             self.builder.render("unsupported", "png")
         assert "Unsupported diagram type: unsupported" in str(excinfo.value)
-
-    def test_render_unsupported_format(self):
-        """Test rendering with unsupported output format."""
-        with pytest.raises(NotImplementedError) as excinfo:
-            self.builder.render("graph", "mermaid")
-        assert "Mermaid and ASCII rendering has been removed" in str(excinfo.value)
 
     @patch("strands_tools.diagram.save_diagram_to_directory")
     @patch("strands_tools.diagram.open_diagram")
@@ -289,12 +262,6 @@ class TestUMLDiagramBuilder:
         with pytest.raises(ValueError) as excinfo:
             builder.render("png")
         assert "Unsupported UML diagram type: unsupported" in str(excinfo.value)
-
-    def test_render_unsupported_format(self):
-        """Test rendering with unsupported output format."""
-        with pytest.raises(NotImplementedError) as excinfo:
-            self.builder.render("mermaid")
-        assert "Mermaid and ASCII rendering has been removed" in str(excinfo.value)
 
     @patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram")
     def test_render_class(self, mock_save):

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -1,0 +1,804 @@
+"""Tests for the diagram module."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from strands_tools.diagram import (
+    DiagramBuilder,
+    UMLDiagramBuilder,
+    diagram,
+    get_aws_node,
+    open_diagram,
+    save_diagram_to_directory,
+)
+
+
+class TestGetAwsNode:
+    """Tests for the get_aws_node function."""
+
+    def test_get_aws_node_internet_component(self):
+        """Test retrieving the Internet component from onprem.network."""
+        with patch("importlib.import_module") as mock_import:
+            # First mock the main diagrams module (which fails)
+            main_module = MagicMock(spec=[])
+            # Then mock the onprem.network module (which succeeds)
+            onprem_module = MagicMock()
+            onprem_module.Internet = "InternetClass"
+
+            def side_effect(module_name):
+                if module_name == "diagrams":
+                    return main_module
+                elif module_name == "diagrams.onprem.network":
+                    return onprem_module
+                raise ImportError(f"Mock import error: {module_name}")
+
+            mock_import.side_effect = side_effect
+
+            result = get_aws_node("Internet")
+            assert result == "InternetClass"
+
+    def test_get_aws_node_case_insensitive_match(self):
+        """Test retrieving a node with case-insensitive matching."""
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock(spec=["Lambda"])
+            mock_module.Lambda = "LambdaClass"
+
+            def side_effect(module_name):
+                if module_name == "diagrams.aws.compute":
+                    return mock_module
+                return MagicMock(spec=[])
+
+            mock_import.side_effect = side_effect
+
+            # Should find Lambda even with different case
+            result = get_aws_node("lambda")
+            assert result == "LambdaClass"
+
+
+class TestSaveDiagramToDirectory:
+    """Tests for the save_diagram_to_directory function."""
+
+    def test_save_diagram_to_directory_without_content(self, tmp_path):
+        """Test saving a diagram without content."""
+        with patch("os.getcwd", return_value=str(tmp_path)):
+            result = save_diagram_to_directory("test_diagram", "png")
+            expected_path = os.path.join(tmp_path, "diagrams", "test_diagram.png")
+            assert result == expected_path
+            assert os.path.exists(os.path.dirname(result))
+
+    def test_save_diagram_to_directory_with_content(self, tmp_path):
+        """Test saving a diagram with content."""
+        with patch("os.getcwd", return_value=str(tmp_path)):
+            result = save_diagram_to_directory("test_diagram", "txt", "Test content")
+            expected_path = os.path.join(tmp_path, "diagrams", "test_diagram.txt")
+            assert result == expected_path
+            assert os.path.exists(result)
+            with open(result, "r") as f:
+                assert f.read() == "Test content"
+
+
+class TestOpenDiagram:
+    """Tests for the open_diagram function."""
+
+    def test_open_diagram_file_not_exists(self, caplog):
+        """Test opening a non-existent diagram."""
+        open_diagram("non_existent_file.png")
+        assert "Cannot open diagram: file does not exist" in caplog.text
+
+    @patch("os.path.exists", return_value=True)
+    def test_open_diagram_macos(self, mock_exists, caplog):
+        """Test opening a diagram on macOS."""
+        with patch("platform.system", return_value="Darwin"):
+            with patch("subprocess.Popen") as mock_popen:
+                with patch("logging.info") as mock_log:
+                    open_diagram("test_diagram.png")
+                    mock_popen.assert_called_once_with(["open", "test_diagram.png"], start_new_session=True)
+                    mock_log.assert_called_once_with("Opened diagram: test_diagram.png")
+
+    @patch("os.path.exists", return_value=True)
+    def test_open_diagram_windows(self, mock_exists, caplog):
+        """Test opening a diagram on Windows."""
+        with patch("platform.system", return_value="Windows"):
+            # Skip the actual startfile call since it's not available on macOS
+            with patch("strands_tools.diagram.os") as mock_os:
+                mock_startfile = MagicMock()
+                mock_os.startfile = mock_startfile
+                with patch("logging.info") as mock_log:
+                    open_diagram("test_diagram.png")
+                    mock_startfile.assert_called_once_with("test_diagram.png")
+                    mock_log.assert_called_once_with("Opened diagram: test_diagram.png")
+
+    @patch("os.path.exists", return_value=True)
+    def test_open_diagram_linux(self, mock_exists, caplog):
+        """Test opening a diagram on Linux."""
+        with patch("platform.system", return_value="Linux"):
+            with patch("subprocess.Popen") as mock_popen:
+                with patch("logging.info") as mock_log:
+                    open_diagram("test_diagram.png")
+                    mock_popen.assert_called_once_with(["xdg-open", "test_diagram.png"], start_new_session=True)
+                    mock_log.assert_called_once_with("Opened diagram: test_diagram.png")
+
+    @patch("os.path.exists", return_value=True)
+    def test_open_diagram_error(self, mock_exists, caplog):
+        """Test error handling when opening a diagram."""
+        with patch("platform.system", return_value="Darwin"):
+            with patch("subprocess.Popen", side_effect=FileNotFoundError("Command not found")):
+                open_diagram("test_diagram.png")
+                assert "System command not found for opening files" in caplog.text
+
+
+class TestDiagramBuilder:
+    """Tests for the DiagramBuilder class."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.nodes = [{"id": "node1", "label": "Node 1"}, {"id": "node2", "label": "Node 2"}]
+        self.edges = [{"from": "node1", "to": "node2", "label": "connects to"}]
+        self.builder = DiagramBuilder(self.nodes, self.edges, "Test Diagram")
+
+    def test_init(self):
+        """Test initialization of DiagramBuilder."""
+        assert self.builder.nodes == self.nodes
+        assert self.builder.edges == self.edges
+        assert self.builder.title == "Test Diagram"
+        assert self.builder.style == {}
+
+    def test_render_unsupported_type(self):
+        """Test rendering with unsupported diagram type."""
+        with pytest.raises(ValueError) as excinfo:
+            self.builder.render("unsupported", "png")
+        assert "Unsupported diagram type: unsupported" in str(excinfo.value)
+
+    def test_render_unsupported_format(self):
+        """Test rendering with unsupported output format."""
+        with pytest.raises(NotImplementedError) as excinfo:
+            self.builder.render("graph", "mermaid")
+        assert "Mermaid and ASCII rendering has been removed" in str(excinfo.value)
+
+    @patch("strands_tools.diagram.save_diagram_to_directory")
+    @patch("strands_tools.diagram.open_diagram")
+    @patch("graphviz.Digraph.render")
+    def test_render_graph(self, mock_render, mock_open, mock_save):
+        """Test rendering a graph diagram."""
+        mock_save.return_value = "test_path"
+        mock_render.return_value = "test_path.png"
+
+        result = self.builder.render("graph", "png")
+
+        assert result == "test_path.png"
+        mock_save.assert_called_once()
+        mock_render.assert_called_once()
+        mock_open.assert_called_once_with("test_path.png")
+
+    @patch("strands_tools.diagram.save_diagram_to_directory")
+    @patch("strands_tools.diagram.open_diagram")
+    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.figure")
+    @patch("networkx.spring_layout")
+    @patch("networkx.draw_networkx_nodes")
+    @patch("networkx.draw_networkx_edges")
+    @patch("networkx.draw_networkx_labels")
+    @patch("networkx.draw_networkx_edge_labels")
+    def test_render_network(
+        self,
+        mock_edge_labels,
+        mock_labels,
+        mock_edges,
+        mock_nodes,
+        mock_layout,
+        mock_figure,
+        mock_savefig,
+        mock_open,
+        mock_save,
+    ):
+        """Test rendering a network diagram."""
+        mock_save.return_value = "test_path.png"
+        mock_layout.return_value = {node["id"]: [0, 0] for node in self.nodes}
+
+        # Create edges without labels to avoid the networkx issue
+        builder = DiagramBuilder(self.nodes, [{"from": "node1", "to": "node2"}], "Test Diagram")
+
+        result = builder.render("network", "png")
+
+        assert result == "test_path.png"
+        mock_save.assert_called_once()
+        mock_savefig.assert_called_once()
+        mock_open.assert_called_once_with("test_path.png")
+        # Verify other mocks were used (even if we don't check specific calls)
+        assert mock_figure.called
+        assert mock_nodes.called
+        assert mock_edges.called
+        assert mock_labels.called
+
+    @patch("strands_tools.diagram.save_diagram_to_directory")
+    @patch("strands_tools.diagram.open_diagram")
+    @patch("strands_tools.diagram.CloudDiagram")
+    @patch("strands_tools.diagram.get_aws_node")
+    def test_render_cloud(self, mock_get_aws_node, mock_cloud_diagram, mock_open, mock_save):
+        """Test rendering a cloud diagram."""
+        mock_save.return_value = "test_path"
+        mock_get_aws_node.return_value = MagicMock()
+
+        # Create a context manager mock for CloudDiagram
+        mock_cm = MagicMock()
+        mock_cloud_diagram.return_value = mock_cm
+
+        nodes = [{"id": "ec2", "type": "EC2"}, {"id": "s3", "type": "S3"}]
+        edges = [{"from": "ec2", "to": "s3"}]
+        builder = DiagramBuilder(nodes, edges, "Cloud Diagram")
+
+        result = builder.render("cloud", "png")
+
+        assert result == "test_path.png"
+        mock_save.assert_called_once()
+        mock_cloud_diagram.assert_called_once()
+        mock_open.assert_called_once_with("test_path.png")
+        mock_get_aws_node.assert_called()
+
+    def test_render_cloud_no_nodes(self):
+        """Test rendering a cloud diagram with no nodes."""
+        builder = DiagramBuilder([], [], "Empty Cloud")
+        with pytest.raises(ValueError) as excinfo:
+            builder.render("cloud", "png")
+        assert "At least one node is required for cloud diagram" in str(excinfo.value)
+
+    def test_render_cloud_invalid_node(self):
+        """Test rendering a cloud diagram with invalid node type."""
+        nodes = [{"id": "invalid", "type": "NonExistentService"}]
+        builder = DiagramBuilder(nodes, [], "Invalid Cloud")
+
+        with patch("strands_tools.diagram.get_aws_node", side_effect=ValueError("Component not found")):
+            with pytest.raises(ValueError) as excinfo:
+                builder.render("cloud", "png")
+            assert "Invalid AWS component types found" in str(excinfo.value)
+
+    def test_render_cloud_missing_node_id(self):
+        """Test rendering a cloud diagram with a node missing an ID."""
+        nodes = [{"type": "EC2"}]  # Missing 'id' field
+        builder = DiagramBuilder(nodes, [], "Missing ID")
+
+        with pytest.raises(ValueError) as excinfo:
+            builder.render("cloud", "png")
+        assert "Node missing required 'id' field" in str(excinfo.value)
+
+
+class TestUMLDiagramBuilder:
+    """Tests for the UMLDiagramBuilder class."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.elements = [
+            {"name": "Class1", "attributes": ["attr1", "attr2"], "methods": ["method1", "method2"]},
+            {"name": "Class2", "attributes": ["attr3"], "methods": ["method3"]},
+        ]
+        self.relationships = [{"from": "Class1", "to": "Class2", "type": "inheritance"}]
+        self.builder = UMLDiagramBuilder("class", self.elements, self.relationships, "Test UML")
+
+    def test_init(self):
+        """Test initialization of UMLDiagramBuilder."""
+        assert self.builder.diagram_type == "class"
+        assert self.builder.elements == self.elements
+        assert self.builder.relationships == self.relationships
+        assert self.builder.title == "Test UML"
+        assert self.builder.style == {}
+
+    def test_render_unsupported_type(self):
+        """Test rendering with unsupported UML diagram type."""
+        builder = UMLDiagramBuilder("unsupported", self.elements)
+        with pytest.raises(ValueError) as excinfo:
+            builder.render("png")
+        assert "Unsupported UML diagram type: unsupported" in str(excinfo.value)
+
+    def test_render_unsupported_format(self):
+        """Test rendering with unsupported output format."""
+        with pytest.raises(NotImplementedError) as excinfo:
+            self.builder.render("mermaid")
+        assert "Mermaid and ASCII rendering has been removed" in str(excinfo.value)
+
+    @patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram")
+    def test_render_class(self, mock_save):
+        """Test rendering a class diagram."""
+        mock_save.return_value = "test_path.png"
+
+        result = self.builder.render("png")
+
+        assert result == "test_path.png"
+        mock_save.assert_called_once()
+
+    @patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram")
+    def test_render_component(self, mock_save):
+        """Test rendering a component diagram."""
+        mock_save.return_value = "test_path.png"
+
+        elements = [
+            {"name": "Component1", "type": "component"},
+            {"name": "Interface1", "type": "interface", "provided": True},
+        ]
+        relationships = [{"from": "Component1", "to": "Interface1", "type": "realization"}]
+        builder = UMLDiagramBuilder("component", elements, relationships)
+
+        result = builder.render("png")
+
+        assert result == "test_path.png"
+        mock_save.assert_called_once()
+
+    @patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram")
+    def test_render_use_case(self, mock_save):
+        """Test rendering a use case diagram."""
+        mock_save.return_value = "test_path.png"
+
+        elements = [{"name": "User", "type": "actor"}, {"name": "Login", "type": "use_case"}]
+        relationships = [{"from": "User", "to": "Login"}]
+        builder = UMLDiagramBuilder("use_case", elements, relationships)
+
+        result = builder.render("png")
+
+        assert result == "test_path.png"
+        mock_save.assert_called_once()
+
+    @patch("strands_tools.diagram.plt.savefig")
+    @patch("strands_tools.diagram.open_diagram")
+    @patch("strands_tools.diagram.save_diagram_to_directory")
+    def test_render_sequence(self, mock_save, mock_open, mock_savefig):
+        """Test rendering a sequence diagram."""
+        mock_save.return_value = "test_path.png"
+
+        elements = [{"name": "Object1"}, {"name": "Object2"}]
+        relationships = [
+            {"from": "Object1", "to": "Object2", "message": "request()", "sequence": 1},
+            {"from": "Object2", "to": "Object1", "message": "response()", "sequence": 2},
+        ]
+        builder = UMLDiagramBuilder("sequence", elements, relationships)
+
+        result = builder.render("png")
+
+        assert result == "test_path.png"
+        mock_save.assert_called_once()
+        mock_savefig.assert_called_once()
+        mock_open.assert_called_once_with("test_path.png")
+
+    def test_render_sequence_no_elements(self):
+        """Test rendering a sequence diagram with no elements."""
+        builder = UMLDiagramBuilder("sequence", [], [])
+        with pytest.raises(ValueError) as excinfo:
+            builder.render("png")
+        assert "At least one element is required for sequence diagram" in str(excinfo.value)
+
+    @patch("strands_tools.diagram.plt.savefig")
+    @patch("strands_tools.diagram.open_diagram")
+    @patch("strands_tools.diagram.save_diagram_to_directory")
+    def test_render_timing(self, mock_save, mock_open, mock_savefig):
+        """Test rendering a timing diagram."""
+        mock_save.return_value = "test_path.png"
+
+        elements = [
+            {
+                "name": "Signal1",
+                "states": [{"state": "High", "start": 0, "end": 5}, {"state": "Low", "start": 5, "end": 10}],
+            },
+            {"name": "Signal2", "states": "High:0-3,Low:3-10"},
+        ]
+        builder = UMLDiagramBuilder("timing", elements)
+
+        result = builder.render("png")
+
+        assert result == "test_path.png"
+        mock_save.assert_called_once()
+        mock_savefig.assert_called_once()
+        mock_open.assert_called_once_with("test_path.png")
+
+    def test_format_visibility(self):
+        """Test the _format_visibility method."""
+        # Test with string input
+        assert self.builder._format_visibility("testMethod()") == "testMethod()"
+
+        # Test with dict input - public visibility
+        member = {"name": "testAttr", "visibility": "public", "type": "int"}
+        assert self.builder._format_visibility(member) == "+ testAttr: int"
+
+        # Test with dict input - private visibility
+        member = {"name": "testAttr", "visibility": "private", "type": "int"}
+        assert self.builder._format_visibility(member) == "- testAttr: int"
+
+        # Test with dict input - no type
+        member = {"name": "testAttr", "visibility": "protected"}
+        assert self.builder._format_visibility(member) == "# testAttr"
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", "test_diagram.py"])
+
+
+class TestDiagramBuilderAdditional:
+    """Additional tests for DiagramBuilder class."""
+
+    def test_render_cloud_with_edge_errors(self):
+        """Test rendering a cloud diagram with edge errors."""
+        nodes = [{"id": "ec2", "type": "EC2"}, {"id": "s3", "type": "S3"}]
+        edges = [
+            {"from": "ec2", "to": "s3"},  # Valid edge
+            {"from": "ec2"},  # Missing 'to'
+            {"to": "s3"},  # Missing 'from'
+            {"from": "nonexistent", "to": "s3"},  # Non-existent source
+            {"from": "ec2", "to": "nonexistent"},  # Non-existent target
+        ]
+
+        builder = DiagramBuilder(nodes, edges, "Cloud Diagram")
+
+        with (
+            patch("strands_tools.diagram.save_diagram_to_directory") as mock_save,
+            patch("strands_tools.diagram.open_diagram") as mock_open,
+            patch("strands_tools.diagram.CloudDiagram") as mock_cloud_diagram,
+            patch("strands_tools.diagram.get_aws_node") as mock_get_aws_node,
+            patch("logging.warning") as mock_warning,
+        ):
+            mock_save.return_value = "test_path"
+            mock_get_aws_node.return_value = MagicMock()
+            mock_cm = MagicMock()
+            mock_cloud_diagram.return_value = mock_cm
+
+            result = builder.render("cloud", "png")
+
+            assert result == "test_path.png"
+            # Check that warnings were logged for the invalid edges
+            assert mock_warning.call_count == 4
+            # Verify other mocks were used
+            assert mock_save.called
+            assert mock_cloud_diagram.called
+            assert mock_open.called
+            assert mock_get_aws_node.called
+
+    def test_render_graph_with_aws_types(self):
+        """Test rendering a graph diagram with AWS service types."""
+        nodes = [
+            {"id": "ec2", "type": "EC2", "label": "EC2 Instance"},
+            {"id": "s3", "label": "S3 Bucket"},  # No type specified
+        ]
+        edges = [{"from": "ec2", "to": "s3", "label": "stores data"}]
+
+        builder = DiagramBuilder(nodes, edges, "Graph Diagram")
+
+        with (
+            patch("strands_tools.diagram.save_diagram_to_directory") as mock_save,
+            patch("strands_tools.diagram.open_diagram") as mock_open,
+            patch("graphviz.Digraph.render") as mock_render,
+            patch("strands_tools.diagram.get_aws_node") as mock_get_aws_node,
+        ):
+            mock_save.return_value = "test_path"
+            mock_render.return_value = "test_path.png"
+            mock_get_aws_node.return_value = MagicMock()
+
+            result = builder.render("graph", "png")
+
+            assert result == "test_path.png"
+            # Check that get_aws_node was called for the node with type
+            mock_get_aws_node.assert_called_once_with("EC2")
+            # Verify other mocks were used
+            assert mock_save.called
+            assert mock_render.called
+            assert mock_open.called
+
+    def test_render_graph_with_invalid_aws_type(self):
+        """Test rendering a graph diagram with an invalid AWS service type."""
+        nodes = [{"id": "invalid", "type": "NonExistentService"}]
+        builder = DiagramBuilder(nodes, [], "Invalid Graph")
+
+        with (
+            patch("strands_tools.diagram.save_diagram_to_directory") as mock_save,
+            patch("strands_tools.diagram.open_diagram") as mock_open,
+            patch("graphviz.Digraph.render") as mock_render,
+            patch("strands_tools.diagram.get_aws_node") as mock_get_aws_node,
+        ):
+            mock_save.return_value = "test_path"
+            mock_render.return_value = "test_path.png"
+            mock_get_aws_node.side_effect = ValueError("Component not found")
+
+            # Should not raise an error, just skip AWS-specific handling
+            result = builder.render("graph", "png")
+            assert result == "test_path.png"
+            # Verify mocks were used
+            assert mock_save.called
+            assert mock_render.called
+            assert mock_open.called
+            assert mock_get_aws_node.called
+
+    def test_render_network_with_aws_service_categories(self):
+        """Test rendering a network diagram with AWS service categories for coloring."""
+        nodes = [
+            {"id": "ec2", "type": "EC2"},  # compute
+            {"id": "rds", "type": "RDS"},  # database
+            {"id": "vpc", "type": "VPC"},  # network
+            {"id": "s3", "type": "S3"},  # storage
+            {"id": "iam", "type": "IAM"},  # security
+            {"id": "unknown", "type": "UnknownService"},  # default color
+            {"id": "noType"},  # no type specified
+        ]
+        edges = [{"from": "ec2", "to": "rds"}]
+
+        builder = DiagramBuilder(nodes, edges, "Network Diagram")
+
+        with (
+            patch("strands_tools.diagram.save_diagram_to_directory") as mock_save,
+            patch("strands_tools.diagram.open_diagram") as mock_open,
+            patch("matplotlib.pyplot.savefig") as mock_savefig,
+            patch("matplotlib.pyplot.figure") as mock_figure,
+            patch("networkx.spring_layout") as mock_layout,
+            patch("networkx.draw_networkx_nodes") as mock_nodes,
+            patch("networkx.draw_networkx_edges") as mock_edges,
+            patch("networkx.draw_networkx_labels") as mock_labels,
+            patch("strands_tools.diagram.get_aws_node") as mock_get_aws_node,
+        ):
+            mock_save.return_value = "test_path.png"
+            mock_layout.return_value = {node["id"]: [0, 0] for node in nodes}
+            mock_get_aws_node.return_value = MagicMock()
+
+            result = builder.render("network", "png")
+
+            assert result == "test_path.png"
+            # Should have called get_aws_node for each node with a type
+            assert mock_get_aws_node.call_count == 6
+            # Verify other mocks were used
+            assert mock_savefig.called
+            assert mock_figure.called
+            assert mock_nodes.called
+            assert mock_edges.called
+            assert mock_labels.called
+            assert mock_open.called
+
+
+class TestUMLDiagramBuilderAdditional:
+    """Additional tests for UMLDiagramBuilder class."""
+
+    def test_render_deployment(self):
+        """Test rendering a deployment diagram."""
+        elements = [{"name": "Server", "type": "node"}, {"name": "WebApp", "type": "artifact"}]
+        relationships = [{"from": "Server", "to": "WebApp", "label": "deploys"}]
+        builder = UMLDiagramBuilder("deployment", elements, relationships)
+
+        with patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram") as mock_save:
+            mock_save.return_value = "test_path.png"
+            result = builder.render("png")
+            assert result == "test_path.png"
+            mock_save.assert_called_once()
+
+    def test_render_package(self):
+        """Test rendering a package diagram."""
+        elements = [{"name": "UI", "type": "package"}, {"name": "Core", "type": "package"}]
+        relationships = [{"from": "UI", "to": "Core", "type": "dependency"}]
+        builder = UMLDiagramBuilder("package", elements, relationships)
+
+        with patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram") as mock_save:
+            mock_save.return_value = "test_path.png"
+            result = builder.render("png")
+            assert result == "test_path.png"
+            mock_save.assert_called_once()
+
+    def test_render_profile(self):
+        """Test rendering a profile diagram."""
+        elements = [
+            {"name": "CustomProfile", "stereotype": "profile"},
+            {"name": "Extension", "stereotype": "extension"},
+        ]
+        relationships = [{"from": "Extension", "to": "CustomProfile"}]
+        builder = UMLDiagramBuilder("profile", elements, relationships)
+
+        with patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram") as mock_save:
+            mock_save.return_value = "test_path.png"
+            result = builder.render("png")
+            assert result == "test_path.png"
+            mock_save.assert_called_once()
+
+    def test_render_composite_structure(self):
+        """Test rendering a composite structure diagram."""
+        elements = [{"name": "Component", "type": "part"}, {"name": "Port", "type": "port", "owner": "Component"}]
+        relationships = [{"from": "Component", "to": "Port", "type": "delegation"}]
+        builder = UMLDiagramBuilder("composite_structure", elements, relationships)
+
+        with patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram") as mock_save:
+            mock_save.return_value = "test_path.png"
+            result = builder.render("png")
+            assert result == "test_path.png"
+            mock_save.assert_called_once()
+
+    def test_render_activity(self):
+        """Test rendering an activity diagram."""
+        elements = [
+            {"name": "Start", "type": "start"},
+            {"name": "Process", "type": "activity"},
+            {"name": "Decision", "type": "decision"},
+            {"name": "End", "type": "end"},
+        ]
+        relationships = [
+            {"from": "Start", "to": "Process"},
+            {"from": "Process", "to": "Decision"},
+            {"from": "Decision", "to": "End"},
+        ]
+        builder = UMLDiagramBuilder("activity", elements, relationships)
+
+        with patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram") as mock_save:
+            mock_save.return_value = "test_path.png"
+            result = builder.render("png")
+            assert result == "test_path.png"
+            mock_save.assert_called_once()
+
+    def test_render_state_machine(self):
+        """Test rendering a state machine diagram."""
+        elements = [
+            {"name": "Initial", "type": "initial"},
+            {"name": "State1", "type": "state"},
+            {"name": "State2", "type": "state"},
+            {"name": "Final", "type": "final"},
+        ]
+        relationships = [
+            {"from": "Initial", "to": "State1"},
+            {"from": "State1", "to": "State2", "event": "trigger", "action": "doSomething"},
+            {"from": "State2", "to": "Final"},
+        ]
+        builder = UMLDiagramBuilder("state_machine", elements, relationships)
+
+        with patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram") as mock_save:
+            mock_save.return_value = "test_path.png"
+            result = builder.render("png")
+            assert result == "test_path.png"
+            mock_save.assert_called_once()
+
+    def test_render_communication(self):
+        """Test rendering a communication diagram."""
+        elements = [{"name": "Client"}, {"name": "Server"}]
+        relationships = [{"from": "Client", "to": "Server", "sequence": "1", "message": "request()"}]
+        builder = UMLDiagramBuilder("communication", elements, relationships)
+
+        with patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram") as mock_save:
+            mock_save.return_value = "test_path.png"
+            result = builder.render("png")
+            assert result == "test_path.png"
+            mock_save.assert_called_once()
+
+    def test_render_interaction_overview(self):
+        """Test rendering an interaction overview diagram."""
+        elements = [
+            {"name": "Start", "type": "initial"},
+            {"name": "Interaction1", "type": "interaction"},
+            {"name": "Decision", "type": "decision"},
+            {"name": "End", "type": "final"},
+        ]
+        relationships = [
+            {"from": "Start", "to": "Interaction1"},
+            {"from": "Interaction1", "to": "Decision"},
+            {"from": "Decision", "to": "End", "guard": "condition", "label": "path"},
+        ]
+        builder = UMLDiagramBuilder("interaction_overview", elements, relationships)
+
+        with patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram") as mock_save:
+            mock_save.return_value = "test_path.png"
+            result = builder.render("png")
+            assert result == "test_path.png"
+            mock_save.assert_called_once()
+
+    def test_render_object(self):
+        """Test rendering an object diagram."""
+        elements = [
+            {"name": "user1", "class": "User", "attributes": {"name": "John", "age": 30}},
+            {"name": "order1", "class": "Order", "attributes": "id = 12345\ntotal = 99.99"},
+        ]
+        relationships = [{"from": "user1", "to": "order1", "label": "places"}]
+        builder = UMLDiagramBuilder("object", elements, relationships)
+
+        with patch("strands_tools.diagram.UMLDiagramBuilder._save_diagram") as mock_save:
+            mock_save.return_value = "test_path.png"
+            result = builder.render("png")
+            assert result == "test_path.png"
+            mock_save.assert_called_once()
+
+    def test_add_class_relationship(self):
+        """Test adding different types of class relationships."""
+        elements = [{"name": "Class1"}, {"name": "Class2"}]
+        builder = UMLDiagramBuilder("class", elements)
+
+        dot = MagicMock()
+
+        # Test inheritance relationship
+        builder._add_class_relationship(dot, {"from": "Class1", "to": "Class2", "type": "inheritance"})
+        dot.edge.assert_called_with("Class1", "Class2", arrowhead="empty")
+
+        # Test composition relationship
+        dot.reset_mock()
+        builder._add_class_relationship(dot, {"from": "Class1", "to": "Class2", "type": "composition"})
+        dot.edge.assert_called_with("Class1", "Class2", arrowhead="diamond", style="filled")
+
+        # Test aggregation relationship
+        dot.reset_mock()
+        builder._add_class_relationship(dot, {"from": "Class1", "to": "Class2", "type": "aggregation"})
+        dot.edge.assert_called_with("Class1", "Class2", arrowhead="diamond")
+
+        # Test dependency relationship
+        dot.reset_mock()
+        builder._add_class_relationship(dot, {"from": "Class1", "to": "Class2", "type": "dependency"})
+        dot.edge.assert_called_with("Class1", "Class2", style="dashed", arrowhead="open")
+
+        # Test association relationship with multiplicity
+        dot.reset_mock()
+        builder._add_class_relationship(dot, {"from": "Class1", "to": "Class2", "multiplicity": "1..*"})
+        dot.edge.assert_called_with("Class1", "Class2", label="1..*")
+
+
+class TestDiagramTool:
+    """Tests for the diagram tool function."""
+
+    def test_diagram_basic_graph(self):
+        """Test creating a basic graph diagram."""
+        nodes = [{"id": "node1", "label": "Node 1"}, {"id": "node2", "label": "Node 2"}]
+        edges = [{"from": "node1", "to": "node2"}]
+
+        with patch("strands_tools.diagram.DiagramBuilder") as mock_builder:
+            mock_instance = MagicMock()
+            mock_builder.return_value = mock_instance
+            mock_instance.render.return_value = "test_path.png"
+
+            result = diagram(diagram_type="graph", nodes=nodes, edges=edges)
+
+            mock_builder.assert_called_once_with(nodes, edges, "diagram", None)
+            mock_instance.render.assert_called_once_with("graph", "png")
+            assert "Created graph diagram" in result
+
+    def test_diagram_cloud(self):
+        """Test creating a cloud diagram."""
+        nodes = [{"id": "ec2", "type": "EC2"}, {"id": "s3", "type": "S3"}]
+        edges = [{"from": "ec2", "to": "s3"}]
+
+        with patch("strands_tools.diagram.DiagramBuilder") as mock_builder:
+            mock_instance = MagicMock()
+            mock_builder.return_value = mock_instance
+            mock_instance.render.return_value = "test_path.png"
+
+            result = diagram(diagram_type="cloud", nodes=nodes, edges=edges, title="AWS Architecture")
+
+            mock_builder.assert_called_once_with(nodes, edges, "AWS Architecture", None)
+            mock_instance.render.assert_called_once_with("cloud", "png")
+            assert "Created cloud diagram" in result
+
+    def test_diagram_uml_class(self):
+        """Test creating a UML class diagram."""
+        elements = [
+            {"name": "User", "attributes": ["name: string", "email: string"], "methods": ["login()", "logout()"]}
+        ]
+        relationships = []
+
+        with patch("strands_tools.diagram.UMLDiagramBuilder") as mock_builder:
+            mock_instance = MagicMock()
+            mock_builder.return_value = mock_instance
+            mock_instance.render.return_value = "test_path.png"
+
+            result = diagram(diagram_type="class", elements=elements, relationships=relationships, output_format="svg")
+
+            mock_builder.assert_called_once_with("class", elements, relationships, "diagram", None)
+            mock_instance.render.assert_called_once_with("svg")
+            assert "Created class UML diagram" in result
+
+    def test_diagram_missing_nodes(self):
+        """Test diagram with missing nodes for basic diagram."""
+        result = diagram(diagram_type="graph")
+        assert "Error: 'nodes' parameter is required for basic diagrams" in result
+
+    def test_diagram_missing_elements(self):
+        """Test diagram with missing elements for UML diagram."""
+        result = diagram(diagram_type="class")
+        assert "Error: 'elements' parameter is required for UML diagrams" in result
+
+    def test_diagram_error_handling(self):
+        """Test error handling in diagram function."""
+        nodes = [{"id": "node1"}]
+
+        with patch("strands_tools.diagram.DiagramBuilder") as mock_builder:
+            mock_instance = MagicMock()
+            mock_builder.return_value = mock_instance
+            mock_instance.render.side_effect = ValueError("Test error")
+
+            result = diagram(diagram_type="graph", nodes=nodes)
+
+            assert "Error creating diagram: Test error" in result
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", "test_diagram.py"])


### PR DESCRIPTION
## Description
This PR introduces a diagram creation tool that supports multiple diagram types and output formats, making it easier for agents to generate visual representations of systems, architectures, and processes.

- This tool can be used to generate some basic diagrams:
  - Cloud architecture diagrams (AWS services)
  - Network diagrams
  - Graph diagrams
- This tool can also be used to generate the 14 different UML (Unified Modeling Language) diagrams: 
  - Structural
    - Class
    - Composite Structure
    - Object
    - Component
    - Deployment
    - Package
    - Profile
  - Behavioral
    - State Machine
    - Activity
    - Use Case
    - Sequence
    - Communication
    - Timing
    - Interaction Overview 
- Multiple output formats supported:
  - Image formats (PNG, SVG, PDF)
- Class-based architecture with DiagramBuilder and UMLDiagramBuilder
- This tool can be paired with the editor tool so an agent can look at code and generate diagrams illustrating how the code works
- If the user wants a Mermaid or ASCII diagram the tool reverts to the LLM's reasoning because these formats are well documented

## Related Issues
Closes #[104](https://github.com/strands-agents/private-sdk-python-staging/issues/104)

## Documentation PR
[Link to related associated PR in the agent-docs repo]

## Type of Change
- [ ] Bug fix
- [x] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
