### PR TITLE
chore(a2a): private webhook variables

### DIFF
--- a/src/strands_tools/a2a_client.py
+++ b/src/strands_tools/a2a_client.py
@@ -50,17 +50,15 @@ class A2AClientToolProvider:
         self._httpx_client: httpx.AsyncClient | None = None
         self._client_factory: ClientFactory | None = None
         self._initial_discovery_done: bool = False
-        
+
         # Push notification configuration
-        self.webhook_url = webhook_url
-        self.webhook_token = webhook_token
+        self._webhook_url = webhook_url
+        self._webhook_token = webhook_token
         self._push_config: PushNotificationConfig | None = None
-        
-        if webhook_url and webhook_token:
+
+        if self._webhook_url and self._webhook_token:
             self._push_config = PushNotificationConfig(
-                id=f"strands-webhook-{uuid4().hex[:8]}",
-                url=webhook_url,
-                token=webhook_token
+                id=f"strands-webhook-{uuid4().hex[:8]}", url=self._webhook_url, token=self._webhook_token
             )
 
     @property


### PR DESCRIPTION
## Description

Converts `webhook_url` and `webhook_token` attributes in the `A2AClientToolProvider` class to private variables by prefixing them with underscores (`_webhook_url` and `_webhook_token`). 

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): Code refactoring - improved encapsulation

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.