### PR TITLE
ci: add bedrock agentcore maintainers as CODEOWNERS of agentcore tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 *       @strands-agents/maintainers
 
 # AWS Bedrock AgentCore maintainers can approve browser and code_interpreter tools
-**/browser/**           @strands-agents/maintainers
-**/code_interpreter/**  @strands-agents/maintainers
+**/browser/**           @strands-agents/maintainers @strands-agents/bedrock-agentcore-maintainers
+**/code_interpreter/**  @strands-agents/maintainers @strands-agents/bedrock-agentcore-maintainers


### PR DESCRIPTION
## Description

To accelerate development, Strands will be granting ownership of the Strands Agents Tools relating to the Bedrock AgentCore Browser and Code Interpreter.


`@aws/bedrock-agentcore-maintainers` comes from https://github.com/aws/bedrock-agentcore-sdk-python/blob/67563f14ef828dfad9301650bbe9dc9e729b3da3/.github/CODEOWNERS#L4

## Documentation PR

N/A

## Type of Change


Other (please describe): CI 

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
