### PR TITLE
fix(code_interpreter): improve code_interpreter docstring

### DIFF
--- a/src/strands_tools/code_interpreter/code_interpreter.py
+++ b/src/strands_tools/code_interpreter/code_interpreter.py
@@ -192,6 +192,22 @@ class CodeInterpreter(ABC):
 
     @tool
     def code_interpreter(self, code_interpreter_input: CodeInterpreterInput) -> Dict[str, Any]:
+        """
+        Execute code in isolated sandbox environments.
+
+        Usage with Strands Agent:
+        ```python
+        code_interpreter = AgentCoreCodeInterpreter(region="us-west-2")
+        agent = Agent(tools=[code_interpreter.code_interpreter])
+        ```
+
+        Args:
+            code_interpreter_input: Structured input containing the action to perform.
+
+        Returns:
+            Dict containing execution results.
+        """
+
         # Auto-start platform on first use
         if not self._started:
             self._start()


### PR DESCRIPTION
- Add docstring to code_interpreter to allow usage with other agents (like langgraph)

BREAKING CHANGE: None - It’s only an improvement with a comment

Refs:  #214

## Description

Add a docstring to code_interpreter. With this comment the tool can be used with langgraph

## Related Issues

No issues

## Documentation PR


## Type of Change

Other: add a docstring for one function

## Testing

No broken tests
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
