### PR TITLE
Add push notification support to A2AClientToolProvider

### DIFF
--- a/src/strands_tools/a2a_client.py
+++ b/src/strands_tools/a2a_client.py
@@ -16,7 +16,7 @@ from uuid import uuid4
 
 import httpx
 from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
-from a2a.types import AgentCard, Message, Part, Role, TextPart, PushNotificationConfig
+from a2a.types import AgentCard, Message, Part, PushNotificationConfig, Role, TextPart
 from strands import tool
 from strands.types.tools import AgentTool
 


### PR DESCRIPTION
## Description

This change adds optional push notification capabilities to the A2AClientToolProvider, enabling real-time webhook notifications when agent tasks complete.

Changes:
- Add `webhook_url` and `webhook_token` parameters to A2AClientToolProvider constructor
- Create PushNotificationConfig automatically when both parameters are provided
- Include push notification configs in ClientFactory configuration
- Update class docstring to document new push notification feature
- Maintain full backward compatibility with existing usage

These parameters are now optional constructor arguments in A2AClientToolProvider, providing webhook notification capabilities while maintaining backward compatibility.

**Backward Compatibility**: There are no functional changes to existing A2AClientToolProvider usage - all new parameters are optional with sensible defaults.

## Usage Examples

### Basic usage (unchanged):

```python
provider = A2AClientToolProvider(
    known_agent_urls=["http://localhost:8081/invocations"]
)
```

### With push notifications:

```python
provider = A2AClientToolProvider(
    known_agent_urls=["http://localhost:8081/invocations"],
    webhook_url="https://my-webhook.com/notifications",
    webhook_token="secret-token"
)
```

### Full configuration example:

```python
provider = A2AClientToolProvider(
    known_agent_urls=["http://localhost:8081/invocations"],
    timeout=300,
    webhook_url="https://my-webhook.com/notifications",
    webhook_token="secret-token"
)
```

### Use with Strands Agent as usual

```python
agent = Agent(model=my_model, tools=provider.tools)
```

## Related Issues

Closes #208

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Enhancement/New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] Verified backward compatibility with existing A2AClientToolProvider usage
- [X] Tested push notification integration with webhook server
- [X] Confirmed webhook notifications include complete task data and conversation history
- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
