### PR TITLE
Fix: Mem0 graph data handling 

### DIFF
--- a/src/strands_tools/mem0_memory.py
+++ b/src/strands_tools/mem0_memory.py
@@ -457,7 +457,8 @@ def format_retrieve_response(memories: List[Dict]) -> Panel:
 def format_retrieve_graph_response(memories: List[Dict]) -> Panel:
     """Format retrieve response for graph data"""
     if not memories:
-        return Panel("No graph memories found matching the query.", title="[bold yellow]No Matches", border_style="yellow")
+        return Panel("No graph memories found matching the query.",
+                     title="[bold yellow]No Matches", border_style="yellow")
 
     table = Table(title="Search Results", show_header=True, header_style="bold magenta")
     table.add_column("Source", style="cyan")


### PR DESCRIPTION
## Description

This PR aims to update the existing the mem0 response handling logic for `list` and `retrieve` operation to make sure data returned from graph backend are printed on screen and being considered for the sub-sequent steps of the agent workflow. 

## Related Issues

[<!-- Link to related issues using #issue-number format -->](https://github.com/strands-agents/tools/pull/230)

## Documentation PR

N/A, as there is no user-facing change on this PR. 

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli


Execute the both `list` and `retreive` operations against mem0 and make sure graph results are being populated as expected. 
```
    memory_agent.tool.mem0_memory(action="list", user_id=USER_ID)
    memory_agent.tool.mem0_memory(action="retrieve", query="accommodation preferences travel Japan trip", user_id=USER_ID)
```
```
╭─────────────────────────── Memories List (Graph) ────────────────────────────╮
│                                Graph Memories                                │
│ ┏━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓ │
│ ┃ Source   ┃ Relationship                                       ┃ Target   ┃ │
│ ┡━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩ │
│ │ mem0_us… │ enjoys                                             │ outdoor… │ │
│ │ mem0_us… │ hobby                                              │ outdoor… │ │
│ │ mem0_us… │ prefers                                            │ airbnbs  │ │
│ │ mem0_us… │ preference                                         │ airbnbs  │ │
│ │ mem0_us… │ name                                               │ alex     │ │
│ │ mem0_us… │ not_preferred                                      │ hotels   │ │
│ │ mem0_us… │ has_pet                                            │ max      │ │
│ │ mem0_us… │ owns                                               │ max      │ │
│ │ mem0_us… │ pet                                                │ max      │ │
│ │ mem0_us… │ plans_trip_to                                      │ japan    │ │
│ │ mem0_us… │ planning_trip_to                                   │ japan    │ │
│ │ mem0_us… │ destination                                        │ japan    │ │
│ │ mem0_us… │ favorite_cuisine                                   │ italian… │ │
│ │ mem0_us… │ enjoys                                             │ hiking   │ │
│ │ mem0_us… │ hobby                                              │ hiking   │ │
│ │ max      │ is_a                                               │ dog      │ │
│ └──────────┴────────────────────────────────────────────────────┴──────────┘ │
╰──────────────────────────────────────────────────────────────────────────────╯

╭─────────────────────────── Search Results (Graph) ───────────────────────────╮
│                                Search Results                                │
│ ┏━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓ │
│ ┃ Source   ┃ Relationship                                       ┃ Destina… ┃ │
│ ┡━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩ │
│ │ mem0_us… │ plans_trip_to                                      │ japan    │ │
│ │ mem0_us… │ planning_trip_to                                   │ japan    │ │
│ │ mem0_us… │ destination                                        │ japan    │ │
│ └──────────┴────────────────────────────────────────────────────┴──────────┘ │
╰──────────────────────────────────────────────────────────────────────────────╯
```


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
