### PR TITLE
fix(workflow): Allow workflow tasks access results from previous dependent tasks

### DIFF
--- a/src/strands_tools/browser/agent_core_browser.py
+++ b/src/strands_tools/browser/agent_core_browser.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_IDENTIFIER = "aws.browser.v1"
 
+
 class AgentCoreBrowser(Browser):
     """Bedrock AgentCore browser implementation."""
 

--- a/src/strands_tools/workflow.py
+++ b/src/strands_tools/workflow.py
@@ -445,7 +445,11 @@ class WorkflowManager:
 
             # Extract response content - handle both dict and custom object return types
             try:
-                content = result.get("content", []) if hasattr(result, "get") else getattr(result, "content", [])
+                content = (
+                    result.message.get("content", [])
+                    if hasattr(result.message, "get")
+                    else getattr(result.message, "content", [])
+                )
             except AttributeError:
                 content = [{"text": str(result)}]
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from strands import Agent
+from strands.agent import AgentResult
 from strands_tools import workflow as workflow_module
 
 
@@ -415,14 +416,11 @@ class TestWorkflowManager:
         ):
             # Create a proper mock agent result that returns structured data
             mock_task_agent = MagicMock()
-            mock_result = MagicMock()
-            mock_result.__str__ = MagicMock(return_value="Task completed successfully")
-            mock_result.get = MagicMock(
-                side_effect=lambda k, default=None: {
-                    "content": [{"text": "Task completed successfully"}],
-                    "stop_reason": "completed",
-                    "metrics": None,
-                }.get(k, default)
+            mock_result = AgentResult(
+                message={"content": [{"text": "Task completed successfully"}]},
+                stop_reason="completed",
+                metrics=None,
+                state=MagicMock(),
             )
 
             mock_task_agent.return_value = mock_result


### PR DESCRIPTION
## Description

Fix: Workflow tasks cannot get the result from previous dependent tasks.

In [https://github.com/strands-agents/tools/blob/main/src/strands_tools/workflow.py](url)
the code: 
 `content = result.get("content", []) if hasattr(result, "get") else getattr(result, "content", [])`
is supposed to get the result from previous tasks and save it in the context for later use.

However, the code cannot parse the object of AgentResult type and get the result from the agent run.

I also updated the test cases in tests/test_workflow.py to mock up the ActionResult return value.

## Related Issues

https://github.com/strands-agents/tools/issues/201

## Documentation PR

No need to update the documentation, as it's the expected behavior from the workflow tool.

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
