### PR TITLE
fix: hatch virtual env fix with optional-dependencies normalization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,13 +62,13 @@ Documentation = "https://strandsagents.com/"
 
 [project.optional-dependencies]
 build = [
-    "hatch>=1.0.0,<1.16.0", # TODO: https://github.com/pypa/hatch/issues/2128
+    "hatch>=1.16.5",
 ]
 dev = [
     "commitizen>=4.4.0,<5.0.0",
     "mypy>=0.981,<1.0.0",
     "pre-commit>=3.2.0,<4.2.0",
-    "pytest>=8.0.0,<9.0.0",
+    "pytest>=8.0.0,<10.0.0",
     "ruff>=0.13.0,<0.14.0",
     "responses>=0.6.1,<1.0.0",
     "mem0ai>=0.1.104,<1.0.0",
@@ -83,21 +83,21 @@ docs = [
     "sphinx-rtd-theme>=1.0.0,<2.0.0",
     "sphinx-autodoc-typehints>=1.12.0,<2.0.0",
 ]
-mem0_memory = [
+mem0-memory = [
     # Need to be optional as a fix for https://github.com/strands-agents/docs/issues/19
     "mem0ai>=0.1.99,<1.0.0",
     "opensearch-py>=2.8.0,<3.0.0",
 ]
-local_chromium_browser = ["nest-asyncio>=1.5.0,<2.0.0", "playwright>=1.42.0,<2.0.0"]
-agent_core_browser = [
+local-chromium-browser = ["nest-asyncio>=1.5.0,<2.0.0", "playwright>=1.42.0,<2.0.0"]
+agent-core-browser = [
     "nest-asyncio>=1.5.0,<2.0.0",
     "playwright>=1.42.0,<2.0.0",
     "bedrock-agentcore>=1.1.0,<1.2.0"
 ]
-agent_core_code_interpreter = [
+agent-core-code-interpreter = [
     "bedrock-agentcore>=1.1.0,<1.2.0"
 ]
-a2a_client = ["a2a-sdk[sql]>=0.3.0,<0.4.0"]
+a2a-client = ["a2a-sdk[sql]>=0.3.0,<0.4.0"]
 diagram = [
     "matplotlib>=3.5.0,<4.0.0",
     "graphviz>=0.20.0,<1.0.0",
@@ -105,7 +105,7 @@ diagram = [
     "diagrams>=0.23.0,<1.0.0",
 ]
 rss = ["feedparser>=6.0.10,<7.0.0", "html2text>=2020.1.16,<2021.0.0"]
-use_computer = [
+use-computer = [
     "opencv-python>=4.5.0,<5.0.0",
     "psutil>=5.8.0,<6.0.0",
     "pyautogui>=0.9.53,<1.0.0",
@@ -114,15 +114,15 @@ use_computer = [
 twelvelabs = [
     "twelvelabs>=0.4.0,<1.0.0",
 ]
-elasticsearch_memory = [
+elasticsearch-memory = [
     "elasticsearch>=8.0.0,<9.0.0"
 ]
-mongodb_memory = [
+mongodb-memory = [
     "pymongo>=4.0.0,<5.0.0",
 ]
 
 [tool.hatch.envs.hatch-static-analysis]
-features = ["mem0_memory", "local_chromium_browser", "agent_core_browser", "agent_core_code_interpreter", "a2a_client", "diagram", "rss", "use_computer", "twelvelabs", "elasticsearch_memory", "mongodb_memory"]
+features = ["mem0-memory", "local-chromium-browser", "agent-core-browser", "agent-core-code-interpreter", "a2a-client", "diagram", "rss", "use-computer", "twelvelabs", "elasticsearch-memory", "mongodb-memory"]
 dependencies = [
     "strands-agents>=1.0.0",
     "mypy>=0.981,<1.0.0",
@@ -141,14 +141,14 @@ lint-check = [
 lint-fix = ["ruff check --fix"]
 
 [tool.hatch.envs.hatch-test]
-features = ["mem0_memory", "local_chromium_browser",  "agent_core_browser", "agent_core_code_interpreter", "a2a_client", "diagram", "rss", "use_computer", "twelvelabs", "elasticsearch_memory", "mongodb_memory"]
+features = ["mem0-memory", "local-chromium-browser",  "agent-core-browser", "agent-core-code-interpreter", "a2a-client", "diagram", "rss", "use-computer", "twelvelabs", "elasticsearch-memory", "mongodb-memory"]
 extra-dependencies = [
     "moto>=5.1.0,<6.0.0",
-    "pytest>=8.0.0,<9.0.0",
+    "pytest>=8.0.0,<10.0.0",
     "pytest-cov>=4.1.0,<5.0.0",
     "pytest-xdist>=3.0.0,<4.0.0",
     "responses>=0.6.1,<1.0.0",
-    "pytest_asyncio>=0.23.0,<1.0.0",
+    "pytest_asyncio>=0.25.0,<2.0.0",
 ]
 extra-args = ["-n", "auto", '-vv']
 


### PR DESCRIPTION
## Description


Our previous hatch<1.16.0 pin (strands-agents/tools#330) worked around a feature name normalization bug (pypa/hatch#2128), but is not maintainable since virtualenv 21.0.0 broke older hatch versions (pypa/hatch#2193), requiring upgrade to hatch 1.16.5.

This PR resolves both by normalizing our `optional-dependencie`s keys to hyphens (matching hatch's [PEP 685](https://peps.python.org/pep-0685/) normalization) and upgrading to hatch>=1.16.5. Also widens `pytest` and `pytest-asyncio` upper bounds for compat with hatch 1.16.5's test environment. Fully backwards compatible per [PEP 685](https://peps.python.org/pep-0685/).

Documentation and README can be updated in future to use hyphens now rather than underscores in line with hatch standards (ie. `pip install strands-agents-tools[mongodb-memory]`), but functionally both operate the same per PEP 685, so maintaining underscores for now to keep changes to a minimum.


## Related Issues

https://github.com/pypa/hatch/issues/2193

## Documentation PR

n/a

## Type of Change

Bug fix


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
