### PR TITLE
fix: force include a2a-sdk and optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ Documentation = "https://strandsagents.com/"
 [project.optional-dependencies]
 dev = [
     "commitizen>=4.4.0,<5.0.0",
-    "hatch>=1.0.0,<1.15.0",  # https://github.com/pypa/hatch/issues/2128
+    "hatch>=1.0.0,<1.15.1",  # https://github.com/pypa/hatch/issues/2128
     "mypy>=0.981,<1.0.0",
     "pre-commit>=3.2.0,<4.2.0",
     "pytest>=8.0.0,<9.0.0",


### PR DESCRIPTION
## Description

There was a backwards incompatible change relating to optional dependency resolution https://github.com/pypa/hatch/issues/2128. To mitigate this, we are placing a temporary ceiling on the hatch version.


Another example of mem0 experiencing this issue https://github.com/mem0ai/mem0/pull/3802

## Type of Change


Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
