### PR TITLE
refactor: update tools and tools test to call new registry CRUDL interface

### DIFF
--- a/src/strands_tools/graph.py
+++ b/src/strands_tools/graph.py
@@ -150,13 +150,15 @@ def create_agent_with_model(
         if tools:
             # Filter parent agent tools to only include specified tool names
             for tool_name in tools:
-                if tool_name in parent_agent.tool_registry.registry:
-                    agent_tools.append(parent_agent.tool_registry.registry[tool_name])
-                else:
+                try:
+                    tool_spec = parent_agent.tool_registry.read_tool(tool_name)
+                    agent_tools.append(tool_spec)
+                except ValueError:
                     logger.warning(f"Tool '{tool_name}' not found in parent agent's tool registry")
         else:
             # Use all parent agent tools
-            agent_tools = list(parent_agent.tool_registry.registry.values())
+            tools_dict = parent_agent.tool_registry.list_tools()
+            agent_tools = list(tools_dict.values())
 
     # Create and return agent
     kwargs = {}
@@ -213,7 +215,7 @@ class GraphManager:
                     # Create basic agent with parent agent's model and tools
                     # Get all tools from parent agent if no specific tools configuration
                     parent_tools = (
-                        list(parent_agent.tool_registry.registry.values()) if parent_agent.tool_registry else []
+                        list(parent_agent.tool_registry.list_tools().values()) if parent_agent.tool_registry else []
                     )
                     node_agent = Agent(
                         system_prompt=node_def["system_prompt"],

--- a/src/strands_tools/load_tool.py
+++ b/src/strands_tools/load_tool.py
@@ -81,7 +81,7 @@ def load_tool(path: str, name: str, agent=None) -> Dict[str, Any]:
     -------------------
     - Expands the path to handle user paths with tilde (~)
     - Validates that the file exists at the specified path
-    - Uses the tool_registry's load_tool_from_filepath method to:
+    - Uses the tool_registry's create_tool method to:
       * Parse the Python file
       * Extract the tool function and metadata
       * Register the tool with the provided name
@@ -198,7 +198,7 @@ def load_tool(path: str, name: str, agent=None) -> Dict[str, Any]:
             raise FileNotFoundError(f"Tool file not found: {path}")
 
         # Load the tool using the agent's tool registry
-        current_agent.tool_registry.load_tool_from_filepath(tool_name=name, tool_path=path)
+        current_agent.tool_registry.create_tool({"name": name, "path": path})
 
         # Return success message with tool details
         message = f"✅ Tool '{name}' loaded successfully from {path}"

--- a/src/strands_tools/slack.py
+++ b/src/strands_tools/slack.py
@@ -350,7 +350,7 @@ class SocketModeHandler:
             logger.info("Skipping own message")
             return
 
-        tools = list(self.agent.tool_registry.registry.values())
+        tools = list(self.agent.tool_registry.list_tools().values())
         trace_attributes = self.agent.trace_attributes
 
         agent = Agent(
@@ -435,7 +435,7 @@ class SocketModeHandler:
         """Process an interactive event."""
         # Process interactive events similar to messages
         if client and self.agent:
-            tools = list(self.agent.tool_registry.registry.values())
+            tools = list(self.agent.tool_registry.list_tools().values())
 
             agent = Agent(messages=[], system_prompt=SLACK_SYSTEM_PROMPT, tools=tools, callback_handler=None)
 

--- a/src/strands_tools/swarm.py
+++ b/src/strands_tools/swarm.py
@@ -191,7 +191,7 @@ def _create_custom_agents(
         agent_tools = spec.get("tools")
         if agent_tools and parent_agent and hasattr(parent_agent, "tool_registry"):
             # Filter tools to ensure they exist in parent agent's registry
-            available_tools = parent_agent.tool_registry.registry.keys()
+            available_tools = parent_agent.tool_registry.list_tools().keys()
             agent_tools = [tool for tool in agent_tools if tool in available_tools]
             if len(agent_tools) != len(spec.get("tools", [])):
                 missing_tools = set(spec.get("tools", [])) - set(agent_tools)

--- a/src/strands_tools/think.py
+++ b/src/strands_tools/think.py
@@ -102,12 +102,13 @@ Please provide your analysis directly:
             if specified_tools is not None:
                 # Filter parent agent tools to only include specified tool names
                 for tool_name in specified_tools:
-                    if tool_name in parent_agent.tool_registry.registry:
-                        filtered_tools.append(parent_agent.tool_registry.registry[tool_name])
+                    tool_spec = parent_agent.tool_registry.read_tool(tool_name)
+                    if tool_spec is not None:
+                        filtered_tools.append(tool_spec)
                     else:
                         logger.warning(f"Tool '{tool_name}' not found in parent agent's tool registry")
             else:
-                filtered_tools = list(parent_agent.tool_registry.registry.values())
+                filtered_tools = list(parent_agent.tool_registry.list_tools().values())
 
         # Determine which model to use
         selected_model = None

--- a/src/strands_tools/use_agent.py
+++ b/src/strands_tools/use_agent.py
@@ -196,12 +196,13 @@ def use_agent(
             if tools is not None:
                 # Filter parent agent tools to only include specified tool names
                 for tool_name in tools:
-                    if tool_name in agent.tool_registry.registry:
-                        filtered_tools.append(agent.tool_registry.registry[tool_name])
+                    tool_spec = agent.tool_registry.read_tool(tool_name)
+                    if tool_spec is not None:
+                        filtered_tools.append(tool_spec)
                     else:
                         logger.warning(f"Tool '{tool_name}' not found in parent agent's tool registry")
             else:
-                filtered_tools = list(agent.tool_registry.registry.values())
+                filtered_tools = list(agent.tool_registry.list_tools().values())
 
         # Determine which model to use
         selected_model = None

--- a/src/strands_tools/workflow.py
+++ b/src/strands_tools/workflow.py
@@ -328,15 +328,15 @@ class WorkflowManager:
             filtered_tools = []
             if task_tools and self.parent_agent and hasattr(self.parent_agent, "tool_registry"):
                 # Filter parent agent tools to only include specified tool names
-                available_tools = self.parent_agent.tool_registry.registry
+                tools_dict = self.parent_agent.tool_registry.list_tools()
                 for tool_name in task_tools:
-                    if tool_name in available_tools:
-                        filtered_tools.append(available_tools[tool_name])
+                    if tool_name in tools_dict:
+                        filtered_tools.append(tools_dict[tool_name])
                     else:
                         logger.warning(f"Tool '{tool_name}' not found in parent agent's tool registry")
             elif self.parent_agent and hasattr(self.parent_agent, "tool_registry"):
                 # Inherit all tools from parent if none specified
-                filtered_tools = list(self.parent_agent.tool_registry.registry.values())
+                filtered_tools = list(self.parent_agent.tool_registry.list_tools().values())
 
             # Configure model
             selected_model = None

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -23,7 +23,7 @@ def mock_parent_agent():
     mock_agent.tool_registry = mock_tool_registry
 
     # Mock some tools in the registry
-    mock_tool_registry.registry = {
+    mock_tools = {
         "calculator": MagicMock(),
         "file_read": MagicMock(),
         "file_write": MagicMock(),
@@ -31,6 +31,8 @@ def mock_parent_agent():
         "http_request": MagicMock(),
         "researcher_tool": MagicMock(),
     }
+    mock_tool_registry.list_tools.return_value = mock_tools
+    mock_tool_registry.read_tool = lambda name: mock_tools[name] if name in mock_tools else None
 
     # Mock model and other attributes
     mock_agent.model = MagicMock()

--- a/tests/test_load_tool.py
+++ b/tests/test_load_tool.py
@@ -71,9 +71,7 @@ def test_load_tool_direct(temp_tool_file):
     assert "loaded successfully" in result["content"][0]["text"]
 
     # Verify the tool was loaded via the registry
-    mock_tool_registry.load_tool_from_filepath.assert_called_once_with(
-        tool_name="sample_tool", tool_path=temp_tool_file
-    )
+    mock_tool_registry.create_tool.assert_called_once_with({"name": "sample_tool", "path": temp_tool_file})
 
 
 def test_load_tool_disabled():
@@ -90,7 +88,7 @@ def test_load_tool_disabled():
         assert "disabled" in result["content"][0]["text"]
 
         # Verify the tool was not loaded
-        mock_agent.tool_registry.load_tool_from_filepath.assert_not_called()
+        mock_agent.tool_registry.create_tool.assert_not_called()
 
 
 def test_load_tool_file_not_found():
@@ -105,13 +103,13 @@ def test_load_tool_file_not_found():
     assert "not found" in str(result["content"][0]["text"])
 
     # Verify the tool was not loaded
-    mock_agent.tool_registry.load_tool_from_filepath.assert_not_called()
+    mock_agent.tool_registry.create_tool.assert_not_called()
 
 
 def test_load_tool_exception():
     """Test load_tool when an exception occurs during loading."""
     mock_agent = MagicMock()
-    mock_agent.tool_registry.load_tool_from_filepath.side_effect = Exception("Test exception")
+    mock_agent.tool_registry.create_tool.side_effect = Exception("Test exception")
 
     with tempfile.NamedTemporaryFile(suffix=".py") as f:
         # Call the load_tool function with the new signature

--- a/tests/test_slack/test_slack_socket.py
+++ b/tests/test_slack/test_slack_socket.py
@@ -16,8 +16,8 @@ class TestSocketModeHandlerProcessing(unittest.TestCase):
         self.mock_agent = MagicMock()
         # Create a tool registry structure manually for the mock agent
         self.mock_agent.tool_registry = MagicMock()
-        self.mock_agent.tool_registry.registry = MagicMock()
-        self.mock_agent.tool_registry.registry.values.return_value = ["tool1", "tool2"]
+        mock_tools = {"tool1": "tool1", "tool2": "tool2"}
+        self.mock_agent.tool_registry.list_tools.return_value = mock_tools
         self.mock_agent.system_prompt = "Test system prompt"
         self.handler.agent = self.mock_agent
 

--- a/tests/test_swarm.py
+++ b/tests/test_swarm.py
@@ -24,7 +24,7 @@ def mock_parent_agent():
     mock_agent.tool_registry = mock_tool_registry
 
     # Mock some tools in the registry
-    mock_tool_registry.registry = {
+    mock_tools = {
         "calculator": MagicMock(),
         "file_read": MagicMock(),
         "editor": MagicMock(),
@@ -32,6 +32,7 @@ def mock_parent_agent():
         "generate_image": MagicMock(),
         "file_write": MagicMock(),
     }
+    mock_tool_registry.list_tools.return_value = mock_tools
 
     # Mock model and other attributes
     mock_agent.model = MagicMock()

--- a/tests/test_think.py
+++ b/tests/test_think.py
@@ -143,11 +143,13 @@ def test_think_with_tool_filtering():
 
     # Create a mock parent agent with multiple tools
     mock_parent_agent = MagicMock()
-    mock_parent_agent.tool_registry.registry = {
+    mock_tools = {
         "calculator": mock_calculator_tool,
         "file_read": mock_file_read_tool,
         "other_tool": mock_other_tool,
     }
+    mock_parent_agent.tool_registry.list_tools.return_value = mock_tools
+    mock_parent_agent.tool_registry.read_tool = lambda name: mock_tools[name] if name in mock_tools else None
     mock_parent_agent.trace_attributes = {}
 
     with patch("strands_tools.think.Agent") as mock_agent_class:
@@ -193,10 +195,12 @@ def test_think_with_nonexistent_tool_filtering():
 
     # Create a mock parent agent with limited tools
     mock_parent_agent = MagicMock()
-    mock_parent_agent.tool_registry.registry = {
+    mock_tools = {
         "calculator": mock_calculator_tool,
         "file_read": mock_file_read_tool,
     }
+    mock_parent_agent.tool_registry.list_tools.return_value = mock_tools
+    mock_parent_agent.tool_registry.read_tool = lambda name: mock_tools[name] if name in mock_tools else None
     mock_parent_agent.trace_attributes = {}
 
     with (
@@ -242,10 +246,12 @@ def test_think_with_empty_tool_filtering():
     """Test think tool with empty tools list (should result in no tools)."""
     # Create a mock parent agent with tools
     mock_parent_agent = MagicMock()
-    mock_parent_agent.tool_registry.registry = {
+    mock_tools = {
         "calculator": MagicMock(),
         "file_read": MagicMock(),
     }
+    mock_parent_agent.tool_registry.list_tools.return_value = mock_tools
+    mock_parent_agent.tool_registry.read_tool = lambda name: mock_tools[name] if name in mock_tools else None
     mock_parent_agent.trace_attributes = {}
 
     with patch("strands_tools.think.Agent") as mock_agent_class:
@@ -288,11 +294,12 @@ def test_think_without_tool_filtering_inherits_all():
 
     # Create a mock parent agent with multiple tools
     mock_parent_agent = MagicMock()
-    mock_parent_agent.tool_registry.registry.values.return_value = [
-        mock_calculator_tool,
-        mock_file_read_tool,
-        mock_other_tool,
-    ]
+    mock_tools = {
+        "calculator": mock_calculator_tool,
+        "file_read": mock_file_read_tool,
+        "other_tool": mock_other_tool,
+    }
+    mock_parent_agent.tool_registry.list_tools.return_value = mock_tools
     mock_parent_agent.trace_attributes = {}
 
     with patch("strands_tools.think.Agent") as mock_agent_class:
@@ -336,10 +343,12 @@ def test_think_tool_filtering_with_multiple_cycles():
 
     # Create a mock parent agent with tools
     mock_parent_agent = MagicMock()
-    mock_parent_agent.tool_registry.registry = {
+    mock_tools = {
         "calculator": mock_calculator_tool,
         "file_read": mock_file_read_tool,
     }
+    mock_parent_agent.tool_registry.list_tools.return_value = mock_tools
+    mock_parent_agent.tool_registry.read_tool = lambda name: mock_tools[name] if name in mock_tools else None
     mock_parent_agent.trace_attributes = {}
 
     with patch("strands_tools.think.Agent") as mock_agent_class:

--- a/tests/test_use_llm.py
+++ b/tests/test_use_llm.py
@@ -192,7 +192,7 @@ def test_use_llm_with_parent_agent_callback():
 
     # Create a mock parent agent with a callback handler
     mock_parent_agent = MagicMock()
-    mock_parent_agent.tool_registry.registry.values.return_value = []
+    mock_parent_agent.tool_registry.list_tools.return_value = {}
     mock_parent_agent.trace_attributes = {"test_attribute": "test_value"}
     mock_parent_agent.callback_handler = MagicMock(name="parent_callback_handler")
 
@@ -232,7 +232,7 @@ def test_use_llm_with_explicit_callback():
 
     # Create a mock parent agent with a callback handler
     mock_parent_agent = MagicMock()
-    mock_parent_agent.tool_registry.registry.values.return_value = []
+    mock_parent_agent.tool_registry.list_tools.return_value = {}
     mock_parent_agent.trace_attributes = {"test_attribute": "test_value"}
     mock_parent_agent.callback_handler = MagicMock(name="parent_callback_handler")
 
@@ -284,11 +284,13 @@ def test_use_llm_with_tool_filtering():
 
     # Create a mock parent agent with multiple tools
     mock_parent_agent = MagicMock()
-    mock_parent_agent.tool_registry.registry = {
+    mock_tools = {
         "calculator": mock_calculator_tool,
         "file_read": mock_file_read_tool,
         "other_tool": mock_other_tool,
     }
+    mock_parent_agent.tool_registry.list_tools.return_value = mock_tools
+    mock_parent_agent.tool_registry.read_tool = lambda name: mock_tools[name] if name in mock_tools else None
     mock_parent_agent.trace_attributes = {}
     mock_parent_agent.callback_handler = MagicMock()
 
@@ -338,7 +340,9 @@ def test_use_llm_with_nonexistent_tool_filtering():
 
     # Create a mock parent agent with limited tools
     mock_parent_agent = MagicMock()
-    mock_parent_agent.tool_registry.registry = {"calculator": mock_calculator_tool, "file_read": mock_file_read_tool}
+    mock_tools = {"calculator": mock_calculator_tool, "file_read": mock_file_read_tool}
+    mock_parent_agent.tool_registry.list_tools.return_value = mock_tools
+    mock_parent_agent.tool_registry.read_tool = lambda name: mock_tools[name] if name in mock_tools else None
     mock_parent_agent.trace_attributes = {}
     mock_parent_agent.callback_handler = MagicMock()
 
@@ -381,7 +385,9 @@ def test_use_llm_with_empty_tool_filtering():
 
     # Create a mock parent agent with tools
     mock_parent_agent = MagicMock()
-    mock_parent_agent.tool_registry.registry = {"calculator": MagicMock(), "file_read": MagicMock()}
+    mock_tools = {"calculator": MagicMock(), "file_read": MagicMock()}
+    mock_parent_agent.tool_registry.list_tools.return_value = mock_tools
+    mock_parent_agent.tool_registry.read_tool = lambda name: mock_tools[name] if name in mock_tools else None
     mock_parent_agent.trace_attributes = {}
     mock_parent_agent.callback_handler = MagicMock()
 
@@ -428,11 +434,8 @@ def test_use_llm_without_tool_filtering_inherits_all():
 
     # Create a mock parent agent with multiple tools
     mock_parent_agent = MagicMock()
-    mock_parent_agent.tool_registry.registry.values.return_value = [
-        mock_calculator_tool,
-        mock_file_read_tool,
-        mock_other_tool,
-    ]
+    mock_tools = [mock_calculator_tool, mock_file_read_tool, mock_other_tool]
+    mock_parent_agent.tool_registry.list_tools.return_value = {f"tool_{i}": tool for i, tool in enumerate(mock_tools)}
     mock_parent_agent.trace_attributes = {}
     mock_parent_agent.callback_handler = MagicMock()
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -41,7 +41,7 @@ def mock_parent_agent():
     mock_agent.tool_registry = mock_tool_registry
 
     # Mock some tools in the registry
-    mock_tool_registry.registry = {
+    mock_tools = {
         "calculator": MagicMock(),
         "file_read": MagicMock(),
         "file_write": MagicMock(),
@@ -51,6 +51,8 @@ def mock_parent_agent():
         "generate_image": MagicMock(),
         "python_repl": MagicMock(),
     }
+    mock_tool_registry.list_tools.return_value = mock_tools
+    mock_tool_registry.read_tool = lambda name: mock_tools[name] if name in mock_tools else None
 
     # Mock model and other attributes
     mock_agent.model = MagicMock()


### PR DESCRIPTION
## Description
- update tools and tools test to call new registry CRUDL interface
- IMPORTANT: DO NOT MERGE YET UNTIL SDK CHANGES HAVE BEEN MERGED: https://github.com/strands-agents/sdk-python/pull/468

## Related Issues
https://github.com/strands-agents/private-sdk-python-staging/issues/26

## Documentation PR
N/A

## Type of Change
- [ ] Bug fix
- [ ] New Tool
- [X] Breaking change
- [X] Other (please describe): refactor

## Testing
[How have you tested the change?] yes

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [NOT YET] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
