### PR TITLE
Get default collection name from environment when using mem0_memory t…

### DIFF
--- a/src/strands_tools/mem0_memory.py
+++ b/src/strands_tools/mem0_memory.py
@@ -166,7 +166,7 @@ class Mem0ServiceClient:
             "provider": "opensearch",
             "config": {
                 "port": 443,
-                "collection_name": "mem0_memories",
+                "collection_name": os.environ.get("OPENSEARCH_COLLECTION", "mem0"),
                 "host": os.environ.get("OPENSEARCH_HOST"),
                 "embedding_model_dims": 1024,
                 "connection_class": RequestsHttpConnection,


### PR DESCRIPTION
…ool and initiating it use default configuration

## Description
Get the collection_name from the environment rather than use the 'mem0_memory' when use mem0-memory tool with the default configuration.

When use 'mem0_memory' as the collection name to create a collection in AWS Opensearch, it is not a valid collection name.

## Related Issues

[#250](https://github.com/strands-agents/tools/issues/250)

## Documentation PR

N/A, as there is no user-facing change on this PR.

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New Tool
Breaking change
Documentation update
Other (please describe): Enhancement. 

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
