### PR TITLE
fix: store AgentCore browser client for proper session cleanup

### DIFF
--- a/src/strands_tools/browser/agent_core_browser.py
+++ b/src/strands_tools/browser/agent_core_browser.py
@@ -52,6 +52,9 @@ class AgentCoreBrowser(Browser):
 
         logger.info(f"started Bedrock AgentCore browser session: {session_id}")
 
+        # Store the client so close_platform() can properly terminate the session
+        self._client_dict[session_id] = session_client
+
         # Get CDP connection details
         cdp_url, cdp_headers = session_client.generate_ws_headers()
 


### PR DESCRIPTION
## Description

The session_client was not being stored in _client_dict after creation in create_browser_session(), causing close_platform() to iterate over an empty dict and never call client.stop() to terminate AgentCore browser sessions.

This resulted in:

Browser sessions remaining in "READY" status in AWS Console after calling close()
The close() action returning success but not actually terminating the remote session
Applications hanging indefinitely as reported in #205
This fix adds a single line to store the session_client in _client_dict using the session_id as the key, allowing close_platform() to properly terminate all sessions when the browser is closed.

## Related Issues

Fixes #205

## Documentation PR

N/A - No documentation changes required for this bug fix.

## Type of Change

Bug fix

## Testing

Tested manually by:

Creating an AgentCore browser session
Performing browser actions (navigate, get_text, screenshot)
Calling close() action
Verifying via AWS CLI that sessions are now properly terminated (status: TERMINATED) instead of remaining in READY state
`aws bedrock-agentcore list-browser-sessions --browser-identifier aws.browser.v1 --region us-west-2`
Before fix: Sessions remained in READY status after close After fix: Sessions properly show TERMINATED status

- [ ] I ran `hatch run prepare`

## Checklist
- [x ] I have read the CONTRIBUTING document
- [x ] I have added any necessary tests that prove my fix is effective or my feature works
- [N/A] I have updated the documentation accordingly
- [N/A] I have added an appropriate example to the documentation to outline the feature
- [ x] My changes generate no new warnings
- [ x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
