### PR TITLE
feat(retrieve): expand document location extraction for all KB source types

### DIFF
--- a/src/strands_tools/retrieve.py
+++ b/src/strands_tools/retrieve.py
@@ -226,14 +226,26 @@ def format_results_for_display(results: List[Dict[str, Any]], enable_metadata: b
 
     formatted = []
     for result in results:
-        # Extract document location - handle both s3Location and customDocumentLocation
+        # Extract document location - handle all RetrievalResultLocation types
+        # Ref: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_RetrievalResultLocation.html
         location = result.get("location", {})
         doc_id = "Unknown"
         if "customDocumentLocation" in location:
             doc_id = location["customDocumentLocation"].get("id", "Unknown")
         elif "s3Location" in location:
-            # Extract meaningful part from S3 URI
             doc_id = location["s3Location"].get("uri", "")
+        elif "webLocation" in location:
+            doc_id = location["webLocation"].get("url", "")
+        elif "confluenceLocation" in location:
+            doc_id = location["confluenceLocation"].get("url", "")
+        elif "salesforceLocation" in location:
+            doc_id = location["salesforceLocation"].get("url", "")
+        elif "sharePointLocation" in location:
+            doc_id = location["sharePointLocation"].get("url", "")
+        elif "kendraDocumentLocation" in location:
+            doc_id = location["kendraDocumentLocation"].get("uri", "")
+        elif "sqlLocation" in location:
+            doc_id = location["sqlLocation"].get("query", "SQL Query")
         score = result.get("score", 0.0)
         formatted.append(f"\nScore: {score:.4f}")
         formatted.append(f"Document ID: {doc_id}")

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -677,3 +677,129 @@ def test_retrieve_via_agent_with_enable_metadata(agent, mock_boto3_client):
     assert "results with score >=" in result_text
     assert "Metadata:" not in result_text
     assert "test-source" not in result_text
+
+
+def test_format_results_with_web_location():
+    """Test format_results_for_display with webLocation type."""
+    results = [
+        {
+            "content": {"text": "Web content", "type": "TEXT"},
+            "location": {
+                "webLocation": {"url": "https://example.com/doc.html"},
+                "type": "WEB",
+            },
+            "score": 0.92,
+        }
+    ]
+    formatted = retrieve.format_results_for_display(results)
+    assert "Score: 0.9200" in formatted
+    assert "Document ID: https://example.com/doc.html" in formatted
+    assert "Content: Web content" in formatted
+
+
+def test_format_results_with_confluence_location():
+    """Test format_results_for_display with confluenceLocation type."""
+    results = [
+        {
+            "content": {"text": "Confluence content", "type": "TEXT"},
+            "location": {
+                "confluenceLocation": {"url": "https://company.atlassian.net/wiki/spaces/DOC/pages/123"},
+                "type": "CONFLUENCE",
+            },
+            "score": 0.85,
+        }
+    ]
+    formatted = retrieve.format_results_for_display(results)
+    assert "Score: 0.8500" in formatted
+    assert "Document ID: https://company.atlassian.net/wiki/spaces/DOC/pages/123" in formatted
+    assert "Content: Confluence content" in formatted
+
+
+def test_format_results_with_salesforce_location():
+    """Test format_results_for_display with salesforceLocation type."""
+    results = [
+        {
+            "content": {"text": "Salesforce content", "type": "TEXT"},
+            "location": {
+                "salesforceLocation": {"url": "https://company.salesforce.com/article/123"},
+                "type": "SALESFORCE",
+            },
+            "score": 0.78,
+        }
+    ]
+    formatted = retrieve.format_results_for_display(results)
+    assert "Score: 0.7800" in formatted
+    assert "Document ID: https://company.salesforce.com/article/123" in formatted
+    assert "Content: Salesforce content" in formatted
+
+
+def test_format_results_with_sharepoint_location():
+    """Test format_results_for_display with sharePointLocation type."""
+    results = [
+        {
+            "content": {"text": "SharePoint content", "type": "TEXT"},
+            "location": {
+                "sharePointLocation": {"url": "https://company.sharepoint.com/sites/docs/doc.docx"},
+                "type": "SHAREPOINT",
+            },
+            "score": 0.81,
+        }
+    ]
+    formatted = retrieve.format_results_for_display(results)
+    assert "Score: 0.8100" in formatted
+    assert "Document ID: https://company.sharepoint.com/sites/docs/doc.docx" in formatted
+    assert "Content: SharePoint content" in formatted
+
+
+def test_format_results_with_kendra_location():
+    """Test format_results_for_display with kendraDocumentLocation type."""
+    results = [
+        {
+            "content": {"text": "Kendra content", "type": "TEXT"},
+            "location": {
+                "kendraDocumentLocation": {"uri": "kendra://index/doc-id-123"},
+                "type": "KENDRA",
+            },
+            "score": 0.89,
+        }
+    ]
+    formatted = retrieve.format_results_for_display(results)
+    assert "Score: 0.8900" in formatted
+    assert "Document ID: kendra://index/doc-id-123" in formatted
+    assert "Content: Kendra content" in formatted
+
+
+def test_format_results_with_sql_location():
+    """Test format_results_for_display with sqlLocation type."""
+    results = [
+        {
+            "content": {"text": "SQL result content", "type": "TEXT"},
+            "location": {
+                "sqlLocation": {"query": "SELECT * FROM documents WHERE id = 123"},
+                "type": "SQL",
+            },
+            "score": 0.75,
+        }
+    ]
+    formatted = retrieve.format_results_for_display(results)
+    assert "Score: 0.7500" in formatted
+    assert "Document ID: SELECT * FROM documents WHERE id = 123" in formatted
+    assert "Content: SQL result content" in formatted
+
+
+def test_format_results_with_unknown_location():
+    """Test format_results_for_display with unknown location type."""
+    results = [
+        {
+            "content": {"text": "Unknown content", "type": "TEXT"},
+            "location": {
+                "futureLocation": {"id": "future-123"},
+                "type": "FUTURE",
+            },
+            "score": 0.70,
+        }
+    ]
+    formatted = retrieve.format_results_for_display(results)
+    assert "Score: 0.7000" in formatted
+    assert "Document ID: Unknown" in formatted
+    assert "Content: Unknown content" in formatted


### PR DESCRIPTION
## Description

Expand the `format_results_for_display` function in the retrieve tool to handle all `RetrievalResultLocation` types from the Bedrock Knowledge Base API, not just `customDocumentLocation` and `s3Location`.

### Changes:
- Added support for `webLocation` (WEB)
- Added support for `confluenceLocation` (CONFLUENCE)
- Added support for `salesforceLocation` (SALESFORCE)
- Added support for `sharePointLocation` (SHAREPOINT)
- Added support for `kendraDocumentLocation` (KENDRA)
- Added support for `sqlLocation` (SQL)
- Added 7 new unit tests covering all location types plus unknown/future types

### Reference:
https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_RetrievalResultLocation.html

## Related Issues

Closes #364

## Type of Change

- [ ] Bug fix
- [x] New Feature (adds support for additional location types)
- [ ] Breaking change
- [ ] Other

## Testing

- All 30 tests pass including 7 new tests
- Ran `ruff format` and `ruff check` - no issues

```
$ python -m pytest tests/test_retrieve.py -v
============================= test session starts ==============================
collected 30 items

tests/test_retrieve.py::test_format_results_with_web_location PASSED     [ 80%]
tests/test_retrieve.py::test_format_results_with_confluence_location PASSED [ 83%]
tests/test_retrieve.py::test_format_results_with_salesforce_location PASSED [ 86%]
tests/test_retrieve.py::test_format_results_with_sharepoint_location PASSED [ 90%]
tests/test_retrieve.py::test_format_results_with_kendra_location PASSED  [ 93%]
tests/test_retrieve.py::test_format_results_with_sql_location PASSED     [ 96%]
tests/test_retrieve.py::test_format_results_with_unknown_location PASSED [100%]

============================== 30 passed in 0.79s ==============================
```

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly (code comments reference AWS API docs)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.