### PR TITLE
fix: enable optional parameters in use_aws to prevent KeyError

### DIFF
--- a/src/strands_tools/use_aws.py
+++ b/src/strands_tools/use_aws.py
@@ -213,7 +213,6 @@ TOOL_SPEC = {
                 "region",
                 "service_name",
                 "operation_name",
-                "parameters",
                 "label",
             ],
         }
@@ -280,7 +279,7 @@ def use_aws(tool: ToolUse, **kwargs: Any) -> ToolResult:
 
     service_name = tool_input["service_name"]
     operation_name = tool_input["operation_name"]
-    parameters = tool_input["parameters"]
+    parameters = tool_input.get("parameters", {})
     region = tool_input.get("region", aws_region)
     label = tool_input.get("label", "AWS Operation Details")
 

--- a/tests/test_use_aws.py
+++ b/tests/test_use_aws.py
@@ -100,6 +100,24 @@ def test_use_aws_direct_success(mock_boto3_client, mock_available_services, mock
     assert "test-request-id" in result["content"][0]["text"]
 
 
+def test_use_aws_without_parameters(mock_boto3_client, mock_available_services, mock_available_operations):
+    """Test use_aws when parameters is not provided in the input."""
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {
+            "service_name": "s3",
+            "operation_name": "list_buckets",
+            "region": "us-west-2",
+            "label": "List S3 Buckets",
+        },
+    }
+
+    result = use_aws.use_aws(tool=tool_use)
+
+    assert result["toolUseId"] == "test-tool-use-id"
+    assert result["status"] == "success"
+
+
 def test_use_aws_invalid_service(mock_available_services, mock_available_operations):
     """Test use_aws with an invalid service name."""
     tool_use = {


### PR DESCRIPTION
## Description

Make `parameters` optional in the `use_aws` tool to prevent a `KeyError` when the LLM omits it.

   Some AWS operations like `list_buckets` don't require parameters. When using non-Bedrock models (e.g., OpenAI GPT-4o), the LLM often omits the `parameters` field entirely, causing a crash at `tool_input["parameters"]`.

 Changes:
   - Use `tool_input.get("parameters", {})` instead of `tool_input["parameters"]`
   - Remove `parameters` from the `required` list in `TOOL_SPEC`
   - Add unit test for calling `use_aws` without `parameters`

## Related Issues

Fixes #332

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
