### PR TITLE
fix(batch): Return human-readable results for agent display

### DIFF
--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -8,9 +8,29 @@ from strands_tools import batch
 def mock_agent():
     """Fixture to create a mock agent with tools."""
     agent = MagicMock()
-    agent.tool.http_request = MagicMock(return_value={"status": "success", "result": {"ip": "127.0.0.1"}})
-    agent.tool.use_aws = MagicMock(return_value={"status": "success", "result": {"buckets": ["bucket1", "bucket2"]}})
-    agent.tool.error_tool = MagicMock(side_effect=Exception("Tool execution failed"))
+    
+    # Create a mock tool registry that mimics the real agent's tool access pattern
+    mock_tool_registry = MagicMock()
+    mock_tool_registry.registry = {
+        "http_request": MagicMock(return_value={"status": "success", "result": {"ip": "127.0.0.1"}}),
+        "use_aws": MagicMock(return_value={"status": "success", "result": {"buckets": ["bucket1", "bucket2"]}}),
+        "error_tool": MagicMock(side_effect=Exception("Tool execution failed"))
+    }
+    agent.tool_registry = mock_tool_registry
+    
+    # Create a custom mock tool object that properly handles getattr
+    class MockTool:
+        def __init__(self):
+            self.http_request = mock_tool_registry.registry["http_request"]
+            self.use_aws = mock_tool_registry.registry["use_aws"]
+            self.error_tool = mock_tool_registry.registry["error_tool"]
+        
+        def __getattr__(self, name):
+            # Return None for non-existent tools (this will make callable() return False)
+            return None
+    
+    agent.tool = MockTool()
+    
     return agent
 
 
@@ -27,12 +47,26 @@ def test_batch_success(mock_agent):
     assert result["toolUseId"] == "mock_tool_id"
     assert result["status"] == "success"
     assert len(result["content"]) == 2
-    assert result["content"][0]["json"]["name"] == "http_request"
-    assert result["content"][0]["json"]["status"] == "success"
-    assert result["content"][0]["json"]["result"]["result"]["ip"] == "127.0.0.1"
-    assert result["content"][1]["json"]["name"] == "use_aws"
-    assert result["content"][1]["json"]["status"] == "success"
-    assert result["content"][1]["json"]["result"]["result"]["buckets"] == ["bucket1", "bucket2"]
+    
+    # Check the summary text
+    assert "Batch execution completed with 2 tool(s):" in result["content"][0]["text"]
+    assert "✓ http_request: Success" in result["content"][0]["text"]
+    assert "✓ use_aws: Success" in result["content"][0]["text"]
+    
+    # Check the JSON results
+    json_content = result["content"][1]["json"]
+    assert json_content["batch_summary"]["total_tools"] == 2
+    assert json_content["batch_summary"]["successful"] == 2
+    assert json_content["batch_summary"]["failed"] == 0
+    
+    results = json_content["results"]
+    assert len(results) == 2
+    assert results[0]["name"] == "http_request"
+    assert results[0]["status"] == "success"
+    assert results[0]["result"]["result"]["ip"] == "127.0.0.1"
+    assert results[1]["name"] == "use_aws"
+    assert results[1]["status"] == "success"
+    assert results[1]["result"]["result"]["buckets"] == ["bucket1", "bucket2"]
 
 
 def test_batch_missing_tool(mock_agent):
@@ -46,10 +80,23 @@ def test_batch_missing_tool(mock_agent):
 
     assert result["toolUseId"] == "mock_tool_id"
     assert result["status"] == "success"
-    assert len(result["content"]) == 1
-    assert result["content"][0]["toolUseId"] == "mock_tool_id"
-    assert result["content"][0]["status"] == "error"
-    assert "Tool missing" in result["content"][0]["content"][0]["text"]
+    assert len(result["content"]) == 2
+    
+    # Check the summary text
+    assert "Batch execution completed with 1 tool(s):" in result["content"][0]["text"]
+    assert "✗ non_existent_tool: Error" in result["content"][0]["text"]
+    
+    # Check the JSON results
+    json_content = result["content"][1]["json"]
+    assert json_content["batch_summary"]["total_tools"] == 1
+    assert json_content["batch_summary"]["successful"] == 0
+    assert json_content["batch_summary"]["failed"] == 1
+    
+    results = json_content["results"]
+    assert len(results) == 1
+    assert results[0]["name"] == "non_existent_tool"
+    assert results[0]["status"] == "error"
+    assert "not found in agent" in results[0]["error"]
 
 
 def test_batch_tool_error(mock_agent):
@@ -63,10 +110,24 @@ def test_batch_tool_error(mock_agent):
 
     assert result["toolUseId"] == "mock_tool_id"
     assert result["status"] == "success"
-    assert len(result["content"]) == 1
-    assert result["content"][0]["toolUseId"] == "mock_tool_id"
-    assert result["content"][0]["status"] == "error"
-    assert "Error in batch tool" in result["content"][0]["content"][0]["text"]
+    assert len(result["content"]) == 2
+    
+    # Check the summary text
+    assert "Batch execution completed with 1 tool(s):" in result["content"][0]["text"]
+    assert "✗ error_tool: Error" in result["content"][0]["text"]
+    
+    # Check the JSON results
+    json_content = result["content"][1]["json"]
+    assert json_content["batch_summary"]["total_tools"] == 1
+    assert json_content["batch_summary"]["successful"] == 0
+    assert json_content["batch_summary"]["failed"] == 1
+    
+    results = json_content["results"]
+    assert len(results) == 1
+    assert results[0]["name"] == "error_tool"
+    assert results[0]["status"] == "error"
+    assert "Tool execution failed" in results[0]["error"]
+    assert "traceback" in results[0]
 
 
 def test_batch_no_invocations(mock_agent):
@@ -78,7 +139,17 @@ def test_batch_no_invocations(mock_agent):
 
     assert result["toolUseId"] == "mock_tool_id"
     assert result["status"] == "success"
-    assert len(result["content"]) == 0
+    assert len(result["content"]) == 2
+    
+    # Check the summary text
+    assert "Batch execution completed with 0 tool(s):" in result["content"][0]["text"]
+    
+    # Check the JSON results
+    json_content = result["content"][1]["json"]
+    assert json_content["batch_summary"]["total_tools"] == 0
+    assert json_content["batch_summary"]["successful"] == 0
+    assert json_content["batch_summary"]["failed"] == 0
+    assert len(json_content["results"]) == 0
 
 
 def test_batch_top_level_error(mock_agent):


### PR DESCRIPTION
- Add dual output format: human-readable text + structured JSON
- Fix misleading 'Tool missing' error messages
- Preserve original tool results while adding batch metadata
- Enable agents to display individual tool results instead of generic success message
- Fix typo: 'Sammple' -> 'Sample' in documentation
- Update tests to match new output format

Resolves issue where agents only showed 'batch call executed successfully' instead of actual tool results from parallel executions.

## Description
Fixed the batch tool to return human-readable results that agents can properly display. Previously, agents only showed "batch call executed successfully" instead of the actual results from individual tool executions.

## Related Issues
Fixes #271

## Type of Change
Bug fix

## Testing
- [x] I ran `hatch run prepare`
- All 997 tests pass with the changes
- Verified batch tool now returns dual format: human-readable text + structured JSON
- Fixed typo in documentation: 'Sammple' → 'Sample'

## Changes Made
- Add dual output format for agent compatibility  
- Fix misleading 'Tool missing' error messages
- Preserve original tool results while adding batch metadata
- Enable agents to display individual tool results
- Update tests to match new output format

This resolves the issue where agents only showed 'batch call executed successfully' instead of actual tool results from parallel executions.
How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
