### PR TITLE
Feat/add a2a cancel and get task

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,9 +693,13 @@ agent = Agent(tools=provider.tools)
 response = agent("discover available agents and send a greeting message")
 
 # The agent will automatically use the available tools:
-# - discover_agent(url) to find agents
-# - list_discovered_agents() to see all discovered agents
-# - send_message(message_text, target_agent_url) to communicate
+# - a2a_discover_agent(url) to find agents
+# - a2a_list_discovered_agents() to see all discovered agents
+# - a2a_send_message(message_text, target_agent_url) to communicate
+# - a2a_get_task(target_agent_url, task_id) to monitor task status and retrieve history
+# - a2a_cancel_task(target_agent_url, task_id) to cancel running tasks
+# - a2a_get_conversation_state(target_agent_url) to check current conversation state
+# - a2a_clear_conversation_state(target_agent_url) to start a fresh conversation
 ```
 
 ### Diagram

--- a/src/strands_tools/a2a_client.py
+++ b/src/strands_tools/a2a_client.py
@@ -42,14 +42,14 @@ from uuid import uuid4
 
 import httpx
 from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
-from a2a.types import AgentCard, Message, Part, PushNotificationConfig, Role, TextPart
+from a2a.types import AgentCard, Message, Part, PushNotificationConfig, Role, TaskIdParams, TaskQueryParams, TextPart
 from strands import tool
 from strands.types.tools import AgentTool
 
 DEFAULT_TIMEOUT = 300  # set request timeout to 5 minutes
 
 # Terminal task states - tasks in these states should not be continued
-TERMINAL_TASK_STATES = {"completed", "canceled", "failed"}
+TERMINAL_TASK_STATES = {"completed", "canceled", "failed", "rejected"}
 
 logger = logging.getLogger(__name__)
 
@@ -573,3 +573,240 @@ class A2AClientToolProvider:
             "status": "success",
             "target_agent_url": target_agent_url,
         }
+
+    @tool
+    async def a2a_get_task(
+        self,
+        target_agent_url: str,
+        task_id: str,
+        history_length: int | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get the current state and details of a specific task.
+
+        This retrieves comprehensive information about a task including its
+        status, history, artifacts, and metadata. Useful for monitoring task
+        progress, debugging, or checking completion status.
+
+        Args:
+            target_agent_url: The URL of the target A2A agent
+            task_id: The ID of the task to retrieve
+            history_length: Optional number of recent history items to include.
+                If not specified, returns full history. Use lower values for
+                better performance on tasks with extensive history.
+
+        Returns:
+            dict: Task retrieval result including:
+                - status: "success" or "error"
+                - task: The complete task data (if successful)
+                - task_state: The current state of the task
+                - context_id: The task's context ID
+                - error: Error message (if failed)
+                - target_agent_url: The agent URL contacted
+                - task_id: The task ID queried
+        """
+        return await self._get_task(target_agent_url, task_id, history_length)
+
+    async def _get_task(
+        self,
+        target_agent_url: str,
+        task_id: str,
+        history_length: int | None = None,
+    ) -> dict[str, Any]:
+        """Internal async implementation for get_task."""
+        try:
+            await self._ensure_discovered_known_agents()
+
+            # Get the agent card and create client
+            agent_card = await self._discover_agent_card(target_agent_url)
+            client_factory = self._get_client_factory()
+            client = client_factory.create(agent_card)
+
+            # Build task query parameters
+            task_params = TaskQueryParams(id=task_id, history_length=history_length)
+
+            logger.info(
+                f"Retrieving task {task_id} from {target_agent_url}"
+                f"{f' (history_length={history_length})' if history_length else ''}"
+            )
+
+            # Get the task
+            task = await client.get_task(task_params)
+
+            # Extract task state and context
+            task_state_value = task.status.state
+            if hasattr(task_state_value, "value"):
+                task_state_value = task_state_value.value
+
+            task_context_id = getattr(task, "context_id", None)
+
+            # Update conversation state with current task info
+            logger.info(f"Updating the conversation state for {task.id}, state: {task_state_value}")
+            self._update_conversation_state(
+                target_agent_url,
+                context_id=task_context_id,
+                task_id=task.id,
+                task_state=task_state_value,
+            )
+
+            logger.info(f"Successfully retrieved task {task_id}, state: {task_state_value}")
+
+            return {
+                "status": "success",
+                "task": task.model_dump(mode="python", exclude_none=True),
+                "task_id": task_id,
+                "task_state": task_state_value,
+                "context_id": task_context_id,
+                "target_agent_url": target_agent_url,
+            }
+
+        except Exception as e:
+            logger.exception(f"Error retrieving task {task_id} from {target_agent_url}")
+            error_type = type(e).__name__
+
+            # Check if it's a "task not found" error
+            error_message = str(e)
+            if "not found" in error_message.lower() or "404" in error_message:
+                return {
+                    "status": "error",
+                    "error": f"Task not found: {error_message}",
+                    "error_type": error_type,
+                    "task_id": task_id,
+                    "target_agent_url": target_agent_url,
+                }
+
+            return {
+                "status": "error",
+                "error": str(e),
+                "error_type": error_type,
+                "task_id": task_id,
+                "target_agent_url": target_agent_url,
+            }
+
+    @tool
+    async def a2a_cancel_task(
+        self,
+        target_agent_url: str,
+        task_id: str,
+        context_id: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Cancel a running task on a specific A2A agent.
+
+        This attempts to cancel an active task. It validates that the task
+        is not already in a terminal state before attempting cancellation.
+
+        IMPORTANT: Task must be in a non-terminal state (not completed, canceled,
+        failed, or rejected) to be cancelable.
+
+        Args:
+            target_agent_url: The URL of the target A2A agent
+            task_id: The ID of the task to cancel
+            context_id: Optional context ID for validation against the task's context
+
+        Returns:
+            dict: Cancellation result including:
+                - status: "success" or "error"
+                - task: The canceled task data (if successful)
+                - task_state: The current/final state of the task
+                - error: Error message (if failed)
+                - target_agent_url: The agent URL contacted
+                - task_id: The task ID that was canceled
+        """
+        return await self._cancel_task(target_agent_url, task_id, context_id)
+
+    async def _cancel_task(
+        self,
+        target_agent_url: str,
+        task_id: str,
+        context_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Internal async implementation for cancel_task."""
+        try:
+            await self._ensure_discovered_known_agents()
+
+            # Get the agent card and create client
+            agent_card = await self._discover_agent_card(target_agent_url)
+            client_factory = self._get_client_factory()
+            client = client_factory.create(agent_card)
+
+            # First, get the task to check its current state
+            try:
+                current_task = await client.get_task(TaskQueryParams(id=task_id))
+            except Exception as e:
+                logger.error(f"Failed to retrieve task {task_id} before cancellation: {e}")
+                return {
+                    "status": "error",
+                    "error": f"Task not found or inaccessible: {str(e)}",
+                    "task_id": task_id,
+                    "target_agent_url": target_agent_url,
+                }
+
+            # Check if task is in a terminal state
+            task_state_value = current_task.status.state
+            if hasattr(task_state_value, "value"):
+                task_state_value = task_state_value.value
+
+            if task_state_value in TERMINAL_TASK_STATES:
+                logger.warning(f"Task {task_id} cannot be canceled - already in terminal state: {task_state_value}")
+                return {
+                    "status": "error",
+                    "error": f"Task cannot be canceled - current state: {task_state_value}",
+                    "task_id": task_id,
+                    "target_agent_url": target_agent_url,
+                    "task_state": task_state_value,
+                }
+
+            # Validate context_id if provided
+            if context_id and current_task.context_id != context_id:
+                logger.error(
+                    f"Context ID mismatch for task {task_id}: expected {context_id}, got {current_task.context_id}"
+                )
+                return {
+                    "status": "error",
+                    "error": f"Context ID mismatch: expected {context_id}, got {current_task.context_id}",
+                    "task_id": task_id,
+                    "target_agent_url": target_agent_url,
+                }
+
+            logger.info(f"Canceling task {task_id} on {target_agent_url}")
+
+            # Cancel the task
+            task_params = TaskIdParams(id=task_id)
+
+            canceled_task = await client.cancel_task(task_params)
+
+            # Extract final state
+            final_state = canceled_task.status.state
+            if hasattr(final_state, "value"):
+                final_state = final_state.value
+
+            # Cancellation should always result in a terminal state.
+            if final_state in TERMINAL_TASK_STATES:  # should be true, if canceled successfully
+                self._update_conversation_state(
+                    target_agent_url,
+                    context_id=canceled_task.context_id,
+                    task_id=canceled_task.id,
+                    task_state=final_state,
+                )
+
+            logger.info(f"Successfully canceled task {task_id}, final state: {final_state}")
+
+            return {
+                "status": "success",
+                "task": canceled_task.model_dump(mode="python", exclude_none=True),
+                "task_id": task_id,
+                "target_agent_url": target_agent_url,
+                "task_state": final_state,
+            }
+
+        except Exception as e:
+            logger.exception(f"Error canceling task {task_id} on {target_agent_url}")
+            error_type = type(e).__name__
+            return {
+                "status": "error",
+                "error": str(e),
+                "error_type": error_type,
+                "task_id": task_id,
+                "target_agent_url": target_agent_url,
+            }

--- a/src/strands_tools/a2a_client.py
+++ b/src/strands_tools/a2a_client.py
@@ -34,6 +34,20 @@ Usage Examples:
         >>> result1 = await provider.a2a_send_message("Start a task", "http://agent.example.com")
         >>> # Second message - context_id is automatically reused for the same agent
         >>> result2 = await provider.a2a_send_message("Continue the task", "http://agent.example.com")
+
+    Task monitoring and status retrieval:
+        >>> provider = A2AClientToolProvider(known_agent_urls=["http://agent.example.com"])
+        >>> # Get task status with full history
+        >>> task_status = await provider.a2a_get_task("http://agent.example.com", "task-123")
+        >>> # Get task status with limited history for better performance
+        >>> task_status = await provider.a2a_get_task("http://agent.example.com", "task-456", history_length=10)
+
+    Task cancellation:
+        >>> provider = A2AClientToolProvider(known_agent_urls=["http://agent.example.com"])
+        >>> # Cancel a running task
+        >>> result = await provider.a2a_cancel_task("http://agent.example.com", "task-123")
+        >>> # Cancel with context_id validation for security
+        >>> result = await provider.a2a_cancel_task("http://agent.example.com", "task-456", context_id="ctx-789")
 """
 
 import asyncio

--- a/src/strands_tools/a2a_client.py
+++ b/src/strands_tools/a2a_client.py
@@ -6,6 +6,8 @@ This tool provides functionality to discover and communicate with A2A-compliant 
 Key Features:
 - Agent discovery through agent cards from multiple URLs
 - Message sending to specific A2A agents
+- Task monitoring and status retrieval with history and artifacts
+- Task cancellation with terminal state validation
 - Push notification support for real-time task completion alerts
 - Custom authentication support via httpx client arguments
 - Context and task ID persistence for multi-turn conversations

--- a/tests/test_a2a_client.py
+++ b/tests/test_a2a_client.py
@@ -184,7 +184,8 @@ def test_update_conversation_state_removes_terminal_task():
     """Test _update_conversation_state removes tasks in terminal states."""
     provider = A2AClientToolProvider()
     provider._conversation_states["http://agent.com"] = ConversationState(
-        context_id="ctx-123", active_tasks={"task-456": ActiveTask(task_id="task-456", state="working", context_id="ctx-123")}
+        context_id="ctx-123",
+        active_tasks={"task-456": ActiveTask(task_id="task-456", state="working", context_id="ctx-123")},
     )
 
     provider._update_conversation_state("http://agent.com", task_id="task-456", task_state="completed")
@@ -212,7 +213,8 @@ def test_get_task_id_for_continuation_single_active():
     """Test _get_task_id_for_continuation returns task_id when exactly one active."""
     provider = A2AClientToolProvider()
     provider._conversation_states["http://agent.com"] = ConversationState(
-        context_id="ctx-123", active_tasks={"task-456": ActiveTask(task_id="task-456", state="working", context_id="ctx-123")}
+        context_id="ctx-123",
+        active_tasks={"task-456": ActiveTask(task_id="task-456", state="working", context_id="ctx-123")},
     )
 
     task_id = provider._get_task_id_for_continuation("http://agent.com")

--- a/tests/test_a2a_client.py
+++ b/tests/test_a2a_client.py
@@ -991,12 +991,24 @@ async def test_get_task_with_history_length(mock_ensure, mock_factory, mock_disc
 
 @pytest.mark.asyncio
 @patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_get_client_factory")
 @patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
-async def test_get_task_not_found(mock_ensure, mock_discover):
+async def test_get_task_not_found(mock_ensure, mock_factory, mock_discover):
     """Test _get_task when task is not found."""
     provider = A2AClientToolProvider()
 
-    mock_discover.side_effect = Exception("Task not found")
+    # Mock agent card
+    mock_agent_card = Mock()
+    mock_discover.return_value = mock_agent_card
+
+    # Mock ClientFactory and Client
+    mock_client_factory = Mock()
+    mock_client = Mock()
+    mock_factory.return_value = mock_client_factory
+    mock_client_factory.create.return_value = mock_client
+
+    # Mock get_task to raise exception
+    mock_client.get_task = AsyncMock(side_effect=Exception("Task not found"))
 
     result = await provider._get_task("http://test.com", "task-123")
 

--- a/tests/test_a2a_client.py
+++ b/tests/test_a2a_client.py
@@ -63,13 +63,15 @@ def test_tools_property():
     provider = A2AClientToolProvider()
     tools = provider.tools
 
-    # Should have the five @tool decorated methods (including new state management tools)
+    # Should have the seven @tool decorated methods (including task management tools)
     tool_names = [tool.tool_name for tool in tools]
     assert "a2a_discover_agent" in tool_names
     assert "a2a_list_discovered_agents" in tool_names
     assert "a2a_send_message" in tool_names
     assert "a2a_get_conversation_state" in tool_names
     assert "a2a_clear_conversation_state" in tool_names
+    assert "a2a_get_task" in tool_names
+    assert "a2a_cancel_task" in tool_names
 
 
 def test_get_httpx_client_creates_new_client():
@@ -862,3 +864,456 @@ async def test_clear_conversation_state_tool_nonexistent():
     result = await provider.a2a_clear_conversation_state("http://unknown.com")
 
     assert result == {"status": "success", "target_agent_url": "http://unknown.com"}
+
+
+# Tests for a2a_get_task tool
+@pytest.mark.asyncio
+async def test_get_task_tool():
+    """Test a2a_get_task calls internal implementation."""
+    provider = A2AClientToolProvider()
+
+    with patch.object(provider, "_get_task") as mock_get_task:
+        expected_result = {
+            "status": "success",
+            "task": {"id": "task-123", "status": {"state": "working"}},
+            "task_id": "task-123",
+            "task_state": "working",
+            "context_id": "ctx-123",
+            "target_agent_url": "http://test.com",
+        }
+        mock_get_task.return_value = expected_result
+
+        result = await provider.a2a_get_task("http://test.com", "task-123")
+
+        assert result == expected_result
+        mock_get_task.assert_called_once_with("http://test.com", "task-123", None)
+
+
+@pytest.mark.asyncio
+async def test_get_task_tool_with_history_length():
+    """Test a2a_get_task with history_length parameter."""
+    provider = A2AClientToolProvider()
+
+    with patch.object(provider, "_get_task") as mock_get_task:
+        expected_result = {
+            "status": "success",
+            "task": {"id": "task-123", "status": {"state": "working"}},
+            "task_id": "task-123",
+            "task_state": "working",
+            "context_id": "ctx-123",
+            "target_agent_url": "http://test.com",
+        }
+        mock_get_task.return_value = expected_result
+
+        result = await provider.a2a_get_task("http://test.com", "task-123", history_length=10)
+
+        assert result == expected_result
+        mock_get_task.assert_called_once_with("http://test.com", "task-123", 10)
+
+
+@pytest.mark.asyncio
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_get_client_factory")
+@patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
+async def test_get_task_success(mock_ensure, mock_factory, mock_discover):
+    """Test _get_task successfully retrieves task."""
+    provider = A2AClientToolProvider()
+
+    # Mock agent card
+    mock_agent_card = Mock()
+    mock_discover.return_value = mock_agent_card
+
+    # Mock ClientFactory and Client
+    mock_client_factory = Mock()
+    mock_client = Mock()
+    mock_factory.return_value = mock_client_factory
+    mock_client_factory.create.return_value = mock_client
+
+    # Mock task response
+    mock_task = Mock()
+    mock_task.model_dump.return_value = {"id": "task-123", "status": {"state": "working"}}
+    mock_task.id = "task-123"
+    mock_task.status = Mock()
+    mock_task.status.state = "working"
+    mock_task.context_id = "ctx-123"
+
+    mock_client.get_task = AsyncMock(return_value=mock_task)
+
+    result = await provider._get_task("http://test.com", "task-123")
+
+    expected = {
+        "status": "success",
+        "task": {"id": "task-123", "status": {"state": "working"}},
+        "task_id": "task-123",
+        "task_state": "working",
+        "context_id": "ctx-123",
+        "target_agent_url": "http://test.com",
+    }
+    assert result == expected
+    mock_ensure.assert_called_once()
+    mock_discover.assert_called_once_with("http://test.com")
+
+
+@pytest.mark.asyncio
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_get_client_factory")
+@patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
+async def test_get_task_with_history_length(mock_ensure, mock_factory, mock_discover):
+    """Test _get_task with history_length parameter."""
+    provider = A2AClientToolProvider()
+
+    # Mock agent card
+    mock_agent_card = Mock()
+    mock_discover.return_value = mock_agent_card
+
+    # Mock ClientFactory and Client
+    mock_client_factory = Mock()
+    mock_client = Mock()
+    mock_factory.return_value = mock_client_factory
+    mock_client_factory.create.return_value = mock_client
+
+    # Mock task response
+    mock_task = Mock()
+    mock_task.model_dump.return_value = {"id": "task-123", "status": {"state": "completed"}}
+    mock_task.id = "task-123"
+    mock_task.status = Mock()
+    mock_task.status.state = "completed"
+    mock_task.context_id = "ctx-123"
+
+    mock_client.get_task = AsyncMock(return_value=mock_task)
+
+    result = await provider._get_task("http://test.com", "task-123", history_length=5)
+
+    # Verify TaskQueryParams was called with history_length
+    assert mock_client.get_task.called
+    assert result["status"] == "success"
+
+
+@pytest.mark.asyncio
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
+async def test_get_task_not_found(mock_ensure, mock_discover):
+    """Test _get_task when task is not found."""
+    provider = A2AClientToolProvider()
+
+    mock_discover.side_effect = Exception("Task not found")
+
+    result = await provider._get_task("http://test.com", "task-123")
+
+    expected = {
+        "status": "error",
+        "error": "Task not found: Task not found",
+        "error_type": "Exception",
+        "task_id": "task-123",
+        "target_agent_url": "http://test.com",
+    }
+    assert result == expected
+
+
+@pytest.mark.asyncio
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_get_client_factory")
+@patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
+async def test_get_task_updates_conversation_state(mock_ensure, mock_factory, mock_discover):
+    """Test _get_task updates conversation state."""
+    provider = A2AClientToolProvider()
+
+    # Mock agent card
+    mock_agent_card = Mock()
+    mock_discover.return_value = mock_agent_card
+
+    # Mock ClientFactory and Client
+    mock_client_factory = Mock()
+    mock_client = Mock()
+    mock_factory.return_value = mock_client_factory
+    mock_client_factory.create.return_value = mock_client
+
+    # Mock task response
+    mock_task = Mock()
+    mock_task.model_dump.return_value = {"id": "task-123", "status": {"state": "working"}}
+    mock_task.id = "task-123"
+    mock_task.status = Mock()
+    mock_task.status.state = "working"
+    mock_task.context_id = "ctx-456"
+
+    mock_client.get_task = AsyncMock(return_value=mock_task)
+
+    await provider._get_task("http://test.com", "task-123")
+
+    # Verify conversation state was updated
+    state = provider._conversation_states.get("http://test.com")
+    assert state is not None
+    assert state.context_id == "ctx-456"
+    assert "task-123" in state.active_tasks
+
+
+# Tests for a2a_cancel_task tool
+@pytest.mark.asyncio
+async def test_cancel_task_tool():
+    """Test a2a_cancel_task calls internal implementation."""
+    provider = A2AClientToolProvider()
+
+    with patch.object(provider, "_cancel_task") as mock_cancel_task:
+        expected_result = {
+            "status": "success",
+            "task": {"id": "task-123", "status": {"state": "canceled"}},
+            "task_id": "task-123",
+            "task_state": "canceled",
+            "target_agent_url": "http://test.com",
+        }
+        mock_cancel_task.return_value = expected_result
+
+        result = await provider.a2a_cancel_task("http://test.com", "task-123")
+
+        assert result == expected_result
+        mock_cancel_task.assert_called_once_with("http://test.com", "task-123", None)
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_tool_with_context_id():
+    """Test a2a_cancel_task with context_id parameter."""
+    provider = A2AClientToolProvider()
+
+    with patch.object(provider, "_cancel_task") as mock_cancel_task:
+        expected_result = {
+            "status": "success",
+            "task": {"id": "task-123", "status": {"state": "canceled"}},
+            "task_id": "task-123",
+            "task_state": "canceled",
+            "target_agent_url": "http://test.com",
+        }
+        mock_cancel_task.return_value = expected_result
+
+        result = await provider.a2a_cancel_task("http://test.com", "task-123", context_id="ctx-123")
+
+        assert result == expected_result
+        mock_cancel_task.assert_called_once_with("http://test.com", "task-123", "ctx-123")
+
+
+@pytest.mark.asyncio
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_get_client_factory")
+@patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
+async def test_cancel_task_success(mock_ensure, mock_factory, mock_discover):
+    """Test _cancel_task successfully cancels task."""
+    provider = A2AClientToolProvider()
+
+    # Mock agent card
+    mock_agent_card = Mock()
+    mock_discover.return_value = mock_agent_card
+
+    # Mock ClientFactory and Client
+    mock_client_factory = Mock()
+    mock_client = Mock()
+    mock_factory.return_value = mock_client_factory
+    mock_client_factory.create.return_value = mock_client
+
+    # Mock get_task response (task is active)
+    mock_current_task = Mock()
+    mock_current_task.status = Mock()
+    mock_current_task.status.state = "working"
+    mock_current_task.context_id = "ctx-123"
+
+    # Mock cancel_task response
+    mock_canceled_task = Mock()
+    mock_canceled_task.model_dump.return_value = {"id": "task-123", "status": {"state": "canceled"}}
+    mock_canceled_task.id = "task-123"
+    mock_canceled_task.status = Mock()
+    mock_canceled_task.status.state = "canceled"
+    mock_canceled_task.context_id = "ctx-123"
+
+    mock_client.get_task = AsyncMock(return_value=mock_current_task)
+    mock_client.cancel_task = AsyncMock(return_value=mock_canceled_task)
+
+    result = await provider._cancel_task("http://test.com", "task-123")
+
+    expected = {
+        "status": "success",
+        "task": {"id": "task-123", "status": {"state": "canceled"}},
+        "task_id": "task-123",
+        "target_agent_url": "http://test.com",
+        "task_state": "canceled",
+    }
+    assert result == expected
+    mock_ensure.assert_called_once()
+    mock_discover.assert_called_once_with("http://test.com")
+    mock_client.cancel_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_get_client_factory")
+@patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
+async def test_cancel_task_already_terminal(mock_ensure, mock_factory, mock_discover):
+    """Test _cancel_task when task is already in terminal state."""
+    provider = A2AClientToolProvider()
+
+    # Mock agent card
+    mock_agent_card = Mock()
+    mock_discover.return_value = mock_agent_card
+
+    # Mock ClientFactory and Client
+    mock_client_factory = Mock()
+    mock_client = Mock()
+    mock_factory.return_value = mock_client_factory
+    mock_client_factory.create.return_value = mock_client
+
+    # Mock get_task response (task is already completed)
+    mock_current_task = Mock()
+    mock_current_task.status = Mock()
+    mock_current_task.status.state = "completed"
+
+    mock_client.get_task = AsyncMock(return_value=mock_current_task)
+
+    result = await provider._cancel_task("http://test.com", "task-123")
+
+    expected = {
+        "status": "error",
+        "error": "Task cannot be canceled - current state: completed",
+        "task_id": "task-123",
+        "target_agent_url": "http://test.com",
+        "task_state": "completed",
+    }
+    assert result == expected
+    # cancel_task should NOT be called
+    mock_client.cancel_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_get_client_factory")
+@patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
+async def test_cancel_task_context_id_mismatch(mock_ensure, mock_factory, mock_discover):
+    """Test _cancel_task with context_id mismatch."""
+    provider = A2AClientToolProvider()
+
+    # Mock agent card
+    mock_agent_card = Mock()
+    mock_discover.return_value = mock_agent_card
+
+    # Mock ClientFactory and Client
+    mock_client_factory = Mock()
+    mock_client = Mock()
+    mock_factory.return_value = mock_client_factory
+    mock_client_factory.create.return_value = mock_client
+
+    # Mock get_task response (task has different context_id)
+    mock_current_task = Mock()
+    mock_current_task.status = Mock()
+    mock_current_task.status.state = "working"
+    mock_current_task.context_id = "ctx-different"
+
+    mock_client.get_task = AsyncMock(return_value=mock_current_task)
+
+    result = await provider._cancel_task("http://test.com", "task-123", context_id="ctx-expected")
+
+    expected = {
+        "status": "error",
+        "error": "Context ID mismatch: expected ctx-expected, got ctx-different",
+        "task_id": "task-123",
+        "target_agent_url": "http://test.com",
+    }
+    assert result == expected
+    # cancel_task should NOT be called
+    mock_client.cancel_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_get_client_factory")
+@patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
+async def test_cancel_task_not_found(mock_ensure, mock_factory, mock_discover):
+    """Test _cancel_task when task is not found."""
+    provider = A2AClientToolProvider()
+
+    # Mock agent card
+    mock_agent_card = Mock()
+    mock_discover.return_value = mock_agent_card
+
+    # Mock ClientFactory and Client
+    mock_client_factory = Mock()
+    mock_client = Mock()
+    mock_factory.return_value = mock_client_factory
+    mock_client_factory.create.return_value = mock_client
+
+    # Mock get_task to raise exception
+    mock_client.get_task = AsyncMock(side_effect=Exception("Task not found"))
+
+    result = await provider._cancel_task("http://test.com", "task-123")
+
+    expected = {
+        "status": "error",
+        "error": "Task not found or inaccessible: Task not found",
+        "task_id": "task-123",
+        "target_agent_url": "http://test.com",
+    }
+    assert result == expected
+
+
+@pytest.mark.asyncio
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_get_client_factory")
+@patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
+async def test_cancel_task_updates_conversation_state(mock_ensure, mock_factory, mock_discover):
+    """Test _cancel_task updates conversation state when task reaches terminal state."""
+    provider = A2AClientToolProvider()
+
+    # Set up initial active task
+    provider._conversation_states["http://test.com"] = ConversationState(
+        context_id="ctx-123",
+        active_tasks={"task-123": ActiveTask(task_id="task-123", state="working", context_id="ctx-123")},
+    )
+
+    # Mock agent card
+    mock_agent_card = Mock()
+    mock_discover.return_value = mock_agent_card
+
+    # Mock ClientFactory and Client
+    mock_client_factory = Mock()
+    mock_client = Mock()
+    mock_factory.return_value = mock_client_factory
+    mock_client_factory.create.return_value = mock_client
+
+    # Mock get_task response (task is active)
+    mock_current_task = Mock()
+    mock_current_task.status = Mock()
+    mock_current_task.status.state = "working"
+    mock_current_task.context_id = "ctx-123"
+
+    # Mock cancel_task response (task is now canceled)
+    mock_canceled_task = Mock()
+    mock_canceled_task.model_dump.return_value = {"id": "task-123", "status": {"state": "canceled"}}
+    mock_canceled_task.id = "task-123"
+    mock_canceled_task.status = Mock()
+    mock_canceled_task.status.state = "canceled"
+    mock_canceled_task.context_id = "ctx-123"
+
+    mock_client.get_task = AsyncMock(return_value=mock_current_task)
+    mock_client.cancel_task = AsyncMock(return_value=mock_canceled_task)
+
+    await provider._cancel_task("http://test.com", "task-123")
+
+    # Verify task was removed from active tasks (terminal state)
+    state = provider._conversation_states["http://test.com"]
+    assert "task-123" not in state.active_tasks
+
+
+@pytest.mark.asyncio
+@patch.object(A2AClientToolProvider, "_discover_agent_card")
+@patch.object(A2AClientToolProvider, "_ensure_discovered_known_agents")
+async def test_cancel_task_general_error(mock_ensure, mock_discover):
+    """Test _cancel_task handles general errors."""
+    provider = A2AClientToolProvider()
+
+    mock_discover.side_effect = Exception("Network error")
+
+    result = await provider._cancel_task("http://test.com", "task-123")
+
+    expected = {
+        "status": "error",
+        "error": "Network error",
+        "error_type": "Exception",
+        "task_id": "task-123",
+        "target_agent_url": "http://test.com",
+    }
+    assert result == expected


### PR DESCRIPTION
## Description

Adds two new tools to `A2AClientToolProvider` for task lifecycle management:

- **`a2a_get_task`**: Retrieves the current state, history, artifacts and metadata of a specific task. Automatically syncs the local conversation state with the retrieved task's current state.
- **`a2a_cancel_task`**: Cancels an active task with pre-cancellation validation — checks the task is not already in a terminal state before attempting cancellation, and optionally validates `context_id` to prevent operating on the wrong task.

Also fixes `TERMINAL_TASK_STATES` to include `"rejected"`, which is a valid terminal state per the A2A SDK's `TaskState` enum.

## Related Issues

Builds on [#358](https://github.com/strands-agents/tools/pull/358) (context_id and task_id persistence for multi-turn conversations)

## Type of Change

New Tool

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] Added comprehensive unit tests for for a2a_get_task and a2a_cancel_task
- [x] All existing tests pass
- [x] Lint passes (fixed line length issues)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
