### PR TITLE
feat(file_read): add default encoding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,6 +924,7 @@ The Mem0 Memory Tool supports three different backend configurations:
 | FILE_READ_DIFF_TYPE_DEFAULT | Default diff type for file comparisons | unified |
 | FILE_READ_USE_GIT_DEFAULT | Default setting for using git in time machine mode | true |
 | FILE_READ_NUM_REVISIONS_DEFAULT | Default number of revisions to show in time machine mode | 5 |
+| FILE_READ_ENCODING_DEFAULT | Default text encoding for file operations | utf-8 |
 
 #### Browser Tool
 

--- a/tests/test_file_read.py
+++ b/tests/test_file_read.py
@@ -323,3 +323,51 @@ def test_file_read_error_message_brackets():
     result = file_read.file_read(tool=tool_use)
 
     assert result["status"] == "error"
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["view", "preview", "stats", "lines", "chunk", "search", "diff"],
+)
+@pytest.mark.parametrize(
+    "tool_encoding,file_encoding,content",
+    [
+        (None, "utf-8", "Hello 世界"),
+        ("utf-8", "utf-8", "Hello 世界"),
+        ("cp932", "cp932", "Hello 世界"),
+        ("latin-1", "latin-1", "Hello world"),
+    ],
+)
+def test_file_read_encoding(tmp_path, mode, tool_encoding, file_encoding, content):
+    """Test file read with text encoding option."""
+    # Create test file with specified encoding
+    file1_path = tmp_path / "test1.txt"
+    file1_path.write_text(content, encoding=file_encoding)
+
+    tool_input = {
+        "path": str(file1_path),
+        "mode": mode,
+        "encoding": tool_encoding,
+    }
+    expected_content = content
+
+    if mode == "search":
+        expected_content = content.split()[-1]  # Use the last word from content
+        tool_input["search_pattern"] = expected_content
+
+    if mode == "diff":
+        # Create a second file for diffing
+        file2_path = tmp_path / "test2.md"
+        file2_path.write_text("Different content", encoding=file_encoding)
+        tool_input["comparison_path"] = str(file2_path)
+
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": tool_input,
+    }
+
+    result = file_read.file_read(tool=tool_use)
+    result_text = extract_result_text(result)
+
+    assert result["status"] == "success"
+    assert expected_content in result_text


### PR DESCRIPTION
## Description

Add comprehensive text encoding support to the `file_read` tool.  
This allows proper handling of international text files (Japanese, Chinese, Korean, etc.) across all file reading modes.

- Added `encoding` parameter to all file reading functions with `utf-8` default
- Added `FILE_READ_ENCODING_DEFAULT` environment variable for global configuration

**Example issue:**
In Japanese Windows environments, the default system encoding is CP932. When Python opens files without an explicit encoding specification, it uses this system default, which can cause UTF-8 text files to fail due to encoding errors.  
This enhancement sets UTF-8 as the explicit default, preventing these common encoding failures.  
Users can also override the encoding as needed via tool arguments or environment variables.  

**Note:** This change may be slightly breaking for code that relies on the system default encoding.

Thank you!

## Related Issues

## Documentation PR

None (covered in docstrings).

## Type of Change

~~Bug fix~~
~~New Tool~~
~~Breaking change~~
~~Documentation update~~
Other (please describe): Feature enhancement to existing tool

## Testing

- [x] I ran `hatch fmt --formatter`
- [x] I ran `hatch fmt --linter`
- [x] I ran `hatch test`
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
