### PR TITLE
fix(Browser): prevent new_context calls when using persistent_context

### DIFF
--- a/src/strands_tools/browser/browser.py
+++ b/src/strands_tools/browser/browser.py
@@ -238,9 +238,19 @@ class Browser(ABC):
 
         try:
             # Create new browser instance for this session
-            session_browser = await self.create_browser_session()
-            session_context = await session_browser.new_context()
-            session_page = await session_context.new_page()
+            session = await self.create_browser_session()
+
+            if isinstance(session, PlaywrightBrowser):
+                # Normal non-persistent case
+                session_browser = session
+                session_context = await session_browser.new_context()
+                session_page = await session_context.new_page()
+
+            else:
+                # Persistent context case
+                session_context = session
+                session_browser = session_context.browser
+                session_page = await session_context.new_page()
 
             # Create and store session object
             session = BrowserSession(


### PR DESCRIPTION
## Description
Bug Fix: Properly handle ```persistent_context``` sessions in LocalChromiumBrowser by avoiding calls to ```new_context()``` on a persistent session.

## Summary
This PR fixes a bug where initializing a LocalChromiumBrowser session with ```persistent_context=True``` caused failures because ```launch_persistent_context()``` returns a ```BrowserContext``` rather than a ```Browser```. Previously, the tool attempted to call ```new_context()``` on this object, which is invalid.

## Related Issues

Resolves #204 

## Changes Made
**File**: ```src/strands_tools/browser.py```
- Updated session creation logic to distinguish between persistent and non-persistent sessions.
- If the returned object is a ```Browser``` (non-persistent case), a new context and page are created.
- If the returned object is a ```BrowserContext``` (persistent case), the context itself is used.
   - It just gives you access to the already running Chromium Browser object that owns this context.
   - And only a new page is created.
- Added safeguard to correctly assign ```session_browser``` and ```session_context``` in both cases.
- Improved comments to clarify persistent vs. non-persistent session handling.

## Usage Example

```
from strands import Agent
from strands_tools.browser import LocalChromiumBrowser

browser = LocalChromiumBrowser(
    launch_options={
        "persistent_context": True,
        "user_data_dir": os.getenv("PROFILE_DIR")
    }
)
agent = Agent(tools=[browser.browser])

# Start session
agent.tool.browser(
    browser_input={
        "action": {
            "type": "init_session",
            "session_name": "example-session",
            "description": "Persistence test session"
        }
    }
)
```

Output: No error or failures.

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
