### PR TITLE
docs: fix code block formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ processed.head()
 
 ### Code Interpreter
 
+```python
 from strands import Agent
 from strands_tools.code_interpreter import AgentCoreCodeInterpreter
 
@@ -229,7 +230,7 @@ from strands_tools.code_interpreter import AgentCoreCodeInterpreter
 bedrock_agent_core_code_interpreter = AgentCoreCodeInterpreter(region="us-west-2")
 agent = Agent(tools=[bedrock_agent_core_code_interpreter.code_interpreter])
 
-# Create a session and execute code
+# Create a session
 agent.tool.code_interpreter({
     "action": {
         "type": "initSession",
@@ -238,14 +239,16 @@ agent.tool.code_interpreter({
     }
 })
 
+# Execute Python code
 agent.tool.code_interpreter({
     "action": {
         "type": "executeCode",
         "session_name": "analysis-session",
-        "code": "import pandas as pd\nprint('Hello from sandbox!')",
+        "code": "print('Hello from sandbox!')",
         "language": "python"
     }
 })
+```
 
 ### Swarm Intelligence
 


### PR DESCRIPTION
## Description
Fixed missing code block formatting in the README.md file for the Code Interpreter section. Added proper markdown code blocks around the Python examples to improve readability and ensure proper syntax highlighting.

**Changes made:**
- Added opening ````python` code block marker
- Updated comment from "Create a session and execute code" to "Create a session" 
- Added "Execute Python code" comment for clarity
- Simplified the example code by removing pandas import
- Added closing ```` code block marker

## Related Issues
N/A - Minor documentation formatting fix

## Documentation PR
N/A - This is the documentation fix itself

## Type of Change
- [x] Bug fix
- [ ] New Tool
- [ ] Breaking change
- [ ] Other (please describe):

## Testing
Verified that the markdown renders correctly with proper syntax highlighting:

* Manually reviewed the diff using `git diff`
* Confirmed that the code blocks now have proper markdown formatting
* No functional code changes, only documentation formatting

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works (N/A - documentation only)
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature (N/A - formatting fix only)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (N/A)

- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
