### PR TITLE
docs: update the README.md file to use correct syntax for installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pip install strands-agents-tools
 To install the dependencies for optional tools:
 
 ```bash
-pip install strands-agents-tools[mem0_memory, use_browser, rss, use_computer]
+pip install "strands-agents-tools[mem0_memory, use_browser, rss, use_computer]"
 ```
 
 ### Development Install


### PR DESCRIPTION
## Description

Updates the README.md file to use correct syntax for installing the `strands-agents-tools` with extra libraries. It was failing with the following error prior to adding the updated syntax:
```
>>> uv pip install strands-agents-tools[mem0_memory, use_browser, rss, use_computer]
zsh: bad pattern: strands-agents-tools[mem0_memory,
```

## Related Issues

n/a

## Documentation PR

n/a

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Documentation update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
