### PR TITLE
fix(rss): prevent path traversal via unvalidated feed_id in get_feed_file_path

### DIFF
--- a/src/strands_tools/rss.py
+++ b/src/strands_tools/rss.py
@@ -34,7 +34,11 @@ class RSSManager:
         os.makedirs(self.storage_path, exist_ok=True)
 
     def get_feed_file_path(self, feed_id: str) -> str:
-        return os.path.join(self.storage_path, f"{feed_id}.json")
+        file_path = os.path.realpath(os.path.join(self.storage_path, f"{feed_id}.json"))
+        storage_real = os.path.realpath(self.storage_path)
+        if not file_path.startswith(storage_real + os.sep):
+            raise ValueError(f"Invalid feed_id: path traversal detected in '{feed_id}'")
+        return file_path
 
     def get_subscription_file_path(self) -> str:
         return os.path.join(self.storage_path, "subscriptions.json")

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1,6 +1,7 @@
 """Comprehensive tests for RSS feed tool with improved organization."""
 
 import json
+import os
 from unittest.mock import MagicMock, call, mock_open, patch
 
 import pytest
@@ -130,6 +131,28 @@ class TestRSSManager:
             entry_no_content = {"title": "Test Entry"}
             result = manager.format_entry(entry_no_content, include_content=True)
             assert result["content"] == "No content available"
+
+    @pytest.mark.parametrize(
+        "feed_id",
+        [
+            "../outside",
+            "../../etc/config",
+            "subdir/../../../escape",
+            "/absolute/path",
+        ],
+    )
+    def test_get_feed_file_path_rejects_traversal(self, feed_id):
+        """Test that path traversal sequences in feed_id are rejected."""
+        manager = RSSManager()
+        with pytest.raises(ValueError, match="path traversal detected"):
+            manager.get_feed_file_path(feed_id)
+
+    def test_get_feed_file_path_allows_valid_ids(self):
+        """Test that valid feed_ids are accepted."""
+        manager = RSSManager()
+        path = manager.get_feed_file_path("my_valid_feed")
+        assert path.endswith("my_valid_feed.json")
+        assert os.path.realpath(manager.storage_path) in path
 
     @pytest.mark.parametrize(
         "url,expected_id",


### PR DESCRIPTION
## Description

### What
Fix [CWE-22](https://www.cvedetails.com/cwe-details/22/Improper-Limitation-of-a-Pathname-to-a-Restricted-Directory-.html) path traversal vulnerability in the RSS tool's `get_feed_file_path()` method. 

The `feed_id` parameter was concatenated directly into a file path via `os.path.join(self.storage_path, f"{feed_id}.json")` without validation, allowing traversal sequences like `../` to read, write, or delete `.json` files outside the intended storage directory.                                                                                                                        
                                                                                                                                                                                                                                                 
### Fix 
- The fix resolves the constructed path with `os.path.realpath()` and verifies it remains within `storage_path` before returning. This covers all three affected operations (read via `load_feed_data`, write via `save_feed_data`, delete via `unsubscribe`'s `os.remove`) since they all go through `get_feed_file_path`. 

- Added parametrized tests for rejected traversal patterns and accepted valid IDs

## Related Issues
N/A

## Documentation PR

N/A

## Type of Change

Bug fix
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
