### PR TITLE
fix: add info-level logging when auth token is resolved from environment variable

### DIFF
--- a/src/strands_tools/http_request.py
+++ b/src/strands_tools/http_request.py
@@ -35,8 +35,6 @@ import time
 from typing import Any, Dict, Optional, Union
 from urllib.parse import urlparse
 
-logger = logging.getLogger(__name__)
-
 import markdownify
 import requests
 from aws_requests_auth.aws_auth import AWSRequestsAuth
@@ -54,6 +52,8 @@ from urllib3 import Retry
 
 from strands_tools.utils import console_util
 from strands_tools.utils.user_input import get_user_input
+
+logger = logging.getLogger(__name__)
 
 TOOL_SPEC = {
     "name": "http_request",
@@ -438,9 +438,7 @@ def process_auth_headers(headers: Dict[str, Any], tool_input: Dict[str, Any]) ->
 
         auth_token = os.environ.get(env_var_name)
         if not auth_token:
-            raise ValueError(
-                f"Environment variable '{env_var_name}' is not set or is empty."
-            )
+            raise ValueError(f"Environment variable '{env_var_name}' is not set or is empty.")
         logger.info(f"Resolved auth token from environment variable '{env_var_name}' for domain '{request_host}'")
 
     auth_type = tool_input.get("auth_type")


### PR DESCRIPTION
## Description

Adds `info`-level logging to `http_request` when an auth token is successfully resolved from an environment variable via `auth_env_var`. The log message includes the variable name and the target domain, making token resolution visible in standard log output.

`http_request` was the only tool in the repo without a module-level logger. This brings it in line with the rest of the codebase (`agent_graph`, `use_llm`, `elasticsearch_memory`, etc.).

### Why Info?

My thinking here was:

1.  You want to know when an env variable is being used as part of an http request
2.  But because you enabled the feature, it's *not* a warning or error
3.  Debug isn't generally enabled unless you have an issue, which means you wouldn't generally see it at that level, which defeats the purpose of point 1

## Related Issues

Follows on from #424.

## Documentation PR

Not needed

## Type of Change

Other: observability improvement

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [n/a] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
