### PR TITLE
feat: Add handoff to user tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Below is a comprehensive table of all available tools, how to use them with an a
 | slack | `agent.tool.slack(action="post_message", channel="general", text="Hello team!")` | Interact with Slack workspace for messaging and monitoring |
 | speak | `agent.tool.speak(text="Operation completed successfully", style="green", mode="polly")` | Output status messages with rich formatting and optional text-to-speech |
 | stop | `agent.tool.stop(message="Process terminated by user request")` | Gracefully terminate agent execution with custom message |
+| handoff_to_user | `agent.tool.handoff_to_user(message="Please confirm action", breakout_of_loop=False)` | Hand off control to user for confirmation, input, or complete task handoff |
 | use_llm | `agent.tool.use_llm(prompt="Analyze this data", system_prompt="You are a data analyst")` | Create nested AI loops with customized system prompts for specialized tasks |
 | workflow | `agent.tool.workflow(action="create", name="data_pipeline", steps=[{"tool": "file_read"}, {"tool": "python_repl"}])` | Define, execute, and manage multi-step automated workflows |
 | batch| `agent.tool.batch(invocations=[{"name": "current_time", "arguments": {"timezone": "Europe/London"}}, {"name": "stop", "arguments": {}}])` | Call multiple other tools in parallel. |
@@ -329,6 +330,27 @@ result = agent.tool.use_browser(actions=[
     {"action": "click", "args": {"selector": ".next-page"}},
     {"action": "get_html", "args": {"selector": "main"}}
 ])
+```
+
+### Handoff to User
+
+```python
+from strands import Agent
+from strands_tools import handoff_to_user
+
+agent = Agent(tools=[handoff_to_user])
+
+# Request user confirmation and continue
+response = agent.tool.handoff_to_user(
+    message="I need your approval to proceed with deleting these files. Type 'yes' to confirm.",
+    breakout_of_loop=False
+)
+
+# Complete handoff to user (stops agent execution)
+agent.tool.handoff_to_user(
+    message="Task completed. Please review the results and take any necessary follow-up actions.",
+    breakout_of_loop=True
+)
 ```
 
 ### A2A Client

--- a/src/strands_tools/handoff_to_user.py
+++ b/src/strands_tools/handoff_to_user.py
@@ -1,0 +1,204 @@
+"""
+User handoff tool for Strands Agent.
+
+This module provides functionality to hand off control from the agent to the user,
+allowing for human intervention in automated workflows. It's particularly useful for:
+
+1. Getting user confirmation before proceeding with critical actions
+2. Requesting additional information that the agent cannot determine
+3. Allowing users to review and approve agent decisions
+4. Creating interactive workflows where human input is required
+5. Debugging and troubleshooting by pausing execution for user review
+
+Usage with Strands Agent:
+```python
+from strands import Agent
+from strands_tools import handoff_to_user
+
+agent = Agent(tools=[handoff_to_user])
+
+# Request user input and continue
+response = agent.tool.handoff_to_user(
+    message="I need your approval to proceed with deleting these files. Type 'yes' to confirm.",
+    breakout_of_loop=False
+)
+
+# Stop execution and hand off to user
+agent.tool.handoff_to_user(
+    message="Task completed. Please review the results and take any necessary follow-up actions.",
+    breakout_of_loop=True
+)
+```
+
+The handoff tool can either pause for user input or completely stop the event loop,
+depending on the breakout_of_loop parameter.
+"""
+
+import logging
+from typing import Any
+
+from strands.types.tools import ToolResult, ToolUse
+
+# Initialize logging
+logger = logging.getLogger(__name__)
+
+TOOL_SPEC = {
+    "name": "handoff_to_user",
+    "description": "Hand off control from agent to user for confirmation, input, or complete task handoff",
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "Message to display to the user with context and instructions",
+                },
+                "breakout_of_loop": {
+                    "type": "boolean",
+                    "description": "Whether to stop the event loop (True) or wait for user input (False)",
+                    "default": False,
+                },
+            },
+            "required": ["message"],
+        }
+    },
+}
+
+
+def handoff_to_user(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """
+    Hand off control from the agent to the user for human intervention.
+
+    This tool allows the agent to pause execution and request human input or approval.
+    It can either wait for user input and continue, or completely stop the event loop
+    to hand off control to the user.
+
+    How It Works:
+    ------------
+    1. Displays a clear indication that the agent is requesting user handoff
+    2. Shows the agent's message to the user (should include context and instructions)
+    3. If breakout_of_loop is True: Sets the stop_event_loop flag to terminate gracefully
+    4. If breakout_of_loop is False: Waits for user input and returns the response
+
+    Common Usage Scenarios:
+    ---------------------
+    - User confirmation: Get approval before executing critical operations
+    - Information gathering: Request additional details the agent cannot determine
+    - Decision points: Allow users to choose between multiple options
+    - Review and approval: Pause for user to review agent's work
+    - Interactive workflows: Create human-in-the-loop processes
+    - Debugging: Stop execution for troubleshooting and manual intervention
+
+    Args:
+        tool: The tool use object containing the tool input parameters
+            - message: The message to display to the user. Should include:
+                * Context about what the agent was doing
+                * What the agent needs from the user
+                * Clear instructions on how to respond
+                * Any relevant details for decision making
+            - breakout_of_loop: Whether to stop the event loop after displaying the message.
+                * True: Stop the event loop completely (agent hands off control)
+                * False: Wait for user input and continue with the response (default)
+        **kwargs: Additional keyword arguments
+            - request_state: Dictionary containing the current request state
+
+    Returns:
+        ToolResult containing:
+            - toolUseId: The unique identifier for this tool use request
+            - status: "success" or "error"
+            - content: List with result text
+                * If breakout_of_loop=True: Confirmation that handoff was initiated
+                * If breakout_of_loop=False: The user's input response
+
+    Examples:
+        # Request user confirmation
+        handoff_to_user({
+            "toolUseId": "123",
+            "input": {
+                "message": "I'm about to delete 5 files. Type 'confirm' to proceed or 'cancel' to stop.",
+                "breakout_of_loop": False
+            }
+        })
+
+        # Complete handoff to user
+        handoff_to_user({
+            "toolUseId": "456",
+            "input": {
+                "message": "Analysis complete. Results saved to report.pdf. Please review and distribute as needed.",
+                "breakout_of_loop": True
+            }
+        })
+
+    Notes:
+        - Always provide clear, actionable messages to users
+        - Use breakout_of_loop=True for final handoffs or when agent work is complete
+        - Use breakout_of_loop=False for mid-workflow user input
+        - The tool handles the technical details of event loop control
+        - This tool only affects the current event loop cycle, not the entire application
+        - The handoff is graceful, allowing current operations to complete
+    """
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+    request_state = kwargs.get("request_state", {})
+
+    # Extract parameters
+    message = tool_input.get("message", "Agent requesting user handoff")
+    breakout_of_loop = tool_input.get("breakout_of_loop", False)
+
+    # Display handoff notification
+    print("\n" + "=" * 60)
+    print("🤝 AGENT REQUESTING USER HANDOFF")
+    print("=" * 60)
+    print(f"\n{message}\n")
+
+    if breakout_of_loop:
+        # Stop the event loop and hand off control
+        request_state["stop_event_loop"] = True
+        print("🛑 Agent execution stopped. Control handed off to user.")
+        print("=" * 60 + "\n")
+
+        logger.info(f"Agent handoff initiated with message: {message}")
+
+        return {
+            "toolUseId": tool_use_id,
+            "status": "success",
+            "content": [{"text": f"Agent handoff completed. Message displayed to user: {message}"}],
+        }
+    else:
+        # Wait for user input and continue
+        print("⏳ Waiting for your response...")
+        print("-" * 40)
+
+        try:
+            user_response = input("Your response: ").strip()
+            print("=" * 60 + "\n")
+
+            logger.info(f"User handoff completed. User response: {user_response}")
+
+            return {
+                "toolUseId": tool_use_id,
+                "status": "success",
+                "content": [{"text": f"User response received: {user_response}"}],
+            }
+        except KeyboardInterrupt:
+            print("\n🛑 User interrupted. Stopping execution.")
+            print("=" * 60 + "\n")
+            request_state["stop_event_loop"] = True
+
+            logger.info("User interrupted handoff. Execution stopped.")
+
+            return {
+                "toolUseId": tool_use_id,
+                "status": "success",
+                "content": [{"text": "User interrupted handoff. Execution stopped."}],
+            }
+        except Exception as e:
+            logger.error(f"Error during user handoff: {e}")
+            print(f"❌ Error getting user input: {e}")
+            print("=" * 60 + "\n")
+
+            return {
+                "toolUseId": tool_use_id,
+                "status": "error",
+                "content": [{"text": f"Error during user handoff: {str(e)}"}],
+            }

--- a/tests/test_handoff_to_user.py
+++ b/tests/test_handoff_to_user.py
@@ -1,0 +1,181 @@
+"""Tests for the handoff_to_user tool."""
+
+from unittest.mock import patch
+
+import pytest
+from strands import Agent
+from strands_tools import handoff_to_user
+
+
+@pytest.fixture
+def agent():
+    """Create an agent with the handoff_to_user tool loaded."""
+    return Agent(tools=[handoff_to_user])
+
+
+@pytest.fixture
+def mock_request_state():
+    """Create a mock request state dictionary."""
+    return {}
+
+
+def extract_result_text(result):
+    """Extract the result text from the agent response."""
+    if isinstance(result, dict) and "content" in result and isinstance(result["content"], list):
+        return result["content"][0]["text"]
+    return str(result)
+
+
+def test_handoff_with_breakout_true_direct(mock_request_state):
+    """Test handoff with breakout_of_loop=True stops the event loop (direct call)."""
+    # Create a tool use dictionary similar to how the agent would call it
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {"message": "Task completed. Please review the results.", "breakout_of_loop": True},
+    }
+
+    # Call the handoff_to_user function directly with our mock request state
+    result = handoff_to_user.handoff_to_user(tool=tool_use, request_state=mock_request_state)
+
+    # Verify the result has the expected structure
+    assert result["toolUseId"] == "test-tool-use-id"
+    assert result["status"] == "success"
+    assert "Agent handoff completed" in result["content"][0]["text"]
+    assert "Task completed. Please review the results." in result["content"][0]["text"]
+
+    # Verify the stop_event_loop flag was set in request_state
+    assert mock_request_state.get("stop_event_loop") is True
+
+
+@patch("builtins.input", return_value="user response")
+def test_handoff_with_breakout_false_direct(mock_input, mock_request_state):
+    """Test handoff with breakout_of_loop=False waits for user input (direct call)."""
+    # Create a tool use dictionary
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {"message": "Please confirm the action.", "breakout_of_loop": False},
+    }
+
+    # Call the handoff_to_user function directly
+    result = handoff_to_user.handoff_to_user(tool=tool_use, request_state=mock_request_state)
+
+    # Verify input was called
+    mock_input.assert_called_once()
+
+    # Verify the result has the expected structure
+    assert result["toolUseId"] == "test-tool-use-id"
+    assert result["status"] == "success"
+    assert "user response" in result["content"][0]["text"]
+
+    # Verify the event loop stop flag is not set
+    assert mock_request_state.get("stop_event_loop") is not True
+
+
+@patch("builtins.input", side_effect=KeyboardInterrupt())
+def test_handoff_keyboard_interrupt_direct(mock_input, mock_request_state):
+    """Test handoff handles KeyboardInterrupt gracefully (direct call)."""
+    # Create a tool use dictionary
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {"message": "Please confirm the action.", "breakout_of_loop": False},
+    }
+
+    # Call the handoff_to_user function and expect KeyboardInterrupt to be handled
+    result = handoff_to_user.handoff_to_user(tool=tool_use, request_state=mock_request_state)
+
+    # Verify the event loop stop flag is set due to interruption
+    assert mock_request_state["stop_event_loop"] is True
+
+    # Verify the result indicates interruption
+    assert result["toolUseId"] == "test-tool-use-id"
+    assert result["status"] == "success"
+    assert "interrupted" in result["content"][0]["text"]
+
+
+def test_handoff_missing_request_state():
+    """Test handoff works even without request_state."""
+    # Create a tool use dictionary
+    tool_use = {"toolUseId": "test-tool-use-id", "input": {"message": "Task completed.", "breakout_of_loop": True}}
+
+    # Call the handoff_to_user function without request_state
+    result = handoff_to_user.handoff_to_user(tool=tool_use)
+
+    # Should still work and return success
+    assert result["toolUseId"] == "test-tool-use-id"
+    assert result["status"] == "success"
+    assert "Agent handoff completed" in result["content"][0]["text"]
+
+
+@patch("builtins.input", side_effect=Exception("Test error"))
+def test_handoff_input_error_direct(mock_input, mock_request_state):
+    """Test handoff handles input errors gracefully (direct call)."""
+    # Create a tool use dictionary
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {"message": "Please confirm the action.", "breakout_of_loop": False},
+    }
+
+    # Call the handoff_to_user function and expect exception to be handled
+    result = handoff_to_user.handoff_to_user(tool=tool_use, request_state=mock_request_state)
+
+    # Verify the result indicates error
+    assert result["toolUseId"] == "test-tool-use-id"
+    assert result["status"] == "error"
+    assert "Error during user handoff" in result["content"][0]["text"]
+
+
+def test_handoff_default_message():
+    """Test handoff with default message when none provided."""
+    # Create a tool use dictionary without message
+    tool_use = {"toolUseId": "test-tool-use-id", "input": {"breakout_of_loop": True}}
+
+    result = handoff_to_user.handoff_to_user(tool=tool_use)
+
+    assert result["status"] == "success"
+    assert "Agent requesting user handoff" in result["content"][0]["text"]
+
+
+def test_handoff_default_breakout_false():
+    """Test handoff defaults to breakout_of_loop=False when not specified."""
+    with patch("builtins.input", return_value="test response"):
+        tool_use = {"toolUseId": "test-tool-use-id", "input": {"message": "Test message"}}
+
+        result = handoff_to_user.handoff_to_user(tool=tool_use)
+
+        assert result["status"] == "success"
+        assert "test response" in result["content"][0]["text"]
+
+
+def test_handoff_via_agent(agent):
+    """Test handoff via the agent interface.
+
+    Note: This test is more for illustration; in a real environment,
+    handoff behavior would depend on actual user interaction.
+    """
+    # This is a simplified test that doesn't actually test interactive behavior
+    result = agent.tool.handoff_to_user(message="Test via agent", breakout_of_loop=True)
+
+    result_text = extract_result_text(result)
+    assert "Agent handoff completed" in result_text
+    assert "Test via agent" in result_text
+
+
+def test_tool_spec_structure():
+    """Test that the tool spec has the correct structure."""
+    spec = handoff_to_user.TOOL_SPEC
+
+    assert spec["name"] == "handoff_to_user"
+    assert "description" in spec
+    assert "inputSchema" in spec
+    assert "json" in spec["inputSchema"]
+    assert "properties" in spec["inputSchema"]["json"]
+
+    properties = spec["inputSchema"]["json"]["properties"]
+    assert "message" in properties
+    assert "breakout_of_loop" in properties
+    assert properties["message"]["type"] == "string"
+    assert properties["breakout_of_loop"]["type"] == "boolean"
+    assert properties["breakout_of_loop"]["default"] is False
+
+    required = spec["inputSchema"]["json"]["required"]
+    assert "message" in required


### PR DESCRIPTION
## Description

This PR introduces a new handoff_to_user tool that enables agents to hand off control to users for human intervention in automated workflows. The tool provides two distinct modes of operation:

1. Interactive Mode (breakout_of_loop=False): Pauses execution to collect user input and continues with the response
2. Complete Handoff Mode (breakout_of_loop=True): Stops the event loop entirely and transfers control to the user

The tool follows the same architectural patterns as the existing stop tool, using ToolUse and ToolResult types with direct request_state access for event loop control. It provides a professional user interface with clear visual indicators and comprehensive error handling including graceful recovery from KeyboardInterrupt and other exceptions.

## Related Issues
[No specific issues referenced - this is a new feature implementation]

## Documentation PR
Will do in a separate CR 

## Type of Change
• [ ] Bug fix
• [x] New Tool
• [ ] Breaking change
• [ ] Other (please describe):

## Testing

The implementation has been thoroughly tested with comprehensive test coverage:

### Test Coverage (9 test cases):
• Direct function calls with ToolUse objects (matching stop tool pattern)
• Event loop control verification (stop_event_loop flag setting)
• User input collection and response handling
• Error handling (KeyboardInterrupt, general exceptions)
• Default parameter behavior and edge cases
• Agent interface integration testing
• Tool specification structure validation

### Code Quality Checks:
• hatch fmt --linter ✅
• hatch fmt --formatter ✅ 
• hatch test --all ✅ (only a2a test fails, not related to changes)

### Additional Testing:
```
>>> from strands_tools import handoff_to_user
>>> agent = Agent(tools=[handoff_to_user, calculator])
>>> agent("Ask user to pick a number and then get the square root of it")
I'd be happy to help you with this task. I'll need to ask the user to pick a number, and then I'll calculate its square root using the calculator tool.
Tool #1: handoff_to_user

============================================================
🤝 AGENT REQUESTING USER HANDOFF
============================================================

Please pick a number that you'd like me to find the square root of.

⏳ Waiting for your response...
----------------------------------------
Your response: 29931
============================================================

Thank you for choosing the number 29931. I'll calculate its square root now.
Tool #2: calculator
The square root of 29931 is 173.0057802498.AgentResult(stop_reason='end_turn', message={'role': 'assistant', 'content': [{'text': 'The square root of 29931 is 173.0057802498.'}]}, metrics=EventLoopMetrics(cycle_count=3, tool_metrics={'handoff_to_user': ToolMetrics(tool={'toolUseId': 'tooluse_cGPUkvDUTh2-8sNwlRVPjw', 'name': 'handoff_to_user', 'input': {'message': "Please pick a number that you'd like me to find the square root of.", 'breakout_of_loop': False}}, call_count=1, success_count=1, error_count=0, total_time=6.689070224761963), 'calculator': ToolMetrics(tool={'toolUseId': 'tooluse_onFtuqpHSWWFFcwmNgCrCA', 'name': 'calculator', 'input': {'expression': 'sqrt(29931)', 'mode': 'evaluate'}}, call_count=1, success_count=1, error_count=0, total_time=0.10299992561340332)}, cycle_durations=[1.529723882675171], traces=[<strands.telemetry.metrics.Trace object at 0x10c5c0200>, <strands.telemetry.metrics.Trace object at 0x10c5c03b0>, <strands.telemetry.metrics.Trace object at 0x10c5c02c0>], accumulated_usage={'inputTokens': 6645, 'outputTokens': 241, 'totalTokens': 6886}, accumulated_metrics={'latencyMs': 6498}), state={})
```

## Checklist
• [x] I have read the CONTRIBUTING document
• [x] I have added tests that prove my fix is effective or my feature works
• [] I have updated the documentation accordingly
• [x] I have added an appropriate example to the documentation to outline the feature
• [x] My changes generate no new warnings
• [x] Any dependent changes have been merged and published

• By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your 
choice.