### PR TITLE
fix(browser): Fix import errors for browsers with optional dependencies

### DIFF
--- a/src/strands_tools/browser/__init__.py
+++ b/src/strands_tools/browser/__init__.py
@@ -50,9 +50,14 @@ Usage:
     ```
 """
 
-from .agent_core_browser import AgentCoreBrowser
+from typing import TYPE_CHECKING
+
 from .browser import Browser
-from .local_chromium_browser import LocalChromiumBrowser
+
+# Type checking imports for static analysis
+if TYPE_CHECKING:
+    from .agent_core_browser import AgentCoreBrowser
+    from .local_chromium_browser import LocalChromiumBrowser
 
 __all__ = [
     # Base class
@@ -61,3 +66,22 @@ __all__ = [
     "LocalChromiumBrowser",
     "AgentCoreBrowser",
 ]
+
+
+def __getattr__(name: str):
+    """
+    Lazy load browser implementations only when accessed.
+    
+    This defers the import of optional dependencies until actually needed:
+    - LocalChromiumBrowser requires playwright (lazy loaded)
+    - AgentCoreBrowser requires bedrock_agentcore (lazy loaded)
+    """
+    if name == "LocalChromiumBrowser":
+        from .local_chromium_browser import LocalChromiumBrowser
+
+        return LocalChromiumBrowser
+    if name == "AgentCoreBrowser":
+        from .agent_core_browser import AgentCoreBrowser
+
+        return AgentCoreBrowser
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")


### PR DESCRIPTION
## Description

Implementing lazy loading in browser `__init__.py` file. 

This is required because the code below would throw a module not found exception for AgentCore (`ModuleNotFoundError: No module named 'bedrock_agentcore'`)
```
!pip install strands-agents-tools[local_chromium_browser]

from strands_tools.browser import LocalChromiumBrowser
```

This is because when Python is loading the init file, it also loads the dependencies and AgentCore is one of them. We need to add lazy loading to stop this problem.

## Related Issues


## Documentation PR


## Type of Change

Bug fix

## Testing

Manual testing with the code snippet below. Verified that exception is thrown before the error, and it's not thrown after.

```
from strands import Agent
from strands_tools.browser import LocalChromiumBrowser

browser = LocalChromiumBrowser()
agent = Agent(tools=[browser.browser])

agent("check out the amazon stock on yahoo finance")
```

```
$ python -m venv .venv && source .venv/vin/activate
$ pip install -e '.[local_chromium_browser]'
$ python test_script.py
```


How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
