### PR TITLE
pin hatch version

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -62,7 +62,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          pip install --no-cache-dir hatch
+          pip install --no-cache-dir -e ".[build]"
       - name: Run integration tests
         env:
           AWS_REGION: us-east-1

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -61,7 +61,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install --no-cache-dir hatch==1.15.1
+          pip install --no-cache-dir -e ".[build]"
       - name: Run Unit tests
         id: tests
         run: hatch test tests --cover
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --no-cache-dir hatch
+          pip install --no-cache-dir -e ".[build]"
 
       - name: Run lint
         id: lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,11 @@ Homepage = "https://github.com/strands-agents/tools"
 Documentation = "https://strandsagents.com/"
 
 [project.optional-dependencies]
+build = [
+    "hatch>=1.0.0,<1.16.0", # TODO: https://github.com/pypa/hatch/issues/2128
+]
 dev = [
     "commitizen>=4.4.0,<5.0.0",
-    "hatch>=1.0.0,<2.0.0",
     "mypy>=0.981,<1.0.0",
     "pre-commit>=3.2.0,<4.2.0",
     "pytest>=8.0.0,<9.0.0",
@@ -74,6 +76,7 @@ dev = [
     "nest-asyncio>=1.5.0,<2.0.0",
     "playwright>=1.42.0,<2.0.0",
     "twelvelabs>=0.4.0,<1.0.0",
+    "strands-agents-tools[build]",
 ]
 docs = [
     "sphinx>=5.0.0,<6.0.0",


### PR DESCRIPTION
## Description

Hatch was able to resolve dependencies with _ in their names. Starting in version 16.0.0, they seem to be enforcing -. A user has reported this as a bug to the hatch team ([issue](https://github.com/pypa/hatch/issues/2128)). Until we hear back on this issue, we are going to pin the hatch version for our workflows to <=1.15.1.

## Related Issues

https://github.com/pypa/hatch/issues/2128

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] I ran `hatch test tests --cover`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
