### PR TITLE
fix(swarm):swarm tool cannot use the tools from parent Agent

### DIFF
--- a/src/strands_tools/swarm.py
+++ b/src/strands_tools/swarm.py
@@ -298,7 +298,7 @@ class SwarmAgent:
 
             # Construct focused collaborative prompt
             historical_knowledge_str = (
-                json.dumps(historical_knowledge, indent=2)
+                json.dumps(historical_knowledge, indent=2, ensure_ascii=False)
                 if historical_knowledge
                 else "No previous knowledge available yet."
             )
@@ -592,6 +592,7 @@ def swarm(tool: ToolUse, **kwargs: Any) -> ToolResult:
             "inference_config": inference_config,
             "messages": messages,
             "tool_config": tool_config,
+            "agent": kwargs.get("agent"),
         }
         if "callback_handler" in kwargs:
             tool_context["callback_handler"] = kwargs["callback_handler"]
@@ -653,7 +654,9 @@ Key Responsibilities:
 
         # Add collective knowledge
         collective_knowledge = swarm_instance.shared_memory.get_all_knowledge()
-        processed_results.append({"text": f"\n🌟 Collective Knowledge:\n{json.dumps(collective_knowledge, indent=2)}"})
+        processed_results.append(
+            {"text": f"\n🌟 Collective Knowledge:\n{json.dumps(collective_knowledge, indent=2,ensure_ascii=False)}"}
+        )
 
         return {
             "toolUseId": tool_use_id,


### PR DESCRIPTION
## Description
1. fix bug: swarm tool cannot use the tools from parent Agent
2. add ensure_ascii=False parameter for json.dumps() to ensure the non-english text displays properly

## Related Issues
#136 

## Documentation PR
[Link to related associated PR in the agent-docs repo]

## Type of Change
- [x] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`
yes


## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
