### PR TITLE
fix(task): exexcute_task returns balnk output whe using oss model

### DIFF
--- a/src/strands_tools/workflow.py
+++ b/src/strands_tools/workflow.py
@@ -405,7 +405,6 @@ class WorkflowManager:
         wait=wait_exponential(multiplier=1, min=4, max=30),
         reraise=True,
     )
-   
     def execute_task(self, task: Dict, workflow: Dict) -> Dict:
         """Execute a single task using a specialized agent with rate limiting and retries."""
         try:
@@ -487,9 +486,6 @@ class WorkflowManager:
 
             status = "success" if stop_reason != "error" else "error"
 
-            if "ThrottlingException" in str(e):
-                logger.error(f"Task {task['task_id']} hit throttling, will retry with exponential backoff")
-                raise
             return {
                 "status": status,
                 "content": normalized_content,
@@ -499,6 +495,9 @@ class WorkflowManager:
         except Exception as e:
             error_msg = f"Error executing task {task['task_id']}: {str(e)}"
             logger.error(error_msg)
+            if "ThrottlingException" in str(e):
+                logger.error(f"Task {task['task_id']} hit throttling, will retry with exponential backoff")
+                raise
             return {
                 "status": "error",
                 "content": [{"text": error_msg}],


### PR DESCRIPTION
## Description

Refactors execute_task1 for clarity and safety:

- Removed variable assignments inside except blocks.
- Predeclared content, metrics, and stop_reason for deterministic scope.
- Simplified normalization to always produce List[{"text": str}].
- Added safe metrics_to_string conversion and consistent logging.
- Ensured consistent return schema including "metrics": None in all paths.

No functional changes to API calls or rate limiting; improves readability and eliminates potential errors

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

Bug Fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
