### PR TITLE
remove references to max_parallel_tools

### DIFF
--- a/src/strands_tools/a2a_client.py
+++ b/src/strands_tools/a2a_client.py
@@ -6,10 +6,6 @@ This tool provides functionality to discover and communicate with A2A-compliant 
 Key Features:
 - Agent discovery through agent cards from multiple URLs
 - Message sending to specific A2A agents
-
-Warning: when using this collection of tools ensure max_parallel_tools>1 for your Strands Agent.
-This is typically set by default since the the Strands Agents use cpu count as the default value.
-However, if you see "event loop is already running" errors, you should ensure max_parallel_tools>1.
 """
 
 import asyncio
@@ -69,10 +65,7 @@ class A2AClientToolProvider:
         return tools
 
     def _run_async(self, coro):
-        """Handle async-to-sync conversion internally.
-
-        This function requires max_parallel_tools>1 on the Strands Agent.
-        """
+        """Handle async-to-sync conversion internally."""
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:


### PR DESCRIPTION
## Description
`max_parallel_tools` is no longer a parameter of `Agent.__init__`, hence removing references.

## Related Issues
N/A

## Documentation PR
This is the doc update.

## Type of Change
Docs update.

## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
