### PR TITLE
monodb - docs - namespace definition

### DIFF
--- a/docs/mongodb_memory_tool.md
+++ b/docs/mongodb_memory_tool.md
@@ -7,7 +7,7 @@ The MongoDB Atlas Memory Tool provides comprehensive memory management capabilit
 - **Semantic Search**: Automatic embedding generation using Amazon Bedrock Titan for vector similarity search
 - **Memory Management**: Store, retrieve, list, get, and delete memory operations
 - **Index Management**: Automatic vector search index creation with proper configuration
-- **Namespace Support**: Organize memories by namespace for multi-user scenarios
+- **Namespace Field**: Organize and filter memories using a `namespace` document field for logical grouping within a collection
 - **Pagination**: Support for paginated results in list and retrieve operations
 - **Error Handling**: Comprehensive error handling with clear error messages
 
@@ -299,7 +299,7 @@ result = memory_tool.record_memory(
 ### Multiple Namespaces
 
 ```python
-# User-specific memories
+# Logical grouping by user
 result = memory_tool.record_memory(
     content="Alice likes Italian food",
     cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
@@ -494,7 +494,9 @@ result = agent.tool.mongodb_memory(
 
 ### 2. Namespace Organization
 
-The namespace parameter is crucial for data isolation and multi-tenant memory management:
+The `namespace` parameter is a document field used for logical grouping and query filtering within a collection.
+
+> **Note:** This differs from [MongoDB's glossary definition of "namespace"](https://www.mongodb.com/docs/manual/reference/glossary/#std-term-namespace), which refers to the combination of database and collection names.
 
 ```python
 # User-based namespaces


### PR DESCRIPTION
## Description

Updates documentation to clarify that the `namespace` parameter is a document field for logical grouping and query filtering, not MongoDB's official namespace concept (which refers to the database.collection identifier).

Adds a note linking to MongoDB's glossary definition to prevent confusion with industry-standard namespace concepts that imply isolation guarantees:
> **Note:** This differs from [MongoDB's glossary definition of "namespace"](https://www.mongodb.com/docs/manual/reference/glossary/#std-term-namespace), which refers to the combination of database and collection names.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Documentation update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
