### PR TITLE
fix: add allowlist for auth_env_var parameter for http_request tool

### DIFF
--- a/src/strands_tools/http_request.py
+++ b/src/strands_tools/http_request.py
@@ -2,18 +2,26 @@
 Make HTTP requests with comprehensive authentication, session management, and metrics.
 Supports all major authentication types and enterprise patterns.
 
-Environment Variable Support:
-1. Authentication tokens:
-   - Uses auth_env_var parameter to read tokens from environment (e.g., GITHUB_TOKEN, GITLAB_TOKEN)
-   - Example: http_request(method="GET", url="...", auth_type="token", auth_env_var="GITHUB_TOKEN")
-   - Supported variables: GITHUB_TOKEN, GITLAB_TOKEN, SLACK_BOT_TOKEN, AWS_ACCESS_KEY_ID, etc.
-2. AWS credentials:
-   - Reads AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_REGION automatically
-   - Example: http_request(method="GET", url="...", auth_type="aws_sig_v4", aws_auth={"service": "s3"})
-Use the environment tool (agent.tool.environment) to view available environment variables:
-- List all: environment(action="list")
-- Get specific: environment(action="get", name="GITHUB_TOKEN")
-- Set new: environment(action="set", name="CUSTOM_TOKEN", value="your-token")
+Authentication Support:
+1. Direct tokens: Pass auth_token directly for Bearer, token, custom, or api_key auth types
+2. Basic auth: Provide username/password via basic_auth parameter
+3. Digest auth: Provide credentials via digest_auth parameter
+4. JWT: Provide secret/algorithm/expiry via jwt_config parameter
+5. AWS SigV4: Uses boto3 credential chain automatically via aws_auth parameter
+
+Environment Variable Token Config:
+  Import and populate HTTP_REQUEST_TOKEN_CONFIG to allow specific environment variables
+  to be used as auth tokens for requests to matching domains.
+
+  Format: {"ENV_VAR_NAME": ["allowed.domain.com", "*.other.com"]}
+
+  Example:
+    from strands_tools.http_request import HTTP_REQUEST_TOKEN_CONFIG
+    HTTP_REQUEST_TOKEN_CONFIG["GITHUB_TOKEN"] = ["api.github.com"]
+    HTTP_REQUEST_TOKEN_CONFIG["GITLAB_TOKEN"] = ["gitlab.com"]
+
+  When auth_env_var is passed to the tool, the token is only injected if the request
+  domain matches one of the allowed domains for that variable.
 """
 
 import base64
@@ -48,9 +56,8 @@ TOOL_SPEC = {
     "name": "http_request",
     "description": (
         "Make HTTP requests to any API with comprehensive authentication including Bearer tokens, Basic auth, "
-        "JWT, AWS SigV4, Digest auth, and enterprise authentication patterns. Automatically reads tokens from "
-        "environment variables (GITHUB_TOKEN, GITLAB_TOKEN, AWS credentials, etc.) when auth_env_var is specified. "
-        "Use environment(action='list') to view available variables. Includes session management, metrics, "
+        "JWT, AWS SigV4, Digest auth, and enterprise authentication patterns. "
+        "Includes session management, metrics, "
         "streaming support, cookie handling, redirect control, proxy support, and optional HTML to markdown conversion."
     ),
     "inputSchema": {
@@ -82,11 +89,15 @@ TOOL_SPEC = {
                 },
                 "auth_token": {
                     "type": "string",
-                    "description": "Authentication token (if not provided, will check environment variables)",
+                    "description": "Authentication token (if not provided, will check auth_env_var if configured)",
                 },
                 "auth_env_var": {
                     "type": "string",
-                    "description": "Name of environment variable containing the auth token",
+                    "description": (
+                        "Name of an environment variable containing the auth token. "
+                        "The variable must be listed in HTTP_REQUEST_TOKEN_CONFIG "
+                        "with an allowed domain that matches the request URL."
+                    ),
                 },
                 "headers": {
                     "type": "object",
@@ -197,6 +208,12 @@ SESSION_CACHE = {}
 
 # Metrics storage
 REQUEST_METRICS = collections.defaultdict(list)
+
+# Token config: maps env var names to lists of allowed domains.
+# Import and populate this dict to enable auth_env_var support:
+#   from strands_tools.http_request import HTTP_REQUEST_TOKEN_CONFIG
+#   HTTP_REQUEST_TOKEN_CONFIG["GITHUB_TOKEN"] = ["api.github.com"]
+HTTP_REQUEST_TOKEN_CONFIG: Dict[str, list] = {}
 
 
 def extract_content_from_html(html: str) -> str:
@@ -372,12 +389,14 @@ def format_headers_table(headers: Dict) -> Table:
 
 
 def process_auth_headers(headers: Dict[str, Any], tool_input: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Process authentication headers based on input parameters.
+    """Process authentication headers based on input parameters.
 
     Supports multiple authentication methods:
-    1. Environment variables: Uses auth_env_var to read tokens
-    2. Direct token: Uses auth_token parameter
+    1. Direct token: Uses auth_token parameter
+    2. Env var token: Uses auth_env_var parameter, validated against HTTP_REQUEST_TOKEN_CONFIG
+    3. Basic auth: Handled separately via handle_basic_auth
+    4. JWT: Handled separately via handle_jwt
+    5. AWS SigV4: Handled separately via handle_aws_sigv4
 
     Special handling for different APIs:
     - GitHub: Uses "token" prefix (auth_type="token")
@@ -385,23 +404,39 @@ def process_auth_headers(headers: Dict[str, Any], tool_input: Dict[str, Any]) ->
     - AWS: Uses SigV4 signing (auth_type="aws_sig_v4")
 
     Examples:
-        # GitHub API with environment variable
-        process_auth_headers({}, {"auth_type": "token", "auth_env_var": "GITHUB_TOKEN"})
+        # GitHub API with env var (requires HTTP_REQUEST_TOKEN_CONFIG["GITHUB_TOKEN"] = ["api.github.com"])
+        process_auth_headers({}, {"auth_type": "token", "auth_env_var": "GITHUB_TOKEN", "url": "https://api.github.com/user"})
 
-        # GitLab API with environment variable
-        process_auth_headers({}, {"auth_type": "Bearer", "auth_env_var": "GITLAB_TOKEN"})
+        # Direct token
+        process_auth_headers({}, {"auth_type": "Bearer", "auth_token": "my-token"})
     """
     headers = headers or {}
 
-    # Get auth token from input or environment
     auth_token = tool_input.get("auth_token")
+
+    # Resolve token from environment variable if auth_env_var is provided
     if not auth_token and "auth_env_var" in tool_input:
         env_var_name = tool_input["auth_env_var"]
-        auth_token = os.getenv(env_var_name)
+        allowed_domains = HTTP_REQUEST_TOKEN_CONFIG.get(env_var_name)
+
+        if allowed_domains is None:
+            raise ValueError(
+                f"Environment variable '{env_var_name}' is not listed in STRANDS_HTTP_REQUEST_TOKEN_CONFIG. "
+                f"Add it with an explicit list of allowed domains before using it as an auth token."
+            )
+
+        # Validate the request URL against the allowed domains using URL parsing
+        request_url = tool_input.get("url", "")
+        request_host = urlparse(request_url).hostname or ""
+        if request_host not in allowed_domains:
+            raise ValueError(
+                f"Request to '{request_host}' is not in the allowed domains for '{env_var_name}': {allowed_domains}"
+            )
+
+        auth_token = os.environ.get(env_var_name)
         if not auth_token:
             raise ValueError(
-                f"Environment variable '{env_var_name}' not found or empty. "
-                f"Use environment(action='list') to see available variables."
+                f"Environment variable '{env_var_name}' is not set or is empty."
             )
 
     auth_type = tool_input.get("auth_type")
@@ -559,11 +594,31 @@ def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
             method="GET",
             url="https://api.github.com/user",
             auth_type="token",
+            auth_token="<your-github-token>",
+        )
+        ```
+
+        Or with env var (requires HTTP_REQUEST_TOKEN_CONFIG["GITHUB_TOKEN"] = ["api.github.com"]):
+        ```python
+        http_request(
+            method="GET",
+            url="https://api.github.com/user",
+            auth_type="token",
             auth_env_var="GITHUB_TOKEN",
         )
         ```
 
     2. GitLab API (uses "Bearer" auth_type):
+        ```python
+        http_request(
+            method="GET",
+            url="https://gitlab.com/api/v4/user",
+            auth_type="Bearer",
+            auth_token="<your-gitlab-token>",
+        )
+        ```
+
+        Or with env var (requires HTTP_REQUEST_TOKEN_CONFIG["GITLAB_TOKEN"] = ["gitlab.com"]):
         ```python
         http_request(
             method="GET",
@@ -622,9 +677,10 @@ def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
         ```
 
     Environment Variables:
-    - Authentication tokens are read from environment when auth_env_var is specified
     - AWS credentials are automatically loaded from environment variables or credentials file
-    - Use environment(action='list') to view all available environment variables
+
+    Token Config:
+    - Use HTTP_REQUEST_TOKEN_CONFIG to allow specific env vars as auth tokens for permitted domains
     """
     console = console_util.create()
 
@@ -937,9 +993,9 @@ def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
         if "auth" in error_str or "token" in error_str or "credential" in error_str or "unauthorized" in error_str:
             suggestion = (
                 "\n\nSuggestion: Check your authentication setup. Common solutions:\n"
-                "- For GitHub API: Use auth_type='token' with auth_env_var='GITHUB_TOKEN'\n"
-                "- For GitLab API: Use auth_type='Bearer' with auth_env_var='GITLAB_TOKEN'\n"
-                "- Use environment(action='list') to view available environment variables"
+                "- For GitHub API: Use auth_type='token' with auth_token='<your-token>'\n"
+                "- For GitLab API: Use auth_type='Bearer' with auth_token='<your-token>'\n"
+                "- For AWS APIs: Use auth_type='aws_sig_v4' with aws_auth configuration"
             )
 
         # Special handling for ImportError to help with test assertions

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -25,7 +25,6 @@ def mock_request_state():
     """Create a mock request state dictionary."""
     return {}
 
-
 @pytest.fixture
 def mock_env_vars():
     """Set up mock environment variables for testing."""
@@ -44,7 +43,6 @@ def extract_result_text(result):
     if isinstance(result, dict) and "content" in result and isinstance(result["content"], list):
         return "\n".join([item["text"] for item in result["content"]])
     return str(result)
-
 
 @responses.activate
 def test_basic_get_request():
@@ -232,7 +230,7 @@ def test_disable_redirects():
 
 
 @responses.activate
-def test_auth_token_direct(mock_env_vars):
+def test_auth_token_direct():
     """Test using auth_token parameter directly."""
     responses.add(
         responses.GET,
@@ -262,8 +260,8 @@ def test_auth_token_direct(mock_env_vars):
 
 
 @responses.activate
-def test_auth_token_from_env(mock_env_vars):
-    """Test getting auth token from environment variable."""
+def test_auth_token_bearer():
+    """Test Bearer auth with direct auth_token."""
     responses.add(
         responses.GET,
         "https://api.example.com/protected",
@@ -278,7 +276,7 @@ def test_auth_token_from_env(mock_env_vars):
             "method": "GET",
             "url": "https://api.example.com/protected",
             "auth_type": "Bearer",
-            "auth_env_var": "TEST_TOKEN",
+            "auth_token": "test-token-value",
         },
     }
 
@@ -292,7 +290,7 @@ def test_auth_token_from_env(mock_env_vars):
 
 
 @responses.activate
-def test_github_api_auth(mock_env_vars):
+def test_github_api_auth():
     """Test GitHub API authentication with token prefix."""
     responses.add(
         responses.GET,
@@ -315,7 +313,7 @@ def test_github_api_auth(mock_env_vars):
             "method": "GET",
             "url": "https://api.github.com/user",
             "auth_type": "token",
-            "auth_env_var": "GITHUB_TOKEN",
+            "auth_token": "github-token-1234",
         },
     }
 
@@ -328,6 +326,85 @@ def test_github_api_auth(mock_env_vars):
     # Check that GitHub-specific headers were set
     assert responses.calls[0].request.headers["Authorization"] == "token github-token-1234"
     assert responses.calls[0].request.headers["Accept"] == "application/vnd.github.v3+json"
+
+
+@responses.activate
+def test_auth_env_var_allowed_domain(mock_env_vars):
+    """Test auth_env_var resolves token when domain is in the allowlist."""
+    responses.add(
+        responses.GET,
+        "https://api.github.com/user",
+        json={"login": "testuser"},
+        status=200,
+    )
+
+    tool_use = {
+        "toolUseId": "test-env-var-allowed-id",
+        "input": {
+            "method": "GET",
+            "url": "https://api.github.com/user",
+            "auth_type": "token",
+            "auth_env_var": "GITHUB_TOKEN",
+        },
+    }
+
+    token_config = {"GITHUB_TOKEN": ["api.github.com"]}
+    with (
+        patch("strands_tools.http_request.HTTP_REQUEST_TOKEN_CONFIG", token_config),
+        patch("strands_tools.http_request.get_user_input") as mock_input,
+    ):
+        mock_input.return_value = "y"
+        result = http_request.http_request(tool=tool_use)
+
+    assert result["status"] == "success"
+    assert responses.calls[0].request.headers["Authorization"] == "token github-token-1234"
+
+
+def test_auth_env_var_domain_not_allowed(mock_env_vars):
+    """Test auth_env_var raises error when domain is not in the allowlist."""
+    tool_use = {
+        "toolUseId": "test-env-var-denied-id",
+        "input": {
+            "method": "GET",
+            "url": "https://evil.example.com/steal",
+            "auth_type": "token",
+            "auth_env_var": "GITHUB_TOKEN",
+        },
+    }
+
+    token_config = {"GITHUB_TOKEN": ["api.github.com"]}
+    with (
+        patch("strands_tools.http_request.HTTP_REQUEST_TOKEN_CONFIG", token_config),
+        patch("strands_tools.http_request.get_user_input") as mock_input,
+    ):
+        mock_input.return_value = "y"
+        result = http_request.http_request(tool=tool_use)
+
+    assert result["status"] == "error"
+    assert "not in the allowed domains" in result["content"][0]["text"]
+
+
+def test_auth_env_var_not_in_config():
+    """Test auth_env_var raises error when env var is not in token config at all."""
+    tool_use = {
+        "toolUseId": "test-env-var-no-config-id",
+        "input": {
+            "method": "GET",
+            "url": "https://api.github.com/user",
+            "auth_type": "token",
+            "auth_env_var": "SOME_UNKNOWN_TOKEN",
+        },
+    }
+
+    with (
+        patch("strands_tools.http_request.HTTP_REQUEST_TOKEN_CONFIG", {}),
+        patch("strands_tools.http_request.get_user_input") as mock_input,
+    ):
+        mock_input.return_value = "y"
+        result = http_request.http_request(tool=tool_use)
+
+    assert result["status"] == "error"
+    assert "STRANDS_HTTP_REQUEST_TOKEN_CONFIG" in result["content"][0]["text"]
 
 
 @responses.activate
@@ -439,27 +516,6 @@ def test_cancellation(monkeypatch):
             monkeypatch.setenv("BYPASS_TOOL_CONSENT", original_env)
         else:
             monkeypatch.delenv("BYPASS_TOOL_CONSENT", raising=False)
-
-
-@responses.activate
-def test_missing_env_var():
-    """Test error when environment variable doesn't exist."""
-    tool_use = {
-        "toolUseId": "test-missing-env-id",
-        "input": {
-            "method": "GET",
-            "url": "https://api.example.com/",
-            "auth_type": "Bearer",
-            "auth_env_var": "NON_EXISTENT_TOKEN",
-        },
-    }
-
-    with patch("strands_tools.http_request.get_user_input") as mock_input:
-        mock_input.return_value = "y"
-        result = http_request.http_request(tool=tool_use)
-
-    assert result["status"] == "error"
-    assert "Environment variable 'NON_EXISTENT_TOKEN' not found" in result["content"][0]["text"]
 
 
 def test_aws_sigv4_auth():


### PR DESCRIPTION
## Description

Replaces the unconstrained `auth_env_var` parameter in the `http_request` tool with a domain-scoped allowlist. This was originally added as a convenience — callers could pass an environment variable name (e.g. `GITHUB_TOKEN`) and the tool would resolve it at runtime — but the behavior is non-obvious and violates our tenet of "the obvious path is the happy path."

`auth_env_var` is still supported, but now requires the variable to be explicitly registered in `HTTP_REQUEST_TOKEN_CONFIG` with a list of permitted domains. Tokens are only injected when the request URL's hostname matches an entry in that list — exact match:

```python
from strands_tools.http_request import HTTP_REQUEST_TOKEN_CONFIG
HTTP_REQUEST_TOKEN_CONFIG["GITHUB_TOKEN"] = ["api.github.com"]
HTTP_REQUEST_TOKEN_CONFIG["GITLAB_TOKEN"] = ["gitlab.com"]
```

We considered a flat env-var allowlist (no domain scoping), but that doesn't map well to real usage: the right set of variables depends on the domain being called, so the config needs to be per-domain anyway. A static importable dict is the simplest shape for that.

For teams that want fully automatic token injection without any call-site configuration, [Hooks or Plugins](https://strandsagents.com/docs/user-guide/concepts/agents/hooks/) are the right abstraction — a `BeforeToolCallEvent` hook can intercept `http_request` calls and inject tokens based on any logic, with full visibility into what's happening and why.

## Related Issues

Internal tracking id: V2151924562

## Documentation PR

Not needed

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.