### PR TITLE
fix: linting error in hand_off_to_user

### DIFF
--- a/src/strands_tools/handoff_to_user.py
+++ b/src/strands_tools/handoff_to_user.py
@@ -179,7 +179,9 @@ def handoff_to_user(tool: ToolUse, **kwargs: Any) -> ToolResult:
     else:
         # Wait for user input and continue
         try:
-            user_response = get_user_input(f"<bold>Agent requested user input:</bold> {message}\n<bold>Your response:</bold> ").strip()
+            user_response = get_user_input(
+                f"<bold>Agent requested user input:</bold> {message}\n<bold>Your response:</bold> "
+            ).strip()
 
             console.print()
 

--- a/tests/test_handoff_to_user.py
+++ b/tests/test_handoff_to_user.py
@@ -63,7 +63,9 @@ def test_handoff_with_breakout_false_direct(mock_get_user_input, mock_request_st
     result = handoff_to_user.handoff_to_user(tool=tool_use, request_state=mock_request_state)
 
     # Verify get_user_input was called
-    mock_get_user_input.assert_called_once_with("<bold>Agent requested user input:</bold> Please confirm the action.\n<bold>Your response:</bold> ")
+    mock_get_user_input.assert_called_once_with(
+        "<bold>Agent requested user input:</bold> Please confirm the action.\n<bold>Your response:</bold> "
+    )
 
     # Verify the result has the expected structure
     assert result["toolUseId"] == "test-tool-use-id"


### PR DESCRIPTION
## Description

<!-- Provide a detailed description of the changes in this PR -->
Fix linting error in the tool handoff_to_user:

```
src/strands_tools/handoff_to_user.py:182:121: E501 Line too long (135 > 120)
tests/test_handoff_to_user.py:66:121: E501 Line too long (148 > 120)

```

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New Tool
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
