### PR TITLE
fix(browser): add missing PressKeyAction to dispatcher chain

### DIFF
--- a/src/strands_tools/browser/browser.py
+++ b/src/strands_tools/browser/browser.py
@@ -171,6 +171,8 @@ class Browser(ABC):
             return self.network_intercept(action)
         elif isinstance(action, ExecuteCdpAction):
             return self.execute_cdp(action)
+        elif isinstance(action, PressKeyAction):
+            return self.press_key(action)
         elif isinstance(action, CloseAction):
             return self.close(action)
         else:


### PR DESCRIPTION
## Description

Fixes #384

The `PressKeyAction` was fully implemented but missing from the dispatcher chain in the `browser()` method. This caused 'Unknown action type' errors when trying to use the `press_key` action.

## Root Cause Analysis

As the issue author correctly identified:
- ✅ `PressKeyAction` imported in browser.py (line 42)
- ✅ `PressKeyAction` model defined in models.py (lines 137-142)
- ✅ `PressKeyAction` included in `BrowserInput` union (models.py line 288)
- ✅ `press_key()` handler method exists (browser.py line 501)
- ✅ `_async_press_key()` async handler exists (browser.py line 505)
- ❌ **MISSING**: `isinstance` check in dispatcher (browser.py lines 134-176)

## Fix

Added the missing handler to the dispatcher chain:

```python
elif isinstance(action, PressKeyAction):
    return self.press_key(action)
```

Placed before `CloseAction` check as suggested in the issue.

## Testing

- [x] Module imports successfully
- [x] Syntax verification passed

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

---
🤖 *AI agent response from the Strands team. [Strands Agents](https://github.com/strands-agents). Feedback welcome!*