### PR TITLE
feat: enhance retrieve tool with configurable metadata output (#280)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Below is a comprehensive table of all available tools, how to use them with an a
 | calculator | `agent.tool.calculator(expression="2 * sin(pi/4) + log(e**2)")` | Performing mathematical operations, symbolic math, equation solving |
 | code_interpreter | `code_interpreter = AgentCoreCodeInterpreter(region="us-west-2"); agent = Agent(tools=[code_interpreter.code_interpreter])` | Execute code in isolated sandbox environments with multi-language support (Python, JavaScript, TypeScript), persistent sessions, and file operations |
 | use_aws | `agent.tool.use_aws(service_name="s3", operation_name="list_buckets", parameters={}, region="us-west-2")` | Interacting with AWS services, cloud resource management |
-| retrieve | `agent.tool.retrieve(text="What is STRANDS?")` | Retrieving information from Amazon Bedrock Knowledge Bases |
+| retrieve | `agent.tool.retrieve(text="What is STRANDS?")` | Retrieving information from Amazon Bedrock Knowledge Bases with optional metadata |
 | nova_reels | `agent.tool.nova_reels(action="create", text="A cinematic shot of mountains", s3_bucket="my-bucket")` | Create high-quality videos using Amazon Bedrock Nova Reel with configurable parameters via environment variables |
 | agent_core_memory | `agent.tool.agent_core_memory(action="record", content="Hello, I like vegetarian food")` | Store and retrieve memories with Amazon Bedrock Agent Core Memory service |
 | mem0_memory | `agent.tool.mem0_memory(action="store", content="Remember I like to play tennis", user_id="alex")` | Store user and agent memories across agent runs to provide personalized experience |
@@ -501,6 +501,33 @@ result = agent.tool.use_aws(
     parameters={},
     region="us-east-1",
     label="List all subnets"
+)
+```
+
+### Retrieve Tool
+
+```python
+from strands import Agent
+from strands_tools import retrieve
+
+agent = Agent(tools=[retrieve])
+
+# Basic retrieval without metadata
+result = agent.tool.retrieve(
+    text="What is artificial intelligence?"
+)
+
+# Retrieval with metadata enabled
+result = agent.tool.retrieve(
+    text="What are the latest developments in machine learning?",
+    enableMetadata=True
+)
+
+# Using environment variable to set default metadata behavior
+# Set RETRIEVE_ENABLE_METADATA_DEFAULT=true in your environment
+result = agent.tool.retrieve(
+    text="Tell me about cloud computing"
+    # enableMetadata will default to the environment variable value
 )
 ```
 
@@ -1075,6 +1102,12 @@ The Mem0 Memory Tool supports three different backend configurations:
 | STRANDS_RSS_MAX_ENTRIES | Default setting for maximum number of entries per feed | 100 |
 | STRANDS_RSS_UPDATE_INTERVAL | Default amount of time between updating rss feeds in minutes | 60 |
 | STRANDS_RSS_STORAGE_PATH | Default storage path where rss feeds are stored locally | strands_rss_feeds (this may vary based on your system) |
+
+#### Retrieve Tool
+
+| Environment Variable | Description | Default |
+|----------------------|-------------|---------|
+| RETRIEVE_ENABLE_METADATA_DEFAULT | Default setting for enabling metadata in retrieve tool responses | false |
 
 #### Video Tools
 

--- a/src/strands_tools/retrieve.py
+++ b/src/strands_tools/retrieve.py
@@ -34,6 +34,12 @@ agent = Agent(tools=[retrieve])
 # Basic search with default knowledge base and region
 results = agent.tool.retrieve(text="What is the STRANDS SDK?")
 
+# Search with metadata enabled for source information
+results = agent.tool.retrieve(
+    text="What is the STRANDS SDK?",
+    enableMetadata=True
+)
+
 # Advanced search with custom parameters
 results = agent.tool.retrieve(
     text="deployment steps for production",
@@ -41,6 +47,7 @@ results = agent.tool.retrieve(
     score=0.7,
     knowledgeBaseId="custom-kb-id",
     region="us-east-1",
+    enableMetadata=True,
     retrieveFilter={
         "andAll": [
             {"equals": {"key": "category", "value": "security"}},
@@ -151,6 +158,14 @@ Usage Examples:
                         "specified."
                     ),
                 },
+                "enableMetadata": {
+                    "type": "boolean",
+                    "description": (
+                        "Whether to include metadata in the response. When enabled, shows source URI, chunk ID, "
+                        "data source ID, and other document metadata. Default is false."
+                    ),
+                    "default": False,
+                },
             },
             "required": ["text"],
         }
@@ -176,18 +191,21 @@ def filter_results_by_score(results: List[Dict[str, Any]], min_score: float) -> 
     return [result for result in results if result.get("score", 0.0) >= min_score]
 
 
-def format_results_for_display(results: List[Dict[str, Any]]) -> str:
+def format_results_for_display(results: List[Dict[str, Any]], enable_metadata: bool = False) -> str:
     """
     Format retrieval results for readable display.
 
     This function takes the raw results from a knowledge base query and formats
     them into a human-readable string with scores, document IDs, and content.
+    Optionally includes metadata when enabled.
 
     Args:
         results: List of retrieval results from Bedrock Knowledge Base
+        enable_metadata: Whether to include metadata in the formatted output (default: False)
 
     Returns:
-        Formatted string containing the results in a readable format, including score, document ID, and content.
+        Formatted string containing the results in a readable format, including score, 
+        document ID, optional metadata, and content.
     """
     if not results:
         return "No results found above score threshold."
@@ -210,6 +228,12 @@ def format_results_for_display(results: List[Dict[str, Any]]) -> str:
         if content and isinstance(content.get("text"), str):
             text = content["text"]
             formatted.append(f"Content: {text}\n")
+
+        # Add metadata if enabled and present
+        if enable_metadata:
+            metadata = result.get("metadata")
+            if metadata:
+                formatted.append(f"Metadata: {metadata}")
 
     return "\n".join(formatted)
 
@@ -269,6 +293,7 @@ def retrieve(tool: ToolUse, **kwargs: Any) -> ToolResult:
     default_knowledge_base_id = os.getenv("KNOWLEDGE_BASE_ID")
     default_aws_region = os.getenv("AWS_REGION", "us-west-2")
     default_min_score = float(os.getenv("MIN_SCORE", "0.4"))
+    default_enable_metadata = os.getenv("RETRIEVE_ENABLE_METADATA_DEFAULT", "false").lower() == "true"
     tool_use_id = tool["toolUseId"]
     tool_input = tool["input"]
 
@@ -279,6 +304,7 @@ def retrieve(tool: ToolUse, **kwargs: Any) -> ToolResult:
         kb_id = tool_input.get("knowledgeBaseId", default_knowledge_base_id)
         region_name = tool_input.get("region", default_aws_region)
         min_score = tool_input.get("score", default_min_score)
+        enable_metadata = tool_input.get("enableMetadata", default_enable_metadata)
         retrieve_filter = tool_input.get("retrieveFilter")
 
         # Initialize Bedrock client with optional profile name
@@ -315,8 +341,8 @@ def retrieve(tool: ToolUse, **kwargs: Any) -> ToolResult:
         all_results = response.get("retrievalResults", [])
         filtered_results = filter_results_by_score(all_results, min_score)
 
-        # Format results for display
-        formatted_results = format_results_for_display(filtered_results)
+        # Format results for display with optional metadata
+        formatted_results = format_results_for_display(filtered_results, enable_metadata)
 
         # Return success with formatted results
         return {

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -133,6 +133,145 @@ def test_format_results_for_display():
     assert "Content: S3 content" in s3_formatted
 
 
+def test_format_results_with_metadata():
+    """Test the format_results_for_display function with metadata enabled."""
+    test_results = [
+        {
+            "content": {"text": "Sample content with metadata", "type": "TEXT"},
+            "location": {
+                "customDocumentLocation": {"id": "test-doc-1"},
+                "type": "CUSTOM",
+            },
+            "score": 0.95,
+            "metadata": {
+                "x-amz-bedrock-kb-source-uri": "s3://my-bucket/documents/user-guide.pdf",
+                "x-amz-bedrock-kb-chunk-id": "chunk-12345",
+                "x-amz-bedrock-kb-data-source-id": "datasource-67890",
+                "custom-field": "production-docs"
+            }
+        }
+    ]
+
+    # Test with metadata enabled
+    formatted = retrieve.format_results_for_display(test_results, enable_metadata=True)
+    assert "Score: 0.9500" in formatted
+    assert "Document ID: test-doc-1" in formatted
+    assert "Content: Sample content with metadata" in formatted
+    # Check that metadata is included as raw dictionary
+    assert "Metadata: {" in formatted
+    assert "x-amz-bedrock-kb-source-uri" in formatted
+    assert "s3://my-bucket/documents/user-guide.pdf" in formatted
+    assert "chunk-12345" in formatted
+    assert "datasource-67890" in formatted
+    assert "custom-field" in formatted
+
+
+def test_format_results_without_metadata():
+    """Test the format_results_for_display function without metadata."""
+    test_results = [
+        {
+            "content": {"text": "Sample content without metadata", "type": "TEXT"},
+            "location": {
+                "customDocumentLocation": {"id": "test-doc-2"},
+                "type": "CUSTOM",
+            },
+            "score": 0.85,
+            "metadata": {
+                "x-amz-bedrock-kb-source-uri": "s3://my-bucket/documents/user-guide.pdf",
+                "x-amz-bedrock-kb-chunk-id": "chunk-12345",
+                "x-amz-bedrock-kb-data-source-id": "datasource-67890",
+                "custom-field": "production-docs"
+            }
+        }
+    ]
+
+    formatted = retrieve.format_results_for_display(test_results)
+    assert "Score: 0.8500" in formatted
+    assert "Document ID: test-doc-2" in formatted
+    assert "Content: Sample content without metadata" in formatted
+    # Ensure no metadata line is added when metadata is missing
+    assert "Metadata:" not in formatted
+
+
+def test_format_results_with_empty_metadata():
+    """Test the format_results_for_display function with empty metadata."""
+    test_results = [
+        {
+            "content": {"text": "Sample content with empty metadata", "type": "TEXT"},
+            "location": {
+                "customDocumentLocation": {"id": "test-doc-3"},
+                "type": "CUSTOM",
+            },
+            "score": 0.75,
+            "metadata": {}  # Empty metadata
+        }
+    ]
+
+    formatted = retrieve.format_results_for_display(test_results)
+    assert "Score: 0.7500" in formatted
+    assert "Document ID: test-doc-3" in formatted
+    assert "Content: Sample content with empty metadata" in formatted
+    # Empty metadata should not be displayed
+    assert "Metadata:" not in formatted
+
+
+def test_format_results_with_metadata_enabled():
+    """Test the format_results_for_display function with metadata enabled."""
+    test_results = [
+        {
+            "content": {"text": "Sample content with metadata enabled", "type": "TEXT"},
+            "location": {
+                "customDocumentLocation": {"id": "test-doc-4"},
+                "type": "CUSTOM",
+            },
+            "score": 0.85,
+            "metadata": {
+                "x-amz-bedrock-kb-source-uri": "s3://my-bucket/documents/guide.pdf",
+                "x-amz-bedrock-kb-chunk-id": "chunk-67890",
+                "custom-field": "test-data"
+            }
+        }
+    ]
+
+    # Test with metadata enabled
+    formatted = retrieve.format_results_for_display(test_results, enable_metadata=True)
+    assert "Score: 0.8500" in formatted
+    assert "Document ID: test-doc-4" in formatted
+    assert "Content: Sample content with metadata enabled" in formatted
+    assert "Metadata: {" in formatted
+    assert "x-amz-bedrock-kb-source-uri" in formatted
+    assert "s3://my-bucket/documents/guide.pdf" in formatted
+    assert "chunk-67890" in formatted
+    assert "custom-field" in formatted
+
+
+def test_format_results_with_metadata_disabled():
+    """Test the format_results_for_display function with metadata explicitly disabled."""
+    test_results = [
+        {
+            "content": {"text": "Sample content with metadata disabled", "type": "TEXT"},
+            "location": {
+                "customDocumentLocation": {"id": "test-doc-5"},
+                "type": "CUSTOM",
+            },
+            "score": 0.65,
+            "metadata": {
+                "x-amz-bedrock-kb-source-uri": "s3://my-bucket/documents/guide.pdf",
+                "x-amz-bedrock-kb-chunk-id": "chunk-11111"
+            }
+        }
+    ]
+
+    # Test with metadata explicitly disabled
+    formatted = retrieve.format_results_for_display(test_results, enable_metadata=False)
+    assert "Score: 0.6500" in formatted
+    assert "Document ID: test-doc-5" in formatted
+    assert "Content: Sample content with metadata disabled" in formatted
+    # Metadata should not be displayed when disabled
+    assert "Metadata:" not in formatted
+    assert "x-amz-bedrock-kb-source-uri" not in formatted
+
+
 def test_retrieve_tool_direct(mock_boto3_client):
     """Test direct invocation of the retrieve tool."""
     # Create a tool use dictionary similar to how the agent would call it
@@ -408,3 +547,140 @@ def test_retrieve_with_invalid_filter(mock_boto3_client):
     result = retrieve.retrieve(tool=tool_use)
     assert result["status"] == "error"
     assert "must contain at least 2 items" in result["content"][0]["text"]
+
+
+def test_retrieve_with_enable_metadata_true(mock_boto3_client):
+    """Test retrieve with enableMetadata=True."""
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {
+            "text": "test query",
+            "knowledgeBaseId": "test-kb-id",
+            "enableMetadata": True,
+        },
+    }
+
+    result = retrieve.retrieve(tool=tool_use)
+
+    # Verify the result has the expected structure
+    assert result["toolUseId"] == "test-tool-use-id"
+    assert result["status"] == "success"
+    assert "Retrieved 2 results with score >= 0.4" in result["content"][0]["text"]
+    
+    # Verify metadata is included in the response
+    result_text = result["content"][0]["text"]
+    assert "Metadata:" in result_text
+    assert "test-source-1" in result_text
+    assert "test-source-2" in result_text
+
+
+def test_retrieve_with_enable_metadata_false(mock_boto3_client):
+    """Test retrieve with enableMetadata=False."""
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {
+            "text": "test query",
+            "knowledgeBaseId": "test-kb-id",
+            "enableMetadata": False,
+        },
+    }
+
+    result = retrieve.retrieve(tool=tool_use)
+
+    # Verify the result has the expected structure
+    assert result["toolUseId"] == "test-tool-use-id"
+    assert result["status"] == "success"
+    assert "Retrieved 2 results with score >= 0.4" in result["content"][0]["text"]
+    
+    # Verify metadata is NOT included in the response
+    result_text = result["content"][0]["text"]
+    assert "Metadata:" not in result_text
+    assert "test-source-1" not in result_text
+    assert "test-source-2" not in result_text
+
+
+def test_retrieve_with_enable_metadata_default(mock_boto3_client):
+    """Test retrieve with default enableMetadata behavior."""
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {
+            "text": "test query",
+            "knowledgeBaseId": "test-kb-id",
+            # No enableMetadata parameter - should default to False
+        },
+    }
+
+    result = retrieve.retrieve(tool=tool_use)
+
+    # Verify the result has the expected structure
+    assert result["toolUseId"] == "test-tool-use-id"
+    assert result["status"] == "success"
+    assert "Retrieved 2 results with score >= 0.4" in result["content"][0]["text"]
+    
+    # Verify metadata is NOT included by default
+    result_text = result["content"][0]["text"]
+    assert "Metadata:" not in result_text
+    assert "test-source-1" not in result_text
+
+
+def test_retrieve_with_environment_variable_default(mock_boto3_client):
+    """Test retrieve with environment variable controlling default enableMetadata."""
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {
+            "text": "test query",
+            "knowledgeBaseId": "test-kb-id",
+            # No enableMetadata parameter - should use environment default
+        },
+    }
+
+    # Test with environment variable set to true
+    with mock.patch.dict(os.environ, {"RETRIEVE_ENABLE_METADATA_DEFAULT": "true"}):
+        result = retrieve.retrieve(tool=tool_use)
+
+    # Verify metadata is included due to environment variable
+    assert result["status"] == "success"
+    result_text = result["content"][0]["text"]
+    assert "Metadata:" in result_text
+    assert "test-source-1" in result_text
+
+    # Test with environment variable set to false
+    with mock.patch.dict(os.environ, {"RETRIEVE_ENABLE_METADATA_DEFAULT": "false"}):
+        result = retrieve.retrieve(tool=tool_use)
+
+    # Verify metadata is NOT included
+    assert result["status"] == "success"
+    result_text = result["content"][0]["text"]
+    assert "Metadata:" not in result_text
+    assert "test-source-1" not in result_text
+
+
+def test_retrieve_via_agent_with_enable_metadata(agent, mock_boto3_client):
+    """Test retrieving via the agent interface with enableMetadata."""
+    with mock.patch.dict(os.environ, {"KNOWLEDGE_BASE_ID": "agent-kb-id"}):
+        # Test with metadata enabled
+        result = agent.tool.retrieve(
+            text="agent query", 
+            knowledgeBaseId="test-kb-id",
+            enableMetadata=True
+        )
+
+    result_text = extract_result_text(result)
+    assert "Retrieved" in result_text
+    assert "results with score >=" in result_text
+    assert "Metadata:" in result_text
+    assert "test-source" in result_text
+
+    # Test with metadata disabled
+    with mock.patch.dict(os.environ, {"KNOWLEDGE_BASE_ID": "agent-kb-id"}):
+        result = agent.tool.retrieve(
+            text="agent query", 
+            knowledgeBaseId="test-kb-id",
+            enableMetadata=False
+        )
+
+    result_text = extract_result_text(result)
+    assert "Retrieved" in result_text
+    assert "results with score >=" in result_text
+    assert "Metadata:" not in result_text
+    assert "test-source" not in result_text


### PR DESCRIPTION
## Description
The retrieve tool currently does not support including metadata in its response.
This change introduces an optional parameter that enables metadata ingestion in the retrieve method’s response.

#### Implementation Details:
    - Added enableMetadata boolean parameter to retrieve tool TOOL_SPEC
    - Implemented environment variable support for default metadata behavior
    - Updated result formatting to conditionally display metadata fields
    - Ensured backward compatibility (metadata disabled by default)
    - Added comprehensive unit test coverage
    - Updated documentation and usage examples

## Related Issues

https://github.com/strands-agents/tools/issues/280

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
