### PR TITLE
chore(deps): update bedrock-agentcore SDK to 1.1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,10 +92,10 @@ local_chromium_browser = ["nest-asyncio>=1.5.0,<2.0.0", "playwright>=1.42.0,<2.0
 agent_core_browser = [
     "nest-asyncio>=1.5.0,<2.0.0",
     "playwright>=1.42.0,<2.0.0",
-    "bedrock-agentcore==0.1.0"
+    "bedrock-agentcore>=1.1.0,<1.2.0"
 ]
 agent_core_code_interpreter = [
-    "bedrock-agentcore==0.1.0"
+    "bedrock-agentcore>=1.1.0,<1.2.0"
 ]
 a2a_client = ["a2a-sdk[sql]>=0.3.0,<0.4.0"]
 diagram = [

--- a/src/strands_tools/retrieve.py
+++ b/src/strands_tools/retrieve.py
@@ -176,8 +176,8 @@ Usage Examples:
                         "lessThanOrEquals, in (value in list), notIn, listContains (list contains value), "
                         "stringContains (substring match), startsWith (OpenSearch Serverless only), "
                         "andAll (all conditions must match, min 2 items), orAll (at least one condition must match, "
-                        "min 2 items). Example: {\"andAll\": [{\"equals\": {\"key\": \"category\", "
-                        "\"value\": \"security\"}}, {\"greaterThan\": {\"key\": \"year\", \"value\": \"2022\"}}]}"
+                        'min 2 items). Example: {"andAll": [{"equals": {"key": "category", '
+                        '"value": "security"}}, {"greaterThan": {"key": "year", "value": "2022"}}]}'
                     ),
                 },
             },

--- a/tests/test_calculator_precision.py
+++ b/tests/test_calculator_precision.py
@@ -16,6 +16,7 @@ def extract_text(result):
 # Core regression tests (original bug)
 # ------------------------------------------------------------
 
+
 def test_precision_does_not_change_real_value():
     r2 = calculator("221 * 318.11", precision=2)
     r4 = calculator("221 * 318.11", precision=4)
@@ -24,7 +25,7 @@ def test_precision_does_not_change_real_value():
     t4 = extract_text(r4)
 
     assert "70302.31" in t2
-    assert "70302.31" in t4   # trailing zeros are stripped by design
+    assert "70302.31" in t4  # trailing zeros are stripped by design
 
 
 def test_precision_does_not_change_division_value():
@@ -42,6 +43,7 @@ def test_precision_does_not_change_division_value():
 # Complex number regression tests
 # ------------------------------------------------------------
 
+
 def test_precision_does_not_change_complex_value():
     r2 = calculator("(1 + I) * 318.11", precision=2)
     r4 = calculator("(1 + I) * 318.11", precision=4)
@@ -57,6 +59,7 @@ def test_precision_does_not_change_complex_value():
 # Symbolic guardrails (correct semantics)
 # ------------------------------------------------------------
 
+
 def test_expression_with_symbols_remains_symbolic():
     r = calculator("x + 1", precision=2)
     t = extract_text(r)
@@ -69,4 +72,3 @@ def test_force_numeric_applies_numeric_evaluation():
     t = extract_text(r)
 
     assert "1.4142" in t
-


### PR DESCRIPTION
## Description


Update bedrock-agentcore dependency version constraint. The most recent version of [AgentCore SDK is 1.1.1](https://github.com/aws/bedrock-agentcore-sdk-python/releases/). This PR is updating the pinned version so we can use `1.1.x` packages.

## Related Issues

Addresses #269 

## Documentation PR

No known documentation updates.

## Type of Change

Other (please describe): Dependency update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] I ran integration test:
```
$ pytest tests_integ/browser
========================== test session starts ===========================
platform darwin -- Python 3.11.5, pytest-8.4.2, pluggy-1.6.0
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Users/ateendra/Developer/strands/tools
configfile: pyproject.toml
plugins: hypothesis-6.105.1, anyio-4.12.0, random-order-1.1.1, langsmith-0.4.1, typeguard-4.3.0, cov-7.0.0, localserver-0.8.1
collected 2 items

tests_integ/browser/test_browser.py ..                             [100%]
```

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.