### PR TITLE
docs: update repository guidelines for new tools policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
       value: |
         Thanks for suggesting a new feature for Strands Agents Tools!
 
-        > **Note:** Due to maintenance and scalability concerns, we are not accepting new tools into this repository. If you'd like to build a new tool, please use our [extension template](https://github.com/strands-agents/extension-template-python) and publish it as a standalone package. You can then get it featured in our [community catalog](https://strandsagents.com/docs/community/get-featured/).
+        > **Note:** We are not accepting new tools into this repository. If you'd like to build a new tool, we recommend using our [extension template](https://github.com/strands-agents/extension-template-python) to publish it as a standalone package. You can then get it featured in our [community catalog](https://strandsagents.com/docs/community/get-featured/).
         >
         > We still welcome feature requests for **improvements to existing tools**.
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,6 +8,10 @@ body:
     attributes:
       value: |
         Thanks for suggesting a new feature for Strands Agents Tools!
+
+        > **Note:** Due to maintenance and scalability concerns, we are not accepting new tools into this repository. If you'd like to build a new tool, please use our [extension template](https://github.com/strands-agents/extension-template-python) and publish it as a standalone package. You can then get it featured in our [community catalog](https://strandsagents.com/docs/community/get-featured/).
+        >
+        > We still welcome feature requests for **improvements to existing tools**.
   - type: textarea
     id: problem-statement
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,8 +14,9 @@
 
 <!-- Choose one of the following types of changes, delete the rest -->
 
+> Please note that due to maintenance and scalability concerns, we are not accepting new tools. To publish your own tool, use our [extension template](https://github.com/strands-agents/extension-template-python) and get featured in our [community catalog](https://strandsagents.com/docs/community/get-featured/).
+
 Bug fix
-New Tool
 Breaking change
 Documentation update
 Other (please describe):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 
 <!-- Choose one of the following types of changes, delete the rest -->
 
-> Please note that due to maintenance and scalability concerns, we are not accepting new tools. To publish your own tool, use our [extension template](https://github.com/strands-agents/extension-template-python) and get featured in our [community catalog](https://strandsagents.com/docs/community/get-featured/).
+> Please note that we are not accepting new tools into this repository. Instead, we recommend using our [extension template](https://github.com/strands-agents/extension-template-python) to publish your own tool package and get it featured in our [community catalog](https://strandsagents.com/docs/community/get-featured/).
 
 Bug fix
 Breaking change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,27 @@ Please read through this document before submitting any issues or pull requests 
 information to effectively respond to your bug report or contribution.
 
 
+## New Tools Policy
+
+Due to maintenance and scalability concerns, **we are not accepting new tools into this repository**. To avoid the Strands team being the bottleneck for new tool reviews and releases, we encourage contributors to publish new tools as standalone community packages.
+
+**What we accept:**
+- Bug fixes for existing tools
+- Documentation improvements
+- Performance enhancements to existing tools
+- Test coverage improvements
+
+**What we don't accept:**
+- New tool submissions (PRs adding new tools will be closed)
+- New tool feature requests (issues requesting new tools will be closed)
+
+**Want to build a tool?** You can use our [extension template](https://github.com/strands-agents/extension-template-python) to scaffold your own tool package and publish it to PyPI. Once published, you can get it featured in our docs and community catalog:
+
+- Extension template: https://github.com/strands-agents/extension-template-python
+- Get featured in docs: https://strandsagents.com/docs/community/get-featured/
+- Contribution guide: https://strandsagents.com/docs/contribute/
+
+
 ## Reporting Bugs/Feature Requests
 
 We welcome you to use the [Bug Reports](../../issues/new?template=bug_report.yml) file to report bugs or [Feature Requests](../../issues/new?template=feature_request.yml) to suggest features.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ information to effectively respond to your bug report or contribution.
 
 ## New Tools Policy
 
-Due to maintenance and scalability concerns, **we are not accepting new tools into this repository**. To avoid the Strands team being the bottleneck for new tool reviews and releases, we encourage contributors to publish new tools as standalone community packages.
+**We are not accepting new tools into this repository.** Instead, we recommend publishing new tools as standalone community packages — this way you own your release cycle and can iterate independently.
 
 **What we accept:**
 - Bug fixes for existing tools
@@ -21,7 +21,7 @@ Due to maintenance and scalability concerns, **we are not accepting new tools in
 - New tool submissions (PRs adding new tools will be closed)
 - New tool feature requests (issues requesting new tools will be closed)
 
-**Want to build a tool?** You can use our [extension template](https://github.com/strands-agents/extension-template-python) to scaffold your own tool package and publish it to PyPI. Once published, you can get it featured in our docs and community catalog:
+**Want to build a tool?** Use our [extension template](https://github.com/strands-agents/extension-template-python) to scaffold your own tool package and publish it to PyPI. Once published, you can get it featured in our docs and community catalog:
 
 - Extension template: https://github.com/strands-agents/extension-template-python
 - Get featured in docs: https://strandsagents.com/docs/community/get-featured/

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@
 </div>
 
 > [!IMPORTANT]
-> **Looking to add a new tool?** Due to maintenance and scalability concerns, we are not accepting new tools into this repository. Instead, we encourage you to publish your tool as a standalone community package. You can use our [extension template](https://github.com/strands-agents/extension-template-python) to get started and get featured in our [community catalog](https://strandsagents.com/docs/community/get-featured/).
+> **Looking to add a new tool?** We are not accepting new tools into this repository. Instead, we recommend publishing your tool as a standalone community package using our [extension template](https://github.com/strands-agents/extension-template-python). Once published, you can get it featured in our [community catalog](https://strandsagents.com/docs/community/get-featured/).
 >
-> We still welcome bug fixes, documentation improvements, and enhancements to existing tools. See our [contribution guide](https://strandsagents.com/docs/contribute/) for details.
+> We welcome bug fixes, documentation improvements, and enhancements to existing tools. See our [contribution guide](https://strandsagents.com/docs/contribute/) for details.
 
 Strands Agents Tools is a community-driven project that provides a powerful set of tools for your agents to use. It bridges the gap between large language models and practical applications by offering ready-to-use tools for file operations, system execution, API interactions, mathematical operations, and more.
 
@@ -1369,7 +1369,7 @@ We welcome contributions from everyone! Here's how you can help:
 - **Tests** that improve coverage
 
 > [!NOTE]
-> We are not accepting new tools into this repository. To publish your own tool, use our [extension template](https://github.com/strands-agents/extension-template-python) and get it listed in the [community catalog](https://strandsagents.com/docs/community/get-featured/).
+> We are not accepting new tools into this repository. Instead, we recommend using our [extension template](https://github.com/strands-agents/extension-template-python) to publish your own tool package and get it listed in the [community catalog](https://strandsagents.com/docs/community/get-featured/).
 
 See our [Contributing Guide](CONTRIBUTING.md) for development setup and pull request process, or visit the [contribution guide](https://strandsagents.com/docs/contribute/) for all the ways to contribute to the Strands ecosystem.
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,6 @@
   </p>
 </div>
 
-> [!IMPORTANT]
-> **Looking to add a new tool?** We are not accepting new tools into this repository. Instead, we recommend publishing your tool as a standalone community package using our [extension template](https://github.com/strands-agents/extension-template-python). Once published, you can get it featured in our [community catalog](https://strandsagents.com/docs/community/get-featured/).
->
-> We welcome bug fixes, documentation improvements, and enhancements to existing tools. See our [contribution guide](https://strandsagents.com/docs/contribute/) for details.
-
 Strands Agents Tools is a community-driven project that provides a powerful set of tools for your agents to use. It bridges the gap between large language models and practical applications by offering ready-to-use tools for file operations, system execution, API interactions, mathematical operations, and more.
 
 ## ✨ Features
@@ -1361,17 +1356,20 @@ The `graph` tool uses the same model provider environment variables as `use_agen
 
 ## Contributing ❤️
 
-We welcome contributions from everyone! Here's how you can help:
+This is a community-driven project, powered by passionate developers like you.
+We enthusiastically welcome contributions from everyone,
+regardless of experience level—your unique perspective is valuable to us!
 
-- **Bug fixes** for existing tools
-- **Documentation improvements**
-- **Performance enhancements** to existing tools
-- **Tests** that improve coverage
+### How to Get Started?
 
-> [!NOTE]
-> We are not accepting new tools into this repository. Instead, we recommend using our [extension template](https://github.com/strands-agents/extension-template-python) to publish your own tool package and get it listed in the [community catalog](https://strandsagents.com/docs/community/get-featured/).
+1. **Find your first opportunity**: If you're new to the project, explore our labeled "good first issues" for beginner-friendly tasks.
+2. **Understand our workflow**: Review our [Contributing Guide](CONTRIBUTING.md)  to learn about our development setup, coding standards, and pull request process.
+3. **Make your impact**: Contributions come in many forms—fixing bugs, enhancing documentation, improving performance, adding features, writing tests, or refining the user experience.
+4. **Submit your work**: When you're ready, submit a well-documented pull request, and our maintainers will provide feedback to help get your changes merged.
 
-See our [Contributing Guide](CONTRIBUTING.md) for development setup and pull request process, or visit the [contribution guide](https://strandsagents.com/docs/contribute/) for all the ways to contribute to the Strands ecosystem.
+Your questions, insights, and ideas are always welcome!
+
+Together, we're building something meaningful that impacts real users. We look forward to collaborating with you!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@
   </p>
 </div>
 
+> [!IMPORTANT]
+> **Looking to add a new tool?** Due to maintenance and scalability concerns, we are not accepting new tools into this repository. Instead, we encourage you to publish your tool as a standalone community package. You can use our [extension template](https://github.com/strands-agents/extension-template-python) to get started and get featured in our [community catalog](https://strandsagents.com/docs/community/get-featured/).
+>
+> We still welcome bug fixes, documentation improvements, and enhancements to existing tools. See our [contribution guide](https://strandsagents.com/docs/contribute/) for details.
+
 Strands Agents Tools is a community-driven project that provides a powerful set of tools for your agents to use. It bridges the gap between large language models and practical applications by offering ready-to-use tools for file operations, system execution, API interactions, mathematical operations, and more.
 
 ## ✨ Features
@@ -1356,20 +1361,17 @@ The `graph` tool uses the same model provider environment variables as `use_agen
 
 ## Contributing ❤️
 
-This is a community-driven project, powered by passionate developers like you.
-We enthusiastically welcome contributions from everyone,
-regardless of experience level—your unique perspective is valuable to us!
+We welcome contributions from everyone! Here's how you can help:
 
-### How to Get Started?
+- **Bug fixes** for existing tools
+- **Documentation improvements**
+- **Performance enhancements** to existing tools
+- **Tests** that improve coverage
 
-1. **Find your first opportunity**: If you're new to the project, explore our labeled "good first issues" for beginner-friendly tasks.
-2. **Understand our workflow**: Review our [Contributing Guide](CONTRIBUTING.md)  to learn about our development setup, coding standards, and pull request process.
-3. **Make your impact**: Contributions come in many forms—fixing bugs, enhancing documentation, improving performance, adding features, writing tests, or refining the user experience.
-4. **Submit your work**: When you're ready, submit a well-documented pull request, and our maintainers will provide feedback to help get your changes merged.
+> [!NOTE]
+> We are not accepting new tools into this repository. To publish your own tool, use our [extension template](https://github.com/strands-agents/extension-template-python) and get it listed in the [community catalog](https://strandsagents.com/docs/community/get-featured/).
 
-Your questions, insights, and ideas are always welcome!
-
-Together, we're building something meaningful that impacts real users. We look forward to collaborating with you!
+See our [Contributing Guide](CONTRIBUTING.md) for development setup and pull request process, or visit the [contribution guide](https://strandsagents.com/docs/contribute/) for all the ways to contribute to the Strands ecosystem.
 
 ## License
 


### PR DESCRIPTION
## Description

Updates repository guidelines to clearly communicate that we are not accepting new tools, and instead recommend contributors publish standalone community packages using the extension template.

## Related Issues

Closes #374

## Changes

### README.md
- Added prominent `[!IMPORTANT]` notice near the top directing contributors to publish community packages
- Updated the Contributing section to list what we accept (bug fixes, docs, perf improvements, tests) and link to the extension template and community catalog

### CONTRIBUTING.md
- Added **New Tools Policy** section explaining:
  - What we accept (bug fixes, docs, perf, tests)
  - What we don't accept (new tool PRs/issues)
  - Links to extension template, get-featured page, and contribution guide

### .github/PULL_REQUEST_TEMPLATE.md
- Added note about not accepting new tools with links to extension template and community catalog
- Removed "New Tool" from the type of change options

### .github/ISSUE_TEMPLATE/feature_request.yml
- Added note in the template header about new tools policy
- Clarified that we welcome feature requests for improvements to existing tools

## Type of Change

Documentation update

## Testing

- [x] Verified all links are correct and working
- [x] Verified markdown renders correctly

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings