### PR TITLE
feat(editor): add option to skip backup file creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,7 @@ The Mem0 Memory Tool supports three different backend configurations:
 | EDITOR_DIR_TREE_MAX_DEPTH | Maximum depth for directory tree visualization | 2 |
 | EDITOR_DEFAULT_STYLE | Default style for output panels | default |
 | EDITOR_DEFAULT_LANGUAGE | Default language for syntax highlighting | python |
+| EDITOR_DISABLE_BACKUP | Skip creating .bak backup files during edit operations | false |
 
 #### Environment Tool
 

--- a/src/strands_tools/editor.py
+++ b/src/strands_tools/editor.py
@@ -536,8 +536,10 @@ def editor(
 
             # Make replacements and backup
             new_content = content.replace(old_str, new_str)
-            backup_path = f"{path}.bak"
-            shutil.copy2(path, backup_path)
+            disable_backup = os.environ.get("EDITOR_DISABLE_BACKUP", "").lower() == "true"
+            if not disable_backup:
+                backup_path = f"{path}.bak"
+                shutil.copy2(path, backup_path)
 
             # Write new content and update cache
             with open(path, "w") as f:
@@ -606,8 +608,12 @@ def editor(
 
             # Make replacements and backup
             new_content = regex.sub(new_str, content)
-            backup_path = f"{path}.bak"
-            shutil.copy2(path, backup_path)
+            disable_backup = os.environ.get("EDITOR_DISABLE_BACKUP", "").lower() == "true"
+            if not disable_backup:
+                backup_path = f"{path}.bak"
+                shutil.copy2(path, backup_path)
+            else:
+                backup_path = "Disabled"
 
             # Write new content and update cache
             with open(path, "w") as f:
@@ -678,8 +684,10 @@ def editor(
                 raise ValueError(f"insert_line {insert_line} is out of range")
 
             # Make backup
-            backup_path = f"{path}.bak"
-            shutil.copy2(path, backup_path)
+            disable_backup = os.environ.get("EDITOR_DISABLE_BACKUP", "").lower() == "true"
+            if not disable_backup:
+                backup_path = f"{path}.bak"
+                shutil.copy2(path, backup_path)
 
             # Insert and write
             lines.insert(insert_line, new_str)

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -254,6 +254,79 @@ class TestEditorDirectCalls:
             assert "Line 2\nINSERTED LINE\nLine 3\n" in content
 
     @patch("strands_tools.editor.get_user_input")
+    @patch.dict("os.environ", {"EDITOR_DISABLE_BACKUP": "true"})
+    def test_str_replace_no_backup(self, mock_user_input, temp_file, clean_content_history):
+        """Test str_replace without creating backup when EDITOR_DISABLE_BACKUP is set."""
+        mock_user_input.return_value = "y"
+
+        result = editor.editor(
+            command="str_replace",
+            path=temp_file,
+            old_str="Line 2",
+            new_str="Modified Line 2"
+        )
+
+        assert result["status"] == "success"
+
+        # Verify backup was NOT created
+        backup_path = f"{temp_file}.bak"
+        assert not os.path.exists(backup_path)
+
+    @patch("strands_tools.editor.get_user_input")
+    @patch.dict("os.environ", {"EDITOR_DISABLE_BACKUP": "true"})
+    def test_pattern_replace_no_backup(self, mock_user_input, temp_file, clean_content_history):
+        """Test pattern_replace without creating backup."""
+        mock_user_input.return_value = "y"
+
+        result = editor.editor(
+            command="pattern_replace",
+            path=temp_file,
+            pattern="Line.*",
+            new_str="Updated Line"
+        )
+
+        assert result["status"] == "success"
+        backup_path = f"{temp_file}.bak"
+        assert not os.path.exists(backup_path)
+
+    @patch("strands_tools.editor.get_user_input")
+    @patch.dict("os.environ", {"EDITOR_DISABLE_BACKUP": "true"})
+    def test_insert_no_backup(self, mock_user_input, temp_file, clean_content_history):
+        """Test insert without creating backup."""
+        mock_user_input.return_value = "y"
+
+        result = editor.editor(
+            command="insert",
+            path=temp_file,
+            new_str="New line",
+            insert_line=2
+        )
+
+        assert result["status"] == "success"
+        backup_path = f"{temp_file}.bak"
+        assert not os.path.exists(backup_path)
+
+    @patch("strands_tools.editor.get_user_input")
+    def test_backup_created_by_default(self, mock_user_input, temp_file, clean_content_history):
+        """Test that backup is still created by default."""
+        # Ensure env var is not set
+        if "EDITOR_DISABLE_BACKUP" in os.environ:
+            del os.environ["EDITOR_DISABLE_BACKUP"]
+
+        mock_user_input.return_value = "y"
+
+        result = editor.editor(
+            command="str_replace",
+            path=temp_file,
+            old_str="Line 2",
+            new_str="Modified Line 2"
+        )
+
+        assert result["status"] == "success"
+        backup_path = f"{temp_file}.bak"
+        assert os.path.exists(backup_path)
+
+    @patch("strands_tools.editor.get_user_input")
     def test_insert_with_search_text(self, mock_user_input, temp_file, clean_content_history):
         """Test inserting text after a line found by search."""
         mock_user_input.return_value = "y"  # Confirm insertion


### PR DESCRIPTION
## Description

Adds a new environment variable `EDITOR_DISABLE_BACKUP` that allows users to skip the creation of .bak backup files during editor operations. When set to "true", the editor tool will no longer create backup files for str_replace, pattern_replace, and insert commands, which can be useful in automated environments or when backup files are not desired.

The feature maintains backward compatibility - backup files are still created by default unless explicitly disabled.

## Related Issues

n/a

## Documentation PR

n/a

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New Tool
Breaking change
Documentation update
Other (please describe): enhancement

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
