### PR TITLE
feat: make verify_ssl=False opt-in via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,12 @@ The Mem0 Memory Tool supports three different backend configurations:
 |----------------------|-------------|---------|
 | ENV_VARS_MASKED_DEFAULT | Default setting for masking sensitive values | true |
 
+#### HTTP Request Tool
+
+| Environment Variable | Description | Default |
+|----------------------|-------------|---------|
+| STRANDS_HTTP_ALLOW_INSECURE_SSL | Allow disabling SSL certificate verification via verify_ssl parameter | false |
+
 #### Dynamic MCP Client Tool
 
 | Environment Variable | Description | Default | 

--- a/src/strands_tools/http_request.py
+++ b/src/strands_tools/http_request.py
@@ -98,7 +98,7 @@ TOOL_SPEC = {
                 },
                 "verify_ssl": {
                     "type": "boolean",
-                    "description": "Whether to verify SSL certificates",
+                    "description": "Whether to verify SSL certificates. Disabling may be restricted.",
                 },
                 "cookie": {
                     "type": "string",
@@ -643,7 +643,17 @@ def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
         url = tool_input["url"]
         headers = process_auth_headers(tool_input.get("headers", {}), tool_input)
         body = tool_input.get("body")
-        verify = tool_input.get("verify_ssl", True)
+
+        # verify_ssl=False is opt-in via STRANDS_HTTP_ALLOW_INSECURE_SSL env var
+        verify_ssl_input = tool_input.get("verify_ssl", True)
+        if verify_ssl_input is False:
+            if os.environ.get("STRANDS_HTTP_ALLOW_INSECURE_SSL", "").lower() != "true":
+                raise ValueError(
+                    "SSL verification cannot be disabled unless the STRANDS_HTTP_ALLOW_INSECURE_SSL "
+                    "environment variable is set to 'true'."
+                )
+        verify = verify_ssl_input
+
         cookie = tool_input.get("cookie")
         cookie_jar = tool_input.get("cookie_jar")
 

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -605,21 +605,53 @@ def test_verify_ssl_option():
         },
     }
 
-    # Call http_request with verify_ssl=False
-    with patch("strands_tools.http_request.get_user_input") as mock_input:
-        mock_input.return_value = "y"
-        # Use a real request but don't actually send it over the network
-        with responses.RequestsMock() as rsps:
-            rsps.add(
-                responses.GET,
-                "https://example.com/api/insecure",
-                json={"status": "insecure"},
-                status=200,
-            )
-            result = http_request.http_request(tool=tool_use)
+    # Call http_request with verify_ssl=False (requires STRANDS_HTTP_ALLOW_INSECURE_SSL)
+    original_env = os.environ.copy()
+    os.environ["STRANDS_HTTP_ALLOW_INSECURE_SSL"] = "true"
+    try:
+        with patch("strands_tools.http_request.get_user_input") as mock_input:
+            mock_input.return_value = "y"
+            # Use a real request but don't actually send it over the network
+            with responses.RequestsMock() as rsps:
+                rsps.add(
+                    responses.GET,
+                    "https://example.com/api/insecure",
+                    json={"status": "insecure"},
+                    status=200,
+                )
+                result = http_request.http_request(tool=tool_use)
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)
 
     # Verify the result
     assert result["status"] == "success"
+
+
+def test_verify_ssl_blocked_without_env_var():
+    """Test that verify_ssl=False is blocked without STRANDS_HTTP_ALLOW_INSECURE_SSL."""
+    tool_use = {
+        "toolUseId": "test-ssl-blocked-id",
+        "input": {
+            "method": "GET",
+            "url": "https://example.com/api/insecure",
+            "verify_ssl": False,
+        },
+    }
+
+    # Ensure the env var is NOT set
+    original_env = os.environ.copy()
+    os.environ.pop("STRANDS_HTTP_ALLOW_INSECURE_SSL", None)
+    try:
+        with patch("strands_tools.http_request.get_user_input") as mock_input:
+            mock_input.return_value = "y"
+            result = http_request.http_request(tool=tool_use)
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)
+
+    assert result["status"] == "error"
+    assert "STRANDS_HTTP_ALLOW_INSECURE_SSL" in result["content"][0]["text"]
 
 
 @responses.activate


### PR DESCRIPTION
## Description

The `http_request` tool originally supported `verify_ssl=False` as a convenience for cases like internal environments with self-signed certificates. The problem is that it's very non-obvious behavior — an agent can silently disable SSL verification without any operator awareness or explicit opt-in, which is surprising for anyone reading or auditing the configuration. This violates our tenet of "the obvious path is the happy path": the easy thing to do should also be the safe thing to do.

This change makes `verify_ssl=False` opt-in at the environment level via `STRANDS_HTTP_ALLOW_INSECURE_SSL=true`. Without that env var set, passing `verify_ssl=False` returns an error. Operators who genuinely need to disable SSL verification can still do so by explicitly setting the env var, making the intent visible and deliberate.

## Related Issues

Internal tracking id: V2151924562

## Documentation PR

N/A

## Type of Change

Other

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [N/A] I have added an appropriate example to the documentation to outline the feature - not needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
