### PR TITLE
feat: allow slack tool to use pass in agent

### DIFF
--- a/src/strands_tools/mem0_memory.py
+++ b/src/strands_tools/mem0_memory.py
@@ -457,8 +457,9 @@ def format_retrieve_response(memories: List[Dict]) -> Panel:
 def format_retrieve_graph_response(memories: List[Dict]) -> Panel:
     """Format retrieve response for graph data"""
     if not memories:
-        return Panel("No graph memories found matching the query.",
-                     title="[bold yellow]No Matches", border_style="yellow")
+        return Panel(
+            "No graph memories found matching the query.", title="[bold yellow]No Matches", border_style="yellow"
+        )
 
     table = Table(title="Search Results", show_header=True, header_style="bold magenta")
     table.add_column("Source", style="cyan")

--- a/src/strands_tools/slack.py
+++ b/src/strands_tools/slack.py
@@ -350,17 +350,20 @@ class SocketModeHandler:
             logger.info("Skipping own message")
             return
 
-        tools = list(self.agent.tool_registry.registry.values())
-        trace_attributes = self.agent.trace_attributes
+        if self.agent:
+            tools = list(self.agent.tool_registry.registry.values())
+            trace_attributes = self.agent.trace_attributes
 
-        agent = Agent(
-            model=self.agent.model,
-            messages=[],
-            system_prompt=f"{self.agent.system_prompt}\n{SLACK_SYSTEM_PROMPT}",
-            tools=tools,
-            callback_handler=self.agent.callback_handler,
-            trace_attributes=trace_attributes,
-        )
+            agent = Agent(
+                model=self.agent.model,
+                messages=[],
+                system_prompt=f"{self.agent.system_prompt}\n{SLACK_SYSTEM_PROMPT}",
+                tools=tools,
+                callback_handler=self.agent.callback_handler,
+                trace_attributes=trace_attributes,
+            )
+        else:
+            agent = Agent(tools=[slack], system_prompt=SLACK_SYSTEM_PROMPT, messages=[])
 
         channel_id = event.get("channel")
         text = event.get("text", "")
@@ -437,16 +440,19 @@ class SocketModeHandler:
     def _process_interactive(self, event):
         """Process an interactive event."""
         # Process interactive events similar to messages
-        if client and self.agent:
-            tools = list(self.agent.tool_registry.registry.values())
+        if client:
+            if self.agent:
+                tools = list(self.agent.tool_registry.registry.values())
 
-            agent = Agent(
-                model=self.agent.model,
-                messages=[],
-                system_prompt=SLACK_SYSTEM_PROMPT,
-                tools=tools,
-                callback_handler=self.agent.callback_handler,
-            )
+                agent = Agent(
+                    model=self.agent.model,
+                    messages=[],
+                    system_prompt=SLACK_SYSTEM_PROMPT,
+                    tools=tools,
+                    callback_handler=self.agent.callback_handler,
+                )
+            else:
+                agent = Agent(tools=[slack], system_prompt=SLACK_SYSTEM_PROMPT, messages=[])
 
             channel_id = event.get("channel")
             actions = event.get("actions", [])


### PR DESCRIPTION
## Description

<!-- Provide a detailed description of the changes in this PR -->
When we pass in `agent=` we use that pass in agent configuration.

## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/sdk-python/issues/545

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New Tool
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

Unit test and local test

- [ x] I ran `hatch run prepare`

## Checklist
- [x ] I have read the CONTRIBUTING document
- [x ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x ] My changes generate no new warnings
- [x ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
