### PR TITLE
fix: Improve print in handoff to user

### DIFF
--- a/src/strands_tools/handoff_to_user.py
+++ b/src/strands_tools/handoff_to_user.py
@@ -179,7 +179,7 @@ def handoff_to_user(tool: ToolUse, **kwargs: Any) -> ToolResult:
     else:
         # Wait for user input and continue
         try:
-            user_response = get_user_input("<bold>Your response:</bold> ").strip()
+            user_response = get_user_input(f"<bold>Agent requested user input:</bold> {message}\n<bold>Your response:</bold> ").strip()
 
             console.print()
 

--- a/tests/test_handoff_to_user.py
+++ b/tests/test_handoff_to_user.py
@@ -63,7 +63,7 @@ def test_handoff_with_breakout_false_direct(mock_get_user_input, mock_request_st
     result = handoff_to_user.handoff_to_user(tool=tool_use, request_state=mock_request_state)
 
     # Verify get_user_input was called
-    mock_get_user_input.assert_called_once_with("<bold>Your response:</bold> ")
+    mock_get_user_input.assert_called_once_with("<bold>Agent requested user input:</bold> Please confirm the action.\n<bold>Your response:</bold> ")
 
     # Verify the result has the expected structure
     assert result["toolUseId"] == "test-tool-use-id"


### PR DESCRIPTION
## Description

This PR improves the user experience in the `handoff_to_user` tool by enhancing the prompt message displayed to users. The change makes it clearer what the agent is requesting by including the agent's message in the user input prompt.

This is essentially important for customers who do not have `STRANDS_TOOL_CONSOLE_MODE` enabled.

**Changes made:**
- Modified the user input prompt in `handoff_to_user.py` to include the agent's message before asking for user response
- Updated the corresponding test to reflect the new prompt format
- The prompt now shows: `"Agent requested user input: {message}\nYour response: "` instead of just `"Your response: "`

This improvement provides better context to users about what the agent is asking for, making the interaction more intuitive and user-friendly.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] Updated existing unit test to verify the new prompt format
- [x] Verified that the test passes with the new implementation
- [x] Confirmed that the change maintains backward compatibility for the tool's functionality

Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli
- [ ] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
