### PR TITLE
fix(browser): make get_text extraction method and get_html truncation configurable

### DIFF
--- a/src/strands_tools/browser/browser.py
+++ b/src/strands_tools/browser/browser.py
@@ -538,7 +538,10 @@ class Browser(ABC):
             return {"status": "error", "content": [{"text": "Error: No active page for session"}]}
 
         try:
-            text = await page.text_content(action.selector)
+            if action.method == "inner_text":
+                text = await page.inner_text(action.selector)
+            else:
+                text = await page.text_content(action.selector)
             return {"status": "success", "content": [{"text": f"Text content: {text}"}]}
         except Exception as e:
             logger.debug("exception=<%s> | get text action failed on selector '%s'", str(e), action.selector)
@@ -584,9 +587,9 @@ class Browser(ABC):
                         ],
                     }
 
-            # Truncate long HTML content
-            truncated_result = result[:1000] + "..." if len(result) > 1000 else result
-            return {"status": "success", "content": [{"text": truncated_result}]}
+            if action.max_length and len(result) > action.max_length:
+                result = result[:action.max_length] + "..."
+            return {"status": "success", "content": [{"text": result}]}
         except Exception as e:
             logger.debug("exception=<%s> | get HTML action failed", str(e))
             return {"status": "error", "content": [{"text": f"Error: {str(e)}"}]}

--- a/src/strands_tools/browser/models.py
+++ b/src/strands_tools/browser/models.py
@@ -150,6 +150,11 @@ class GetTextAction(BaseModel):
     type: Literal["get_text"] = Field(description="Get text content from an element")
     session_name: str = Field(description="Required session name from a previous init_session call")
     selector: str = Field(description="CSS selector for the element")
+    method: Literal["inner_text", "text_content"] = Field(
+        default="inner_text",
+        description="Text extraction method: 'inner_text' (default) excludes script/style/hidden content, "
+        "'text_content' returns all raw text including scripts and styles",
+    )
 
 
 class GetHtmlAction(BaseModel):
@@ -159,6 +164,10 @@ class GetHtmlAction(BaseModel):
     type: Literal["get_html"] = Field(description="Get HTML content")
     session_name: str = Field(description="Required session name from a previous init_session call")
     selector: Optional[str] = Field(default=None, description="CSS selector for specific element (optional)")
+    max_length: Optional[int] = Field(
+        default=None,
+        description="Maximum character length of returned HTML. None (default) returns full content without truncation",
+    )
 
 
 class ScreenshotAction(BaseModel):


### PR DESCRIPTION
## Summary

- **get_text**: Default text extraction changed from `text_content()` to `inner_text()`,
  which excludes script/style/hidden content. The old behavior is available via
  `method: "text_content"` on `GetTextAction`.
- **get_html**: Removed the hard-coded 1,000-character truncation. Full HTML is now returned
  by default. An optional `max_length` field on `GetHtmlAction` lets callers opt into truncation.

## Motivation

- `text_content()` includes `<script>`, `<style>`, and hidden element text, polluting LLM
  context when agents read pages. `inner_text()` is style-aware and produces much cleaner output.
- The 1,000-char HTML truncation made `get_html` unusable for reading full page content,
  and the LLM was never informed about it. Meanwhile `get_text` had no truncation at all,
  making the limit inconsistent.
- `get_html` returns proper HTML with tags (`<script>`, `<style>`, `<nav>`, etc.), which
  downstream processing (like markdown conversion) can strip effectively. Without full HTML,
  the only option is `get_text` where JavaScript/CSS appears as untagged noise that cannot
  be reliably cleaned.

## References

- [Playwright: innerText vs textContent](https://www.codekru.com/playwright/innertext-vs-textcontent-in-playwright) — `text_content()` includes scripts/styles, `inner_text()` excludes them
- [Playwright Issue #18894](https://github.com/microsoft/playwright/issues/18894) — edge case where `inner_text` can still include script content; Playwright team recommends stripping `<script>` elements as workaround
- Playwright itself imposes no character limit on `content()`, `inner_html()`, or `text_content()` — the 1,000-char truncation was an arbitrary application-level constraint

## Test plan

- [ ] Verify `get_text` with default (no `method` field) uses `inner_text` and excludes scripts/styles
- [ ] Verify `get_text` with `method: "text_content"` returns raw text including scripts
- [ ] Verify `get_html` with no `max_length` returns full HTML without truncation
- [ ] Verify `get_html` with `max_length: 500` truncates and appends "..."
- [ ] Existing browser tests still pass