### PR TITLE
test: fix python_repl tests failing with BYPASS_TOOL_CONSENT=true

### DIFF
--- a/tests/test_python_repl.py
+++ b/tests/test_python_repl.py
@@ -1,6 +1,4 @@
-"""
-Tests for the python_repl tool using the Agent interface.
-"""
+"""Tests for the python_repl tool using the Agent interface."""
 
 import os
 import sys
@@ -315,13 +313,19 @@ class TestPythonRepl:
 
     def test_user_rejection_cancels_execution(self, mock_console):
         """Test that user rejection properly cancels execution."""
+        # Clear REPL state to ensure clean test environment
+        python_repl.repl_state.clear_state()
+
         tool_use = {
             "toolUseId": "test-id",
             "input": {"code": "should_not_execute = True", "interactive": False},
         }
 
-        # Mock user rejecting the execution
-        with patch("strands_tools.python_repl.get_user_input", side_effect=["n", "Testing rejection"]):
+        # Mock user rejecting the execution and ensure bypass conditions are disabled
+        with (
+            patch("strands_tools.python_repl.get_user_input", side_effect=["n", "Testing rejection"]),
+            patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "false"}, clear=False),
+        ):
             result = python_repl.python_repl(tool=tool_use)
 
             assert result["status"] == "error"
@@ -330,13 +334,19 @@ class TestPythonRepl:
 
     def test_custom_rejection_message(self, mock_console):
         """Test that custom rejection message is included."""
+        # Clear REPL state to ensure clean test environment
+        python_repl.repl_state.clear_state()
+
         tool_use = {
             "toolUseId": "test-id",
             "input": {"code": "print('Should not run')", "interactive": False},
         }
 
-        # Mock user providing custom rejection reason
-        with patch("strands_tools.python_repl.get_user_input", side_effect=["custom reason", ""]):
+        # Mock user providing custom rejection reason and ensure bypass conditions are disabled
+        with (
+            patch("strands_tools.python_repl.get_user_input", side_effect=["custom reason", ""]),
+            patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "false"}, clear=False),
+        ):
             result = python_repl.python_repl(tool=tool_use)
 
             assert result["status"] == "error"


### PR DESCRIPTION
## Description
Fixed python_repl tests that were failing when the BYPASS_TOOL_CONSENT environment variable is set to true. The issue was caused by test isolation problems where environment variables were not properly mocked and REPL state was not cleared between tests.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change
- [x] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
Fixed the failing tests by:
- Adding proper environment variable mocking with `patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "false"}, clear=False)`
- Adding REPL state clearing with `python_repl.repl_state.clear_state()` before tests
- Ensuring test isolation for user rejection scenarios

Verified with:
* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.