### PR TITLE
fix: fixed memory retrieve response

### DIFF
--- a/src/strands_tools/memory.py
+++ b/src/strands_tools/memory.py
@@ -494,6 +494,7 @@ class MemoryFormatter:
 
             result_text += f"\n\nScore: {score:.4f}"
             result_text += f"\nDocument ID: {doc_id}"
+            result_text += f"content_text: {text}"
 
             # Try to parse content as JSON for better display
             try:
@@ -506,10 +507,10 @@ class MemoryFormatter:
                 pass
 
             # Add content preview
-            preview = text[:150]
-            if len(text) > 150:
-                preview += "..."
-            result_text += f"\nContent Preview: {preview}"
+            # preview = text[:150]
+            # if len(text) > 150:
+            #     preview += "..."
+            # result_text += f"\nContent Preview: {preview}"
 
         content.append({"text": result_text})
 


### PR DESCRIPTION
## Description
fixes the issue with `format_retrieve_response` method to return whole response from memory(or knowledge base)

## Related Issues
[Link to related issues using #issue-number format]

## Documentation PR
[Link to related associated PR in the agent-docs repo]

## Type of Change
- [X] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
[How have you tested the change?] - Yes

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
