### PR TITLE
feat(code-interpreter): add session_timeout_seconds parameter to AgentCoreCodeInterpreter

### DIFF
--- a/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
+++ b/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
@@ -53,6 +53,7 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         session_name: Optional[str] = None,
         auto_create: bool = True,
         persist_sessions: bool = True,
+        session_timeout_seconds: int = 900,
     ) -> None:
         """
         Initialize the Bedrock AgentCore code interpreter with session persistence support.
@@ -99,6 +100,10 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
                 invocation but the Python process persists. Setting this to True allows
                 sessions to survive across invocations and be reconnected by subsequent
                 instances via module-level cache.
+
+            session_timeout_seconds (int): Timeout in seconds for sessions created
+                by this instance. Sessions automatically terminate after the timeout period.
+                Default: 900 (15 minutes).
 
         Session Lifecycle:
             Invocation 1 (Instance #1):
@@ -180,6 +185,7 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         self.identifier = identifier or "aws.codeinterpreter.v1"
         self.auto_create = auto_create
         self.persist_sessions = persist_sessions
+        self.session_timeout_seconds = session_timeout_seconds
 
         if session_name is None:
             self.default_session = f"session-{uuid.uuid4().hex[:12]}"
@@ -262,8 +268,11 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
             # Create new sandbox client
             client = BedrockAgentCoreCodeInterpreterClient(region=self.region)
 
-            # Start session with identifier and name
-            client.start(identifier=self.identifier, name=session_name)
+            client.start(
+                identifier=self.identifier,
+                name=session_name,
+                session_timeout_seconds=self.session_timeout_seconds,
+            )
 
             aws_session_id = client.session_id
 

--- a/tests/code_interpreter/test_agent_core_code_interpreter.py
+++ b/tests/code_interpreter/test_agent_core_code_interpreter.py
@@ -67,6 +67,7 @@ def test_initialization(interpreter):
     assert interpreter.default_session.startswith("session-")
     assert interpreter.auto_create is True
     assert interpreter.persist_sessions is True
+    assert interpreter.session_timeout_seconds == 900
 
 
 def test_initialization_with_new_parameters():
@@ -75,6 +76,22 @@ def test_initialization_with_new_parameters():
         mock_resolve.return_value = "us-west-2"
         interpreter = AgentCoreCodeInterpreter(region="us-west-2", persist_sessions=False)
         assert interpreter.persist_sessions is False
+
+
+def test_initialization_with_session_timeout():
+    """Test initialization with custom session timeout."""
+    with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
+        mock_resolve.return_value = "us-west-2"
+        interpreter = AgentCoreCodeInterpreter(region="us-west-2", session_timeout_seconds=1800)
+        assert interpreter.session_timeout_seconds == 1800
+
+
+def test_initialization_without_session_timeout():
+    """Test initialization without session timeout defaults to 900."""
+    with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
+        mock_resolve.return_value = "us-west-2"
+        interpreter = AgentCoreCodeInterpreter(region="us-west-2")
+        assert interpreter.session_timeout_seconds == 900
 
 
 def test_session_name_no_cleaning():
@@ -396,7 +413,9 @@ def test_init_session_success(mock_client_class, interpreter, mock_client):
     assert result["content"][0]["json"]["sessionId"] == "test-session-id-123"
 
     mock_client_class.assert_called_once_with(region="us-west-2")
-    mock_client.start.assert_called_once_with(identifier="aws.codeinterpreter.v1", name="my-session")
+    mock_client.start.assert_called_once_with(
+        identifier="aws.codeinterpreter.v1", name="my-session", session_timeout_seconds=900
+    )
 
     assert "my-session" in interpreter._sessions
     session_info = interpreter._sessions["my-session"]
@@ -429,7 +448,9 @@ def test_init_session_with_custom_identifier(mock_client_class, mock_client):
         assert result["content"][0]["json"]["sessionId"] == "test-session-id-123"
 
         mock_client_class.assert_called_once_with(region="us-west-2")
-        mock_client.start.assert_called_once_with(identifier=custom_id, name="custom-session")
+        mock_client.start.assert_called_once_with(
+            identifier=custom_id, name="custom-session", session_timeout_seconds=900
+        )
 
         assert "custom-session" in interpreter._sessions
         session_info = interpreter._sessions["custom-session"]
@@ -458,7 +479,9 @@ def test_init_session_with_default_identifier(mock_client_class, mock_client):
         assert result["content"][0]["json"]["sessionId"] == "test-session-id-123"
 
         mock_client_class.assert_called_once_with(region="us-west-2")
-        mock_client.start.assert_called_once_with(identifier="aws.codeinterpreter.v1", name="default-session")
+        mock_client.start.assert_called_once_with(
+            identifier="aws.codeinterpreter.v1", name="default-session", session_timeout_seconds=900
+        )
 
         assert "default-session" in interpreter._sessions
         session_info = interpreter._sessions["default-session"]
@@ -466,6 +489,44 @@ def test_init_session_with_default_identifier(mock_client_class, mock_client):
         assert session_info.session_id == "test-session-id-123"
         assert session_info.description == "Test session"
         assert session_info.client == mock_client
+
+
+@patch("strands_tools.code_interpreter.agent_core_code_interpreter.BedrockAgentCoreCodeInterpreterClient")
+def test_init_session_with_session_timeout(mock_client_class, mock_client):
+    """Test session initialization passes session_timeout_seconds to client.start() when set."""
+    with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
+        mock_resolve.return_value = "us-west-2"
+        mock_client_class.return_value = mock_client
+
+        interpreter = AgentCoreCodeInterpreter(region="us-west-2", session_timeout_seconds=1800)
+
+        action = InitSessionAction(type="initSession", description="Test session", session_name="timeout-session")
+
+        result = interpreter.init_session(action)
+
+        assert result["status"] == "success"
+        mock_client.start.assert_called_once_with(
+            identifier="aws.codeinterpreter.v1", name="timeout-session", session_timeout_seconds=1800
+        )
+
+
+@patch("strands_tools.code_interpreter.agent_core_code_interpreter.BedrockAgentCoreCodeInterpreterClient")
+def test_init_session_without_session_timeout(mock_client_class, mock_client):
+    """Test session initialization passes default session_timeout_seconds to client.start()."""
+    with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
+        mock_resolve.return_value = "us-west-2"
+        mock_client_class.return_value = mock_client
+
+        interpreter = AgentCoreCodeInterpreter(region="us-west-2")
+
+        action = InitSessionAction(type="initSession", description="Test session", session_name="no-timeout-session")
+
+        result = interpreter.init_session(action)
+
+        assert result["status"] == "success"
+        mock_client.start.assert_called_once_with(
+            identifier="aws.codeinterpreter.v1", name="no-timeout-session", session_timeout_seconds=900
+        )
 
 
 @patch("strands_tools.code_interpreter.agent_core_code_interpreter.BedrockAgentCoreCodeInterpreterClient")
@@ -498,9 +559,12 @@ def test_init_session_multiple_identifiers_verification(mock_client_class, mock_
         assert mock_client.start.call_count == 3
         call_args_list = mock_client.start.call_args_list
 
-        assert call_args_list[0] == ((), {"identifier": custom_id1, "name": "session1"})
-        assert call_args_list[1] == ((), {"identifier": custom_id2, "name": "session2"})
-        assert call_args_list[2] == ((), {"identifier": "aws.codeinterpreter.v1", "name": "session3"})
+        assert call_args_list[0] == ((), {"identifier": custom_id1, "name": "session1", "session_timeout_seconds": 900})
+        assert call_args_list[1] == ((), {"identifier": custom_id2, "name": "session2", "session_timeout_seconds": 900})
+        assert call_args_list[2] == (
+            (),
+            {"identifier": "aws.codeinterpreter.v1", "name": "session3", "session_timeout_seconds": 900},
+        )
 
 
 @patch("strands_tools.code_interpreter.agent_core_code_interpreter.BedrockAgentCoreCodeInterpreterClient")


### PR DESCRIPTION
Allow callers to configure the session timeout passed to the underlying
Bedrock AgentCore client.start() call, defaulting to 900s (15 minutes).

## Description

<!-- Provide a detailed description of the changes in this PR -->
This adds support to pass the AgentCore Code Interpreter session
timeout as a configuration.

Occasionally, we face a sesion that is no longer active due to the 
agent being available longer than the code interpreter session.

## Related Issues

<!-- Link to related issues using #issue-number format -->
NA

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->
NA

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): Tool Improvement

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
