### PR TITLE
Add Amazon S3 Vector Memory tool for memory management

### DIFF
--- a/src/strands_tools/s3_vector_memory.py
+++ b/src/strands_tools/s3_vector_memory.py
@@ -43,13 +43,15 @@ Requirements:
     - Amazon Bedrock access for embeddings
 """
 
-import boto3
 import json
-import uuid
 import os
-from typing import Dict, List
+import uuid
 from datetime import datetime
+from typing import Dict, List
+
+import boto3
 from strands import tool
+
 
 @tool
 def s3_vector_memory(
@@ -62,16 +64,16 @@ def s3_vector_memory(
     top_k: int = 20,
     region_name: str = None,
     embedding_model: str = None,
-    min_score: float = 0.1
+    min_score: float = 0.1,
 ) -> Dict:
     """
     AWS-native memory management using Amazon S3 Vectors.
-    
+
     Actions:
     - store: Store new memory content
     - retrieve: Search and retrieve relevant memories
     - list: List all user memories
-    
+
     Args:
         action: Operation to perform (store/retrieve/list)
         content: Content to store (required for store action)
@@ -83,28 +85,28 @@ def s3_vector_memory(
         region_name: AWS region (env: AWS_REGION, default: us-east-1)
         embedding_model: Bedrock embedding model (env: EMBEDDING_MODEL)
         min_score: Minimum similarity threshold (default: 0.1)
-        
+
     Returns:
         Dict with operation results and status
     """
-    
+
     # Validate required user_id for security
     if not user_id:
         return {"status": "error", "message": "user_id is required for memory isolation"}
-    
+
     try:
         # Load configuration from environment or parameters
         config = {
-            "bucket_name": vector_bucket_name or os.environ.get('VECTOR_BUCKET_NAME', 'multimodal-vector-store'),
-            "index_name": index_name or os.environ.get('VECTOR_INDEX_NAME', 'strands-multimodal'),
-            "region": region_name or os.environ.get('AWS_REGION', 'us-east-1'),
-            "model_id": embedding_model or os.environ.get('EMBEDDING_MODEL', 'amazon.titan-embed-text-v2:0')
+            "bucket_name": vector_bucket_name or os.environ.get("VECTOR_BUCKET_NAME", "multimodal-vector-store"),
+            "index_name": index_name or os.environ.get("VECTOR_INDEX_NAME", "strands-multimodal"),
+            "region": region_name or os.environ.get("AWS_REGION", "us-east-1"),
+            "model_id": embedding_model or os.environ.get("EMBEDDING_MODEL", "amazon.titan-embed-text-v2:0"),
         }
-        
+
         # Initialize AWS clients
         bedrock = boto3.client("bedrock-runtime", region_name=config["region"])
         s3vectors = boto3.client("s3vectors", region_name=config["region"])
-        
+
         # Route to appropriate action
         if action == "store":
             return _store_memory(s3vectors, bedrock, config, content, user_id)
@@ -114,66 +116,56 @@ def s3_vector_memory(
             return _list_memories(s3vectors, bedrock, config, user_id, top_k)
         else:
             return {"status": "error", "message": f"Invalid action: {action}"}
-    
+
     except Exception as e:
         return {"status": "error", "message": str(e)}
+
 
 def _generate_embedding(bedrock, model_id: str, text: str) -> List[float]:
     """Generate text embedding using Amazon Bedrock."""
     # Truncate text if exceeds model limit
     if len(text) > 8000:
         text = text[:8000]
-    
-    response = bedrock.invoke_model(
-        modelId=model_id,
-        body=json.dumps({"inputText": text})
-    )
-    
+
+    response = bedrock.invoke_model(modelId=model_id, body=json.dumps({"inputText": text}))
+
     return json.loads(response["body"].read())["embedding"]
+
 
 def _store_memory(s3vectors, bedrock, config: Dict, content: str, user_id: str) -> Dict:
     """Store memory with user isolation."""
     if not content:
         return {"status": "error", "message": "content is required for store action"}
-    
+
     # Generate embedding
     embedding = _generate_embedding(bedrock, config["model_id"], content)
-    
+
     # Create unique memory key with user prefix
     memory_key = f"{user_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
-    
+
     # Prepare vector data with metadata
     vector_data = {
         "key": memory_key,
         "data": {"float32": [float(x) for x in embedding]},
-        "metadata": {
-            "user_id": user_id,
-            "content": content,
-            "timestamp": datetime.now().isoformat()
-        }
-    }
-    
-    # Store in S3 Vectors
-    s3vectors.put_vectors(
-        vectorBucketName=config["bucket_name"],
-        indexName=config["index_name"],
-        vectors=[vector_data]
-    )
-    
-    return {
-        "status": "success", 
-        "message": "Memory stored successfully", 
-        "memory_key": memory_key
+        "metadata": {"user_id": user_id, "content": content, "timestamp": datetime.now().isoformat()},
     }
 
-def _retrieve_memories(s3vectors, bedrock, config: Dict, query: str, user_id: str, top_k: int, min_score: float) -> Dict:
+    # Store in S3 Vectors
+    s3vectors.put_vectors(vectorBucketName=config["bucket_name"], indexName=config["index_name"], vectors=[vector_data])
+
+    return {"status": "success", "message": "Memory stored successfully", "memory_key": memory_key}
+
+
+def _retrieve_memories(
+    s3vectors, bedrock, config: Dict, query: str, user_id: str, top_k: int, min_score: float
+) -> Dict:
     """Retrieve relevant memories for user."""
     if not query:
         return {"status": "error", "message": "query is required for retrieve action"}
-    
+
     # Generate query embedding
     query_embedding = _generate_embedding(bedrock, config["model_id"], query)
-    
+
     # Search with user filter for isolation
     response = s3vectors.query_vectors(
         vectorBucketName=config["bucket_name"],
@@ -182,43 +174,41 @@ def _retrieve_memories(s3vectors, bedrock, config: Dict, query: str, user_id: st
         topK=top_k,
         filter={"user_id": user_id},
         returnDistance=True,
-        returnMetadata=True
+        returnMetadata=True,
     )
-    
+
     # Process results
     memories = []
     for vector in response.get("vectors", []):
         # Verify user isolation
         if vector["metadata"].get("user_id") != user_id:
             continue
-            
+
         # Calculate similarity score
         similarity = 1.0 - vector.get("distance", 1.0)
-        
+
         # Filter by minimum score
         if similarity >= min_score:
-            memories.append({
-                "id": vector["key"],
-                "memory": vector["metadata"].get("content", ""),
-                "similarity": round(similarity, 3),
-                "created_at": vector["metadata"].get("timestamp", "")
-            })
-    
+            memories.append(
+                {
+                    "id": vector["key"],
+                    "memory": vector["metadata"].get("content", ""),
+                    "similarity": round(similarity, 3),
+                    "created_at": vector["metadata"].get("timestamp", ""),
+                }
+            )
+
     # Sort by similarity
     memories.sort(key=lambda x: x["similarity"], reverse=True)
-    
-    return {
-        "status": "success",
-        "memories": memories[:top_k],
-        "total_found": len(memories),
-        "query": query
-    }
+
+    return {"status": "success", "memories": memories[:top_k], "total_found": len(memories), "query": query}
+
 
 def _list_memories(s3vectors, bedrock, config: Dict, user_id: str, top_k: int) -> Dict:
     """List all user memories."""
     # Use generic embedding for listing
     generic_embedding = _generate_embedding(bedrock, config["model_id"], "user memories")
-    
+
     # Query all user vectors
     response = s3vectors.query_vectors(
         vectorBucketName=config["bucket_name"],
@@ -226,27 +216,25 @@ def _list_memories(s3vectors, bedrock, config: Dict, user_id: str, top_k: int) -
         queryVector={"float32": generic_embedding},
         topK=top_k,
         filter={"user_id": user_id},
-        returnMetadata=True
+        returnMetadata=True,
     )
-    
+
     # Process memories
     memories = []
     for vector in response.get("vectors", []):
         # Verify user isolation
         if vector["metadata"].get("user_id") != user_id:
             continue
-            
-        memories.append({
-            "id": vector["key"],
-            "memory": vector["metadata"].get("content", ""),
-            "created_at": vector["metadata"].get("timestamp", "")
-        })
-    
+
+        memories.append(
+            {
+                "id": vector["key"],
+                "memory": vector["metadata"].get("content", ""),
+                "created_at": vector["metadata"].get("timestamp", ""),
+            }
+        )
+
     # Sort by creation time
     memories.sort(key=lambda x: x.get("created_at", ""), reverse=True)
-    
-    return {
-        "status": "success", 
-        "memories": memories, 
-        "total_found": len(memories)
-    }
+
+    return {"status": "success", "memories": memories, "total_found": len(memories)}


### PR DESCRIPTION
## Description

This PR introduces a new Amazon S3 Vector Memory tool that provides AWS-native memory management for Strands agents using Amazon S3 Vectors as the backend storage.

Key Features:
• Persistent memory storage using Amazon S3 Vectors with vector similarity search
• Automatic user isolation for security (all operations require user_id)
• Three core operations: store, retrieve, and list memories
• Integration with Amazon Bedrock for text embeddings (default: amazon.titan-embed-text-v2:0)
• Flexible configuration via environment variables with sensible defaults
• Similarity-based memory retrieval with configurable thresholds
• Automatic memory key generation with timestamps and unique identifiers

Use Cases:
• Multi-session agent conversations with persistent context
• User-specific memory isolation in multi-tenant applications
• Scalable memory backend for production agent deployments
• AWS-native alternative to existing memory solutions

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

New Tool

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] Tested locally with basic functionality validation
- [x] Verified user isolation and error handling
- [x] Confirmed all validation checks work correctly
- [x] Applied code formatting with ruff (all checks pass)

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
