### PR TITLE
fix(shell): close PTY file descriptor to prevent resource leak

### DIFF
--- a/src/strands_tools/shell.py
+++ b/src/strands_tools/shell.py
@@ -185,6 +185,12 @@ class CommandExecutor:
                 return exit_code, "".join(output), ""
 
         finally:
+            # Close the PTY file descriptor
+            if "fd" in locals() and pid > 0:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
             # Restore terminal settings only if they were saved and changed.
             if not non_interactive_mode and old_tty:
                 termios.tcsetattr(sys.stdin, termios.TCSAFLUSH, old_tty)


### PR DESCRIPTION
## Description

Fixed a resource leak in the shell tool by properly closing PTY file descriptors in the CommandExecutor class. The change adds a try-catch block in the finally clause to ensure the PTY file descriptor is closed when the process completes, preventing potential resource exhaustion.

## Related Issues

https://github.com/strands-agents/tools/issues/368

## Documentation PR

None

## Type of Change

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
