### PR TITLE
docs: Use keyword arguments in usage example

### DIFF
--- a/src/strands_tools/code_interpreter/code_interpreter.py
+++ b/src/strands_tools/code_interpreter/code_interpreter.py
@@ -104,44 +104,52 @@ class CodeInterpreter(ABC):
         agent = Agent(tools=[bedrock_agent_core_code_interpreter.code_interpreter])
 
         # Create a session
-        agent.tool.code_interpreter({{
-            "action": {{
-                "type": "initSession",
-                "description": "Data analysis session",
-                "session_name": "analysis-session"
+        agent.tool.code_interpreter(
+            code_interpreter_input={{
+                "action": {{
+                    "type": "initSession",
+                    "description": "Data analysis session",
+                    "session_name": "analysis-session"
+                }}
             }}
-        }})
+        )
 
         # Execute Python code
-        agent.tool.code_interpreter({{
-            "action": {{
-                "type": "executeCode",
-                "session_name": "analysis-session",
-                "code": "import pandas as pd\\ndf = pd.read_csv('data.csv')\\nprint(df.head())",
-                "language": "python"
+        agent.tool.code_interpreter(
+            code_interpreter_input={{
+                "action": {{
+                    "type": "executeCode",
+                    "session_name": "analysis-session",
+                    "code": "import pandas as pd\\ndf = pd.read_csv('data.csv')\\nprint(df.head())",
+                    "language": "python"
+                }}
             }}
-        }})
+        )
 
         # Write files to the sandbox
-        agent.tool.code_interpreter({{
-            "action": {{
-                "type": "writeFiles",
-                "session_name": "analysis-session",
-                "content": [
-                    {{"path": "config.json", "text": '{{"debug": true}}'}},
-                    {{"path": "script.py", "text": "print('Hello, World!')"}}
-                ]
+        agent.tool.code_interpreter(
+            code_interpreter_input={{
+                "action": {{
+                    "type": "writeFiles",
+                    "session_name": "analysis-session",
+                    "content": [
+                        {{"path": "config.json", "text": '{{"debug": true}}'}},
+                        {{"path": "script.py", "text": "print('Hello, World!')"}}
+                    ]
+                }}
             }}
-        }})
+        )
 
         # Execute shell commands
-        agent.tool.code_interpreter({{
-            "action": {{
-                "type": "executeCommand",
-                "session_name": "analysis-session",
-                "command": "ls -la && python script.py"
+        agent.tool.code_interpreter(
+            code_interpreter_input={{
+                "action": {{
+                    "type": "executeCommand",
+                    "session_name": "analysis-session",
+                    "command": "ls -la && python script.py"
+                }}
             }}
-        }})
+        )
         ```
 
         Args:


### PR DESCRIPTION
## Description

Use keyword arguments in code_interpreter.py usage example.

## Related Issues

#194

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

Documentation update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
