### PR TITLE
fix: fix infinite loop in workflow tool with duplicate task names

### DIFF
--- a/src/strands_tools/workflow.py
+++ b/src/strands_tools/workflow.py
@@ -686,6 +686,9 @@ class WorkflowManager:
             completed_count = sum(1 for result in workflow["task_results"].values() if result["status"] == "completed")
             success_rate = (completed_count / total_tasks) * 100 if total_tasks > 0 else 0
 
+            # Reinstantiate Task Executor for next workflow execution
+            self.task_executor = TaskExecutor()
+
             return {
                 "status": "success",
                 "content": [


### PR DESCRIPTION
## Description

This PR instantiates a new TaskExecutor after each workflow execution.

This is needed to avoid infinite loop on consecutive workflow executions with workflows containing tasks with the same names.

## Related Issues

#244 

## Documentation PR

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x ] I ran `hatch run prepare`

## Checklist
- [x ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x ] My changes generate no new warnings
- [x ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
