### PR TITLE
Fix: Add missing identifier assignment in AgentCoreBrowser.__init__

### DIFF
--- a/src/strands_tools/browser/agent_core_browser.py
+++ b/src/strands_tools/browser/agent_core_browser.py
@@ -28,10 +28,12 @@ class AgentCoreBrowser(Browser):
 
         Args:
             region: AWS region for the browser service
+            identifier: Browser service identifier
             session_timeout: Session timeout in seconds (default: 3600)
         """
         super().__init__()
         self.region = resolve_region(region)
+        self.identifier = identifier
         self.session_timeout = session_timeout
         self._client_dict: Dict[str, AgentCoreBrowserClient] = {}
 

--- a/tests/browser/test_agent_core_browser.py
+++ b/tests/browser/test_agent_core_browser.py
@@ -23,6 +23,25 @@ def test_bedrock_browser_with_custom_params():
     assert browser.session_timeout == 7200
 
 
+def test_bedrock_browser_identifier_assignment():
+    """Test AgentCoreBrowser identifier parameter assignment."""
+    # Test default identifier
+    browser_default = AgentCoreBrowser()
+    assert hasattr(browser_default, "identifier")
+    assert browser_default.identifier == "aws.browser.v1"
+
+    # Test custom identifier
+    custom_identifier = "my.custom.browser.v2"
+    browser_custom = AgentCoreBrowser(identifier=custom_identifier)
+    assert browser_custom.identifier == custom_identifier
+
+    # Test identifier with other parameters
+    browser_all_params = AgentCoreBrowser(region="us-west-2", identifier="test.browser.v1", session_timeout=3600)
+    assert browser_all_params.identifier == "test.browser.v1"
+    assert browser_all_params.region == "us-west-2"
+    assert browser_all_params.session_timeout == 3600
+
+
 @pytest.mark.asyncio
 async def test_bedrock_browser_create_browser_session_no_playwright():
     """Test creating session browser without playwright initialized."""


### PR DESCRIPTION
## Description
The `AgentCoreBrowser.__init__()` method accepts an `identifier` parameter but never assigns it to `self.identifier`, causing an `AttributeError` when `create_browser_session()` tries to access it.

This PR adds the missing assignment `self.identifier = identifier` in the constructor and updates the docstring to properly document the identifier parameter.

## Related Issues
Fixes #222

## Documentation PR
N/A - This is a bug fix that doesn't require documentation changes

## Type of Change
Bug fix

## Testing
How have you tested the change?
- Created and ran comprehensive test script that verifies:
  - Default identifier assignment works correctly
  - Custom identifier assignment works correctly
  - All constructor parameters work together properly
  - The identifier attribute is accessible in class methods
  - Documentation is complete and accurate
- Verified that the fix resolves the AttributeError without breaking existing functionality
- Confirmed backward compatibility is maintained

Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
