### PR TITLE
refactor(a2a): upgrade to ClientFactory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ agent_core_browser = [
 agent_core_code_interpreter = [
     "bedrock-agentcore==0.1.0"
 ]
-a2a_client = ["a2a-sdk[sql]>=0.2.16"]
+a2a_client = ["a2a-sdk[sql]>=0.3.0,<0.4.0"]
 diagram = [
     "matplotlib>=3.5.0,<4.0.0",
     "graphviz>=0.20.0,<1.0.0",
@@ -99,9 +99,9 @@ diagram = [
 ]
 rss = ["feedparser>=6.0.10,<7.0.0", "html2text>=2020.1.16,<2021.0.0"]
 use_computer = [
-    "opencv-python>=4.5.0,<5.0.0", 
-    "psutil>=5.8.0,<6.0.0", 
-    "pyautogui>=0.9.53,<1.0.0", 
+    "opencv-python>=4.5.0,<5.0.0",
+    "psutil>=5.8.0,<6.0.0",
+    "pyautogui>=0.9.53,<1.0.0",
     "pytesseract>=0.3.8,<1.0.0"
 ]
 

--- a/src/strands_tools/a2a_client.py
+++ b/src/strands_tools/a2a_client.py
@@ -14,8 +14,8 @@ from typing import Any
 from uuid import uuid4
 
 import httpx
-from a2a.client import A2ACardResolver, A2AClient
-from a2a.types import AgentCard, Message, MessageSendParams, Part, Role, SendMessageRequest, TextPart
+from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
+from a2a.types import AgentCard, Message, Part, Role, TextPart
 from strands import tool
 from strands.types.tools import AgentTool
 
@@ -43,6 +43,7 @@ class A2AClientToolProvider:
         self._known_agent_urls: list[str] = known_agent_urls or []
         self._discovered_agents: dict[str, AgentCard] = {}
         self._httpx_client: httpx.AsyncClient | None = None
+        self._client_factory: ClientFactory | None = None
         self._initial_discovery_done: bool = False
 
     @property
@@ -66,15 +67,20 @@ class A2AClientToolProvider:
             self._httpx_client = httpx.AsyncClient(timeout=self.timeout)
         return self._httpx_client
 
-    async def _create_a2a_client(self, url: str) -> A2AClient:
-        """Create a new A2A client for the given URL."""
-        httpx_client = await self._ensure_httpx_client()
-        agent_card = await self._discover_agent_card(url)
-        logger.info(f"A2AClient created for {url}")
-        return A2AClient(httpx_client=httpx_client, agent_card=agent_card)
+    async def _ensure_client_factory(self) -> ClientFactory:
+        """Ensure the ClientFactory is initialized."""
+        if self._client_factory is None:
+            httpx_client = await self._ensure_httpx_client()
+            config = ClientConfig(
+                httpx_client=httpx_client,
+                streaming=False,  # Use non-streaming mode for simpler response handling
+            )
+            self._client_factory = ClientFactory(config)
+            logger.info("ClientFactory initialized")
+        return self._client_factory
 
     async def _create_a2a_card_resolver(self, url: str) -> A2ACardResolver:
-        """Create a new A2A client for the given URL."""
+        """Create a new A2A card resolver for the given URL."""
         httpx_client = await self._ensure_httpx_client()
         logger.info(f"A2ACardResolver created for {url}")
         return A2ACardResolver(httpx_client=httpx_client, base_url=url)
@@ -213,7 +219,11 @@ class A2AClientToolProvider:
 
         try:
             await self._ensure_discovered_known_agents()
-            client = await self._create_a2a_client(target_agent_url)
+
+            # Get the agent card and create client using factory
+            agent_card = await self._discover_agent_card(target_agent_url)
+            client_factory = await self._ensure_client_factory()
+            client = client_factory.create(agent_card)
 
             if message_id is None:
                 message_id = uuid4().hex
@@ -225,14 +235,45 @@ class A2AClientToolProvider:
                 message_id=message_id,
             )
 
-            request = SendMessageRequest(id=str(uuid4()), params=MessageSendParams(message=message))
-
             logger.info(f"Sending message to {target_agent_url}")
-            response = await client.send_message(request)
 
+            # With streaming=False, this will yield exactly one result
+            async for event in client.send_message(message):
+                if isinstance(event, Message):
+                    # Direct message response
+                    return {
+                        "status": "success",
+                        "response": event.model_dump(mode="python", exclude_none=True),
+                        "message_id": message_id,
+                        "target_agent_url": target_agent_url,
+                    }
+                elif isinstance(event, tuple) and len(event) == 2:
+                    # (Task, UpdateEvent) tuple - extract the task
+                    task, update_event = event
+                    return {
+                        "status": "success",
+                        "response": {
+                            "task": task.model_dump(mode="python", exclude_none=True),
+                            "update": (
+                                update_event.model_dump(mode="python", exclude_none=True) if update_event else None
+                            ),
+                        },
+                        "message_id": message_id,
+                        "target_agent_url": target_agent_url,
+                    }
+                else:
+                    # Fallback for unexpected response types
+                    return {
+                        "status": "success",
+                        "response": {"raw_response": str(event)},
+                        "message_id": message_id,
+                        "target_agent_url": target_agent_url,
+                    }
+
+            # This should never be reached with streaming=False
             return {
-                "status": "success",
-                "response": response.model_dump(mode="python", exclude_none=True),
+                "status": "error",
+                "error": "No response received from agent",
                 "message_id": message_id,
                 "target_agent_url": target_agent_url,
             }

--- a/src/strands_tools/a2a_client.py
+++ b/src/strands_tools/a2a_client.py
@@ -76,7 +76,6 @@ class A2AClientToolProvider:
                 streaming=False,  # Use non-streaming mode for simpler response handling
             )
             self._client_factory = ClientFactory(config)
-            logger.info("ClientFactory initialized")
         return self._client_factory
 
     async def _create_a2a_card_resolver(self, url: str) -> A2ACardResolver:

--- a/tests/test_a2a_client.py
+++ b/tests/test_a2a_client.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from a2a.types import Role, SendMessageRequest
+from a2a.types import Message
 from strands_tools.a2a_client import DEFAULT_TIMEOUT, A2AClientToolProvider
 
 
@@ -309,25 +309,36 @@ async def test_send_message_without_message_id():
 
 @pytest.mark.asyncio
 @patch("strands_tools.a2a_client.uuid4")
-@patch.object(A2AClientToolProvider, "_create_a2a_client")
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_ensure_client_factory")
 @patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
-async def test_send_message_success(mock_ensure, mock_create_client, mock_uuid):
+async def test_send_message_success(mock_ensure, mock_factory, mock_discover, mock_uuid):
     """Test _send_message successful message sending."""
     provider = A2AClientToolProvider()
 
     # Mock UUID generation
     mock_message_uuid = Mock()
     mock_message_uuid.hex = "message_id_123"
-    mock_request_uuid = Mock()
-    mock_request_uuid.__str__ = Mock(return_value="request_id_456")
-    mock_uuid.side_effect = [mock_message_uuid, mock_request_uuid]
+    mock_uuid.return_value = mock_message_uuid
 
-    # Mock A2A client
+    # Mock agent card
+    mock_agent_card = Mock()
+    mock_discover.return_value = mock_agent_card
+
+    # Mock ClientFactory and Client
+    mock_client_factory = Mock()
     mock_client = Mock()
-    mock_response = Mock()
+    mock_factory.return_value = mock_client_factory
+    mock_client_factory.create.return_value = mock_client
+
+    # Mock client response - simulate Message response
+    mock_response = Mock(spec=Message)
     mock_response.model_dump.return_value = {"result": "success"}
-    mock_client.send_message = AsyncMock(return_value=mock_response)
-    mock_create_client.return_value = mock_client
+
+    async def mock_send_message_iter(message):
+        yield mock_response
+
+    mock_client.send_message = mock_send_message_iter
 
     result = await provider._send_message("Hello world", "http://test.com", None)
 
@@ -339,23 +350,17 @@ async def test_send_message_success(mock_ensure, mock_create_client, mock_uuid):
     }
     assert result == expected
     mock_ensure.assert_called_once()
-
-    # Verify client was called with correct message structure
-    mock_client.send_message.assert_called_once()
-    call_args = mock_client.send_message.call_args[0][0]
-    assert isinstance(call_args, SendMessageRequest)
-    assert call_args.id == "request_id_456"
-    assert call_args.params.message.role == Role.user
-    assert call_args.params.message.message_id == "message_id_123"
+    mock_discover.assert_called_once_with("http://test.com")
+    mock_client_factory.create.assert_called_once_with(mock_agent_card)
 
 
 @pytest.mark.asyncio
-@patch.object(A2AClientToolProvider, "_create_a2a_client")
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
 @patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
-async def test_send_message_error(mock_ensure, mock_create_client):
+async def test_send_message_error(mock_ensure, mock_discover):
     """Test _send_message handles errors."""
     provider = A2AClientToolProvider()
-    mock_create_client.side_effect = Exception("Connection failed")
+    mock_discover.side_effect = Exception("Connection failed")
 
     result = await provider._send_message("Hello", "http://test.com", "test_id")
 
@@ -388,20 +393,115 @@ async def test_create_a2a_card_resolver(mock_ensure_client):
 
 @pytest.mark.asyncio
 @patch.object(A2AClientToolProvider, "_ensure_httpx_client")
-@patch.object(A2AClientToolProvider, "_discover_agent_card")
-async def test_create_a2a_client(mock_discover, mock_ensure_client):
-    """Test _create_a2a_client creates client with correct parameters."""
+async def test_ensure_client_factory(mock_ensure_client):
+    """Test _ensure_client_factory creates ClientFactory with correct parameters."""
     provider = A2AClientToolProvider()
     mock_client = Mock()
     mock_ensure_client.return_value = mock_client
+
+    with patch("strands_tools.a2a_client.ClientFactory") as mock_factory_class:
+        with patch("strands_tools.a2a_client.ClientConfig") as mock_config_class:
+            mock_config = Mock()
+            mock_config_class.return_value = mock_config
+            mock_factory = Mock()
+            mock_factory_class.return_value = mock_factory
+
+            result = await provider._ensure_client_factory()
+
+            mock_config_class.assert_called_once()
+            mock_factory_class.assert_called_once_with(mock_config)
+            assert result == mock_factory
+            assert provider._client_factory == mock_factory
+
+
+@pytest.mark.asyncio
+@patch("strands_tools.a2a_client.uuid4")
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_ensure_client_factory")
+@patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
+async def test_send_message_task_response(mock_ensure, mock_factory, mock_discover, mock_uuid):
+    """Test _send_message handling task response from ClientFactory."""
+    provider = A2AClientToolProvider()
+
+    # Mock UUID generation
+    mock_message_uuid = Mock()
+    mock_message_uuid.hex = "message_id_123"
+    mock_uuid.return_value = mock_message_uuid
+
+    # Mock agent card
     mock_agent_card = Mock()
     mock_discover.return_value = mock_agent_card
 
-    with patch("strands_tools.a2a_client.A2AClient") as mock_client_class:
-        mock_a2a_client = Mock()
-        mock_client_class.return_value = mock_a2a_client
+    # Mock ClientFactory and Client
+    mock_client_factory = Mock()
+    mock_client = Mock()
+    mock_factory.return_value = mock_client_factory
+    mock_client_factory.create.return_value = mock_client
 
-        result = await provider._create_a2a_client("http://test.com")
+    # Mock client response - simulate (Task, UpdateEvent) tuple response
+    mock_task = Mock()
+    mock_task.model_dump.return_value = {"task_id": "123", "status": "completed"}
+    mock_update_event = Mock()
+    mock_update_event.model_dump.return_value = {"event": "finished"}
 
-        mock_client_class.assert_called_once_with(httpx_client=mock_client, agent_card=mock_agent_card)
-        assert result == mock_a2a_client
+    async def mock_send_message_iter(message):
+        yield (mock_task, mock_update_event)
+
+    mock_client.send_message = mock_send_message_iter
+
+    result = await provider._send_message("Hello world", "http://test.com", None)
+
+    expected = {
+        "status": "success",
+        "response": {"task": {"task_id": "123", "status": "completed"}, "update": {"event": "finished"}},
+        "message_id": "message_id_123",
+        "target_agent_url": "http://test.com",
+    }
+    assert result == expected
+    mock_ensure.assert_called_once()
+    mock_discover.assert_called_once_with("http://test.com")
+    mock_client_factory.create.assert_called_once_with(mock_agent_card)
+
+
+@pytest.mark.asyncio
+@patch("strands_tools.a2a_client.uuid4")
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_ensure_client_factory")
+@patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
+async def test_send_message_task_response_no_update(mock_ensure, mock_factory, mock_discover, mock_uuid):
+    """Test _send_message handling task response with no update event."""
+    provider = A2AClientToolProvider()
+
+    # Mock UUID generation
+    mock_message_uuid = Mock()
+    mock_message_uuid.hex = "message_id_123"
+    mock_uuid.return_value = mock_message_uuid
+
+    # Mock agent card
+    mock_agent_card = Mock()
+    mock_discover.return_value = mock_agent_card
+
+    # Mock ClientFactory and Client
+    mock_client_factory = Mock()
+    mock_client = Mock()
+    mock_factory.return_value = mock_client_factory
+    mock_client_factory.create.return_value = mock_client
+
+    # Mock client response - simulate (Task, None) tuple response
+    mock_task = Mock()
+    mock_task.model_dump.return_value = {"task_id": "123", "status": "completed"}
+
+    async def mock_send_message_iter(message):
+        yield (mock_task, None)
+
+    mock_client.send_message = mock_send_message_iter
+
+    result = await provider._send_message("Hello world", "http://test.com", None)
+
+    expected = {
+        "status": "success",
+        "response": {"task": {"task_id": "123", "status": "completed"}, "update": None},
+        "message_id": "message_id_123",
+        "target_agent_url": "http://test.com",
+    }
+    assert result == expected


### PR DESCRIPTION
## Description

Upgrade to `ClientFactory` to address warnings in logs:

> DeprecationWarning: A2AClient is deprecated and will be removed in a future version. Use ClientFactory to create a client with a JSON-RPC transport.


## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): General refactor

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
