### PR TITLE
Update github contributing flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,32 +1,39 @@
 ## Description
-[Provide a detailed description of the changes in this PR]
+
+<!-- Provide a detailed description of the changes in this PR -->
 
 ## Related Issues
-[Link to related issues using #issue-number format]
+
+<!-- Link to related issues using #issue-number format -->
 
 ## Documentation PR
-[Link to related associated PR in the agent-docs repo]
+
+<!-- Link to related associated PR in the agent-docs repo -->
 
 ## Type of Change
-- [ ] Bug fix
-- [ ] New Tool
-- [ ] Breaking change
-- [ ] Other (please describe):
+
+<!-- Choose one of the following types of changes, delete the rest -->
+
+Bug fix
+New Tool
+Breaking change
+Documentation update
+Other (please describe):
 
 ## Testing
-[How have you tested the change?]
 
-* `hatch fmt --linter`
-* `hatch fmt --formatter`
-* `hatch test --all`
+How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli
 
+- [ ] I ran `hatch run prepare`
 
 ## Checklist
 - [ ] I have read the CONTRIBUTING document
-- [ ] I have added tests that prove my fix is effective or my feature works
+- [ ] I have added any necessary tests that prove my fix is effective or my feature works
 - [ ] I have updated the documentation accordingly
 - [ ] I have added an appropriate example to the documentation to outline the feature
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published
 
-- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
+----
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -3,7 +3,7 @@ name: Pull Request and Push Action
 on:
   pull_request:  # Safer than pull_request_target for untrusted code
     branches: [ main ]
-    types: [opened, synchronize, reopened, ready_for_review, review_requested, review_request_removed]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [ main ]  # Also run on direct pushes to main
 concurrency:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,12 @@ lint = ["hatch fmt --linter"]
 test-lint = ["hatch fmt --linter --check"]
 test = ["hatch test --cover --cov-report html --cov-report xml {args}"]
 test-integ = ["hatch test tests_integ {args}"]
+prepare = [
+    "hatch run format",
+    "hatch run lint",
+    "hatch run test-lint",
+    "hatch run test"
+]
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION

## Description

These changes:
  - Provide a single command `hatch run prepare` to run all required commands
  - Streamline the GitHub PR template
  - Avoids running the github workflows un-necessarily

These changes were originally made to the SDK a while ago:

 - Streamlining contributions: strands-agents/sdk-python/pull/221
 - Not running workflows on un/approvals: strands-agents/sdk-python/pull/516

----

This GitHub PR uses the updated PR template

## Related Issues

N/A

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): Streamline contributions

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
