### PR TITLE
fix(test): correct integration test for load_tools with agent injection

### DIFF
--- a/tests_integ/mcp_client/test_mcp_client.py
+++ b/tests_integ/mcp_client/test_mcp_client.py
@@ -463,15 +463,20 @@ class TestErrorHandlingAndReliability:
         assert result["status"] == "error"
         assert "Connection 'nonexistent_connection' not found" in result["content"][0]["text"]
 
-    def test_load_tools_without_agent(self, agent):
-        """Test load_tools action without providing agent instance."""
+    def test_load_tools_nonexistent_connection(self, agent):
+        """Test load_tools action with nonexistent connection.
+        
+        Note: When using agent.tool.mcp_client(...), the SDK automatically 
+        injects the agent parameter via invocation_state. So we test connection
+        validation instead, which is the actual error path when using the
+        direct tool calling convention.
+        """
         result = agent.tool.mcp_client(
             action="load_tools",
-            connection_id="test_connection"
-            # Note: agent parameter is not provided
+            connection_id="nonexistent_connection"
         )
         assert result["status"] == "error"
-        assert "agent instance is required" in result["content"][0]["text"]
+        assert "Connection 'nonexistent_connection' not found" in result["content"][0]["text"]
 
 
 class TestConfigurationAndParameterHandling:


### PR DESCRIPTION
## Description

Fixes a failing integration test `test_load_tools_without_agent` in the MCP client test suite.

### Problem
The test expected that not explicitly passing the `agent` parameter would result in no agent being available:
```python
result = agent.tool.mcp_client(
    action="load_tools",
    connection_id="test_connection"
    # Note: agent parameter is not provided  <-- Wrong assumption!
)
assert "agent instance is required" in result["content"][0]["text"]  # ❌ Fails
```

**Actual Error:** `"Connection 'test_connection' not found"`

### Root Cause
When using `agent.tool.mcp_client(...)` (direct tool calling), the SDK **automatically injects** the agent into the tool invocation via `invocation_state`. This is expected behavior.

From `sdk-python/src/strands/tools/executors/_executor.py:137-140`:
```python
invocation_state.update(
    {
        "agent": agent,  # <-- SDK always injects this
        "model": agent.model,
        ...
    }
)
```

### Solution
Changed the test to verify connection validation instead (the actual error path when using the direct tool calling convention):

```python
def test_load_tools_nonexistent_connection(self, agent):
    """Test load_tools action with nonexistent connection."""
    result = agent.tool.mcp_client(
        action="load_tools",
        connection_id="nonexistent_connection"
    )
    assert "Connection 'nonexistent_connection' not found" in result["content"][0]["text"]
```

### Note
The unit test (`tests/test_mcp_client.py:616`) still properly covers the "no agent" case by calling `mcp_client()` directly (not through `agent.tool.x`).

## Related Issues
- Investigation tracked in cagataycali/strands-coder#94

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Verified fix locally - test now passes
- [x] All existing tests pass

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective
- [x] My changes generate no new warnings

---
*Automated by strands-coder* 🦆