### PR TITLE
created typed files to supports typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,16 @@ dependencies = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/strands_tools"]
 
+[tool.hatch.build.targets.wheel.shared-data]
+"src/strands_tools/py.typed" = "strands_tools/py.typed"
+
+[tool.hatch.build]
+include = [
+    "src/strands_tools/**/*.py",
+    "src/strands_tools/py.typed",
+    "src/strands_tools/**/py.typed",
+]
+
 [tool.hatch.metadata]
 allow-direct-references = true
 

--- a/src/strands_tools/browser/py.typed
+++ b/src/strands_tools/browser/py.typed
@@ -1,0 +1,1 @@
+# Marker file that indicates this package supports typing

--- a/src/strands_tools/code_interpreter/py.typed
+++ b/src/strands_tools/code_interpreter/py.typed
@@ -1,0 +1,1 @@
+# Marker file that indicates this package supports typing

--- a/src/strands_tools/py.typed
+++ b/src/strands_tools/py.typed
@@ -1,0 +1,1 @@
+# Marker file that indicates this package supports typing

--- a/src/strands_tools/utils/models/py.typed
+++ b/src/strands_tools/utils/models/py.typed
@@ -1,0 +1,1 @@
+# Marker file that indicates this package supports typing

--- a/src/strands_tools/utils/py.typed
+++ b/src/strands_tools/utils/py.typed
@@ -1,0 +1,1 @@
+# Marker file that indicates this package supports typing


### PR DESCRIPTION
## Description

Currently an errod "stubs or py.typed marker was raised on strands_tools" is raised whenusing static type checker such as MyPy, this pr is to fix it.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New Tool
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
