### PR TITLE
feat: add configurable_swarm_phases feature

### DIFF
--- a/tests/test_swarm.py
+++ b/tests/test_swarm.py
@@ -206,6 +206,7 @@ def test_create_rich_status_panel():
     status = {
         "task": "Test task",
         "coordination_pattern": "collaborative",
+        "phases": 2,  # Add phases field
         "memory_id": "test-memory-id",
         "agents": [
             {"id": "agent1", "status": "completed", "contributions": 2},


### PR DESCRIPTION
## Description

Implements the configurable swarm phases feature, allowing users to pick between 1 and 5 iteration phases for the swarm system of agents.

## Related Issues

#128

## Documentation PR
[Link to related associated PR in the agent-docs repo]

## Type of Change
- [ ] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [x] Other (please describe): extension of an existing tool for more configurability.

## Testing

Did the full pytest suite, and linting with:

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
