### PR TITLE
feat: add sql_database tool with multi-dialect SQL querying and schem…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ elasticsearch-memory = [
 mongodb-memory = [
     "pymongo>=4.0.0,<5.0.0",
 ]
+sql = [
+    "sqlalchemy>=2.0",
+]
 
 [tool.hatch.envs.hatch-static-analysis]
 features = ["mem0-memory", "local-chromium-browser", "agent-core-browser", "agent-core-code-interpreter", "a2a-client", "diagram", "rss", "use-computer", "twelvelabs", "elasticsearch-memory", "mongodb-memory"]

--- a/src/strands_tools/sql_database.py
+++ b/src/strands_tools/sql_database.py
@@ -1,0 +1,356 @@
+"""
+SQL Database Tool for Strands Agents.
+
+Enables agents to connect to SQL databases (PostgreSQL, MySQL, SQLite),
+run queries, and introspect schemas — with safe read-only mode by default.
+
+Environment Variables:
+    DATABASE_URL: Connection string (e.g. postgresql://user:pass@host/db)
+                  Can also be passed directly via the `connection_string` param.
+
+Usage with Strands Agent:
+    from strands import Agent
+    from strands_tools.sql_database import sql_database
+
+    agent = Agent(tools=[sql_database])
+
+    # List all tables
+    agent.tool.sql_database(action="list_tables")
+
+    # Describe a table's schema
+    agent.tool.sql_database(action="describe_table", table="orders")
+
+    # Run a SELECT query
+    agent.tool.sql_database(
+        action="query",
+        sql="SELECT id, name FROM users LIMIT 5"
+    )
+"""
+
+import logging
+import os
+from typing import Any, Optional
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from strands import tool
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_engine(connection_string: str):
+    """Return a SQLAlchemy engine; raises ImportError if sqlalchemy missing."""
+    try:
+        from sqlalchemy import create_engine, text  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "sqlalchemy is required for the sql_database tool. Install it with: pip install 'strands-agents-tools[sql]'"
+        ) from exc
+    from sqlalchemy import create_engine
+
+    return create_engine(connection_string, pool_pre_ping=True)
+
+
+def _resolve_connection_string(connection_string: Optional[str]) -> str:
+    """Resolve connection string from param or DATABASE_URL env var."""
+    cs = connection_string or os.environ.get("DATABASE_URL", "")
+    if not cs:
+        raise ValueError(
+            "No connection string provided. Pass `connection_string` or set the DATABASE_URL environment variable."
+        )
+    return cs
+
+
+def _is_safe_query(sql: str) -> bool:
+    """Return True if the SQL statement is read-only (SELECT / WITH / EXPLAIN)."""
+    first_word = sql.strip().lstrip("(").split()[0].upper()
+    return first_word in {"SELECT", "WITH", "EXPLAIN", "SHOW", "DESCRIBE", "DESC"}
+
+
+def _rows_to_panel(rows, columns, title: str) -> Panel:
+    """Render query results as a rich Panel containing a Table."""
+    tbl = Table(show_header=True, header_style="bold cyan")
+    for col in columns:
+        tbl.add_column(str(col))
+    for row in rows:
+        tbl.add_row(*[str(v) if v is not None else "NULL" for v in row])
+    return Panel(tbl, title=f"[bold cyan]{title}", border_style="cyan")
+
+
+# ---------------------------------------------------------------------------
+# Core actions
+# ---------------------------------------------------------------------------
+
+
+def _list_tables(engine) -> dict[str, Any]:
+    from sqlalchemy import inspect
+
+    inspector = inspect(engine)
+    tables = inspector.get_table_names()
+    views = inspector.get_view_names()
+    console.print(
+        Panel(
+            "\n".join(f"• {t}" for t in sorted(tables + views)) or "(none)",
+            title="[bold cyan]Tables & Views",
+            border_style="cyan",
+        )
+    )
+    return {
+        "status": "success",
+        "tables": tables,
+        "views": views,
+        "content": [{"text": f"Found {len(tables)} table(s) and {len(views)} view(s)."}],
+    }
+
+
+def _describe_table(engine, table: str) -> dict[str, Any]:
+    from sqlalchemy import inspect
+
+    inspector = inspect(engine)
+    try:
+        columns = inspector.get_columns(table)
+        pk = inspector.get_pk_constraint(table)
+        fks = inspector.get_foreign_keys(table)
+    except Exception as exc:
+        return {
+            "status": "error",
+            "content": [{"text": f"Could not describe table '{table}': {exc}"}],
+        }
+
+    tbl = Table(show_header=True, header_style="bold cyan")
+    tbl.add_column("Column")
+    tbl.add_column("Type")
+    tbl.add_column("Nullable")
+    tbl.add_column("Default")
+    tbl.add_column("PK")
+
+    pk_cols = set(pk.get("constrained_columns", []))
+    for col in columns:
+        tbl.add_row(
+            col["name"],
+            str(col["type"]),
+            "YES" if col.get("nullable", True) else "NO",
+            str(col.get("default", "")) or "",
+            "✓" if col["name"] in pk_cols else "",
+        )
+
+    console.print(Panel(tbl, title=f"[bold cyan]Schema: {table}", border_style="cyan"))
+
+    fk_text = ""
+    if fks:
+        fk_lines = [f"  {fk['constrained_columns']} → {fk['referred_table']}.{fk['referred_columns']}" for fk in fks]
+        fk_text = "\nForeign Keys:\n" + "\n".join(fk_lines)
+        console.print(fk_text)
+
+    return {
+        "status": "success",
+        "table": table,
+        "columns": [
+            {
+                "name": c["name"],
+                "type": str(c["type"]),
+                "nullable": c.get("nullable", True),
+                "primary_key": c["name"] in pk_cols,
+            }
+            for c in columns
+        ],
+        "content": [{"text": f"Table '{table}' has {len(columns)} column(s).{fk_text}"}],
+    }
+
+
+def _run_query(engine, sql: str, read_only: bool, max_rows: int) -> dict[str, Any]:
+    from sqlalchemy import text
+
+    if read_only and not _is_safe_query(sql):
+        return {
+            "status": "error",
+            "content": [
+                {
+                    "text": (
+                        "Blocked: only SELECT/WITH/EXPLAIN queries are allowed in "
+                        "read-only mode. Set read_only=False to run write queries."
+                    )
+                }
+            ],
+        }
+
+    with engine.connect() as conn:
+        result = conn.execute(text(sql))
+        if result.returns_rows:
+            columns = list(result.keys())
+            rows = result.fetchmany(max_rows)
+            console.print(_rows_to_panel(rows, columns, f"Results (up to {max_rows} rows)"))
+            truncated = len(rows) == max_rows
+            return {
+                "status": "success",
+                "columns": columns,
+                "rows": [dict(zip(columns, row, strict=False)) for row in rows],
+                "truncated": truncated,
+                "content": [
+                    {"text": (f"Returned {len(rows)} row(s)." + (" Results may be truncated." if truncated else ""))}
+                ],
+            }
+        else:
+            conn.commit()
+            rowcount = result.rowcount
+            console.print(
+                Panel(
+                    f"Query executed successfully. Rows affected: {rowcount}",
+                    title="[bold green]Execute Result",
+                    border_style="green",
+                )
+            )
+            return {
+                "status": "success",
+                "rows_affected": rowcount,
+                "content": [{"text": f"Query executed. Rows affected: {rowcount}"}],
+            }
+
+
+def _get_schema_summary(engine) -> dict[str, Any]:
+    """Return a compact multi-table schema overview — great for Text-to-SQL context."""
+    from sqlalchemy import inspect
+
+    inspector = inspect(engine)
+    tables = inspector.get_table_names()
+    summary: dict[str, list[str]] = {}
+    lines = []
+    for table in sorted(tables):
+        cols = inspector.get_columns(table)
+        col_strs = [f"{c['name']} {c['type']}" for c in cols]
+        summary[table] = col_strs
+        lines.append(f"{table}({', '.join(col_strs)})")
+
+    console.print(
+        Panel(
+            "\n".join(lines) or "(no tables found)",
+            title="[bold cyan]Schema Summary",
+            border_style="cyan",
+        )
+    )
+    return {
+        "status": "success",
+        "schema": summary,
+        "content": [{"text": "\n".join(lines)}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main @tool entry point
+# ---------------------------------------------------------------------------
+
+
+@tool
+def sql_database(
+    action: str,
+    connection_string: Optional[str] = None,
+    sql: Optional[str] = None,
+    table: Optional[str] = None,
+    read_only: bool = True,
+    max_rows: int = 100,
+) -> dict[str, Any]:
+    """
+    Connect to a SQL database and perform queries or schema introspection.
+
+    Supports PostgreSQL, MySQL, and SQLite via SQLAlchemy connection strings.
+    Read-only mode is enabled by default to prevent accidental data modification.
+
+    Args:
+        action:            One of: "query", "execute", "list_tables",
+                           "describe_table", "schema_summary"
+        connection_string: SQLAlchemy connection string
+                           (e.g. "sqlite:///mydb.db",
+                                 "postgresql://user:pass@localhost/dbname",
+                                 "mysql+pymysql://user:pass@localhost/dbname").
+                           Falls back to DATABASE_URL env var if not provided.
+        sql:               SQL statement to run (required for "query"/"execute").
+        table:             Table name (required for "describe_table").
+        read_only:         If True (default), only SELECT/WITH/EXPLAIN are allowed.
+        max_rows:          Maximum number of rows to return for SELECT queries (default 100).
+
+    Returns:
+        dict with "status" ("success" | "error") and action-specific fields.
+
+    Examples:
+        # List all tables
+        sql_database(action="list_tables")
+
+        # Get full schema overview (ideal for Text-to-SQL context)
+        sql_database(action="schema_summary")
+
+        # Describe a single table
+        sql_database(action="describe_table", table="orders")
+
+        # Run a SELECT
+        sql_database(action="query", sql="SELECT * FROM users LIMIT 10")
+
+        # Run a write query (requires read_only=False)
+        sql_database(
+            action="execute",
+            sql="UPDATE users SET active=1 WHERE id=42",
+            read_only=False,
+        )
+    """
+    try:
+        cs = _resolve_connection_string(connection_string)
+    except ValueError as exc:
+        return {"status": "error", "content": [{"text": str(exc)}]}
+
+    try:
+        engine = _get_engine(cs)
+    except ImportError as exc:
+        return {"status": "error", "content": [{"text": str(exc)}]}
+    except Exception as exc:
+        return {
+            "status": "error",
+            "content": [{"text": f"Failed to create database engine: {exc}"}],
+        }
+
+    try:
+        if action == "list_tables":
+            return _list_tables(engine)
+
+        elif action == "schema_summary":
+            return _get_schema_summary(engine)
+
+        elif action == "describe_table":
+            if not table:
+                return {
+                    "status": "error",
+                    "content": [{"text": "`table` parameter is required for describe_table."}],
+                }
+            return _describe_table(engine, table)
+
+        elif action in ("query", "execute"):
+            if not sql:
+                return {
+                    "status": "error",
+                    "content": [{"text": "`sql` parameter is required for query/execute."}],
+                }
+            return _run_query(engine, sql.strip(), read_only, max_rows)
+
+        else:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"Unknown action '{action}'. "
+                            "Valid actions: list_tables, schema_summary, "
+                            "describe_table, query, execute."
+                        )
+                    }
+                ],
+            }
+
+    except Exception as exc:
+        logger.exception("sql_database tool error")
+        return {"status": "error", "content": [{"text": f"Unexpected error: {exc}"}]}
+    finally:
+        engine.dispose()

--- a/tests/test_sql_database.py
+++ b/tests/test_sql_database.py
@@ -1,0 +1,174 @@
+"""
+Tests for the sql_database tool.
+
+Uses pytest tmp_path fixture for isolated, parallel-safe SQLite databases.
+Compatible with pytest-xdist parallel execution.
+"""
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from strands_tools.sql_database import sql_database
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_url(tmp_path):
+    """Create a seeded SQLite DB in a unique temp directory per test worker."""
+    db_file = tmp_path / "test.db"
+    url = f"sqlite:///{db_file}"
+
+    engine = create_engine(url)
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE users (
+                    id      INTEGER PRIMARY KEY,
+                    name    TEXT    NOT NULL,
+                    email   TEXT    UNIQUE,
+                    active  INTEGER DEFAULT 1
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE orders (
+                    id      INTEGER PRIMARY KEY,
+                    user_id INTEGER REFERENCES users(id),
+                    amount  REAL    NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(text("INSERT INTO users VALUES (1, 'Alice', 'alice@example.com', 1)"))
+        conn.execute(text("INSERT INTO users VALUES (2, 'Bob',   'bob@example.com',   0)"))
+        conn.execute(text("INSERT INTO orders VALUES (1, 1, 99.99)"))
+        conn.execute(text("INSERT INTO orders VALUES (2, 2, 49.50)"))
+        conn.commit()
+    engine.dispose()
+
+    return url
+
+
+def run(db_url, action, **kwargs):
+    return sql_database(action=action, connection_string=db_url, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestListTables:
+    def test_returns_success(self, db_url):
+        result = run(db_url, "list_tables")
+        assert result["status"] == "success"
+
+    def test_contains_expected_tables(self, db_url):
+        result = run(db_url, "list_tables")
+        assert "users" in result["tables"]
+        assert "orders" in result["tables"]
+
+
+class TestDescribeTable:
+    def test_describes_users(self, db_url):
+        result = run(db_url, "describe_table", table="users")
+        assert result["status"] == "success"
+        col_names = [c["name"] for c in result["columns"]]
+        assert "id" in col_names
+        assert "email" in col_names
+
+    def test_primary_key_flagged(self, db_url):
+        result = run(db_url, "describe_table", table="users")
+        id_col = next(c for c in result["columns"] if c["name"] == "id")
+        assert id_col["primary_key"] is True
+
+    def test_missing_table_param(self, db_url):
+        result = run(db_url, "describe_table")
+        assert result["status"] == "error"
+        assert "table" in result["content"][0]["text"].lower()
+
+    def test_nonexistent_table(self, db_url):
+        result = run(db_url, "describe_table", table="nonexistent_xyz")
+        assert result["status"] == "error"
+
+
+class TestQuery:
+    def test_select_all_users(self, db_url):
+        result = run(db_url, "query", sql="SELECT * FROM users")
+        assert result["status"] == "success"
+        assert len(result["rows"]) == 2
+
+    def test_columns_returned(self, db_url):
+        result = run(db_url, "query", sql="SELECT id, name FROM users")
+        assert "id" in result["columns"]
+        assert "name" in result["columns"]
+
+    def test_max_rows_respected(self, db_url):
+        result = run(db_url, "query", sql="SELECT * FROM users", max_rows=1)
+        assert len(result["rows"]) == 1
+        assert result["truncated"] is True
+
+    def test_read_only_blocks_insert(self, db_url):
+        result = run(
+            db_url,
+            "query",
+            sql="INSERT INTO users VALUES (99, 'X', 'x@x.com', 1)",
+            read_only=True,
+        )
+        assert result["status"] == "error"
+        assert "read-only" in result["content"][0]["text"].lower()
+
+    def test_empty_sql_rejected(self, db_url):
+        result = run(db_url, "query", sql="")
+        assert result["status"] == "error"
+
+    def test_missing_sql_rejected(self, db_url):
+        result = run(db_url, "query")
+        assert result["status"] == "error"
+
+
+class TestSchemaSummary:
+    def test_returns_success(self, db_url):
+        result = run(db_url, "schema_summary")
+        assert result["status"] == "success"
+
+    def test_all_tables_present(self, db_url):
+        result = run(db_url, "schema_summary")
+        assert "users" in result["schema"]
+        assert "orders" in result["schema"]
+
+    def test_columns_in_summary(self, db_url):
+        result = run(db_url, "schema_summary")
+        users_cols = result["schema"]["users"]
+        assert any("name" in c for c in users_cols)
+
+
+class TestConnectionHandling:
+    def test_missing_connection_string_error(self):
+        import os
+
+        os.environ.pop("DATABASE_URL", None)
+        result = sql_database(action="list_tables", connection_string=None)
+        assert result["status"] == "error"
+        assert "connection" in result["content"][0]["text"].lower()
+
+    def test_invalid_connection_string_error(self):
+        result = sql_database(
+            action="list_tables",
+            connection_string="notavaliddriver://??",
+        )
+        assert result["status"] == "error"
+
+
+class TestUnknownAction:
+    def test_unknown_action_returns_error(self, db_url):
+        result = run(db_url, "fly_to_moon")
+        assert result["status"] == "error"
+        assert "unknown action" in result["content"][0]["text"].lower()


### PR DESCRIPTION
## Summary
Adds a general-purpose `sql_database` tool that enables agents to connect to SQL 
databases and perform natural language-driven queries and schema introspection 
via SQLAlchemy.

## Motivation
The existing `retrieve` tool only works with Amazon Bedrock Knowledge Bases. 
Developers building agents over PostgreSQL, MySQL, or SQLite databases currently 
have no native option and must write custom tooling from scratch. This is a 
significant gap especially for enterprise use cases like Text-to-SQL agents, 
data analysis workflows, and CRM/ERP integrations over relational databases.

## Actions Supported

| Action | Description |
|---|---|
| `list_tables` | List all tables and views in the database |
| `describe_table` | Get column names, types, nullability, PKs and FKs for a table |
| `schema_summary` | Compact multi-table schema overview — ideal as LLM context for Text-to-SQL |
| `query` | Run SELECT statements and return results |
| `execute` | Run write queries — blocked by default via `read_only=True` |

## Usage
```python
from strands import Agent
from strands_tools.sql_database import sql_database

agent = Agent(tools=[sql_database])

# Let the agent answer business questions naturally
agent("What are the top 5 customers by revenue this month? db: postgresql://user:pass@localhost/sales")

# Or call the tool directly
sql_database(action="schema_summary", connection_string="sqlite:///mydb.db")
sql_database(action="query", connection_string="sqlite:///mydb.db", sql="SELECT * FROM orders LIMIT 10")
sql_database(action="describe_table", connection_string="sqlite:///mydb.db", table="users")
```

## Key Design Decisions

- **SQLAlchemy under the hood** — supports PostgreSQL, MySQL, SQLite and any 
  other SQLAlchemy-compatible database out of the box
- **Read-only by default** — `read_only=True` blocks INSERT/UPDATE/DELETE 
  unless explicitly opted in, preventing accidental data modification by agents
- **Connection string via param or env var** — pass `connection_string` directly 
  or set `DATABASE_URL` environment variable
- **`schema_summary` action** — returns a compact single-line schema per table, 
  purpose-built as context for Text-to-SQL LLM prompts

## Testing

Tested and verified on all three supported databases:
- ✅ SQLite — full test suite using `pytest` with `tmp_path` fixture (parallel-safe, no external service required)
- ✅ PostgreSQL — manually verified all 5 actions against a live PostgreSQL instance
- ✅ MySQL — manually verified all 5 actions against a live MySQL instance

## Installation
```bash
# Core (SQLite works out of the box)
pip install "strands-agents-tools[sql]"

# PostgreSQL
pip install psycopg2-binary

# MySQL
pip install pymysql
```

## Changes
- `src/strands_tools/sql_database.py` — new tool
- `tests/test_sql_database.py` — full test suite
- `pyproject.toml` — added `sql` optional dependency group

## Background
This tool was motivated by production experience architecting a Text-to-SQL 
agentic platform at Dell Technologies over multi-schema financial databases 
(400+ columns), achieving 82% SQL execution accuracy on a benchmark of 200 
financial queries. The `schema_summary` action directly addresses the challenge 
of fitting large database schemas into LLM context windows efficiently.