### PR TITLE
feat(exa): add highlights, max_age_hours, instant search type, and new categories

### DIFF
--- a/src/strands_tools/exa.py
+++ b/src/strands_tools/exa.py
@@ -9,6 +9,8 @@ Key Features:
 - Deep search for thorough, comprehensive results
 - Advanced content filtering and domain management
 - Full page content extraction with summaries
+- Highlights for token-efficient page excerpts
+- Content freshness control with max age hours
 - Support for general web search, company info, news, PDFs, GitHub repos, and more
 - Date range filtering and domain management
 - Live crawling with fallback options
@@ -109,6 +111,12 @@ def format_search_response(data: Dict[str, Any]) -> Panel:
             if summary:
                 content.append(f"Summary: {summary}")
 
+            highlights_list = result.get("highlights", [])
+            if highlights_list:
+                content.append("Highlights:")
+                for highlight in highlights_list:
+                    content.append(f"  \u2022 {highlight.strip()}")
+
             # Add full text content (length controlled by API maxCharacters parameter)
             if text:
                 content.append(f"Content: {text.strip()}")
@@ -160,6 +168,12 @@ def format_contents_response(data: Dict[str, Any]) -> Panel:
             if summary:
                 content.append(f"Summary: {summary}")
 
+            highlights_list = result.get("highlights", [])
+            if highlights_list:
+                content.append("Highlights:")
+                for highlight in highlights_list:
+                    content.append(f"  \u2022 {highlight.strip()}")
+
             if subpages:
                 content.append(f"Subpages: {len(subpages)} found")
 
@@ -192,9 +206,19 @@ def format_contents_response(data: Dict[str, Any]) -> Panel:
 @tool
 async def exa_search(
     query: str,
-    type: Optional[Literal["auto", "fast", "deep"]] = "auto",
+    type: Optional[Literal["auto", "instant", "fast", "deep"]] = "auto",
     category: Optional[
-        Literal["company", "news", "pdf", "github", "personal site", "linkedin profile", "financial report"]
+        Literal[
+            "company",
+            "research paper",
+            "news",
+            "pdf",
+            "github",
+            "personal site",
+            "linkedin profile",
+            "people",
+            "financial report",
+        ]
     ] = None,
     user_location: Optional[str] = None,
     num_results: Optional[int] = None,
@@ -210,9 +234,11 @@ async def exa_search(
     moderation: Optional[bool] = None,
     # Contents options
     text: Optional[Union[bool, Dict[str, Any]]] = None,
+    highlights: Optional[Union[bool, Dict[str, Any]]] = None,
     summary: Optional[Dict[str, Any]] = None,
     livecrawl: Optional[Literal["never", "fallback", "always", "preferred"]] = None,
     livecrawl_timeout: Optional[int] = None,
+    max_age_hours: Optional[int] = None,
     subpages: Optional[int] = None,
     subpage_target: Optional[Union[str, List[str]]] = None,
     extras: Optional[Dict[str, Any]] = None,
@@ -232,22 +258,25 @@ async def exa_search(
 
     Search Types:
     - auto: Intelligently selects the best search approach (recommended default)
+    - instant: Lowest latency search for real-time applications
     - fast: Optimized for speed
     - deep: Thorough search for comprehensive results
 
     Categories (optional - general web search works best):
     - company: Focus on company websites and information when specifically needed
+    - research paper: Academic and research papers
     - news: News articles and journalism
     - pdf: PDF documents
     - github: GitHub repositories and code
     - personal site: Personal websites and blogs
     - linkedin profile: LinkedIn profiles
+    - people: People search (LinkedIn profiles)
     - financial report: Financial and earnings reports
 
     Args:
         query: The search query string. Examples: "Latest developments in artificial intelligence",
             "Best project management tools"
-        type: Search type - "auto" (default, recommended), "fast", or "deep"
+        type: Search type - "auto" (default, recommended), "instant", "fast", or "deep"
         category: Optional data category - use sparingly as general search works best.
             Use "company" when specifically looking for company information
         user_location: Two-letter ISO country code (e.g., "US", "UK") for geo-localized results
@@ -264,9 +293,13 @@ async def exa_search(
         moderation: Enable content moderation to filter unsafe content
         text: Include full page text - True/False or object with maxCharacters and includeHtmlTags.
             Use maxCharacters to control text length instead of relying on default limits
+        highlights: Token-efficient page excerpts - True/False or object with maxCharacters
+            and optional query for guiding highlight extraction
         summary: Generate summaries - object with query and optional schema for structured output
         livecrawl: Live crawling options - "never", "fallback", "always", "preferred"
         livecrawl_timeout: Timeout for live crawling in milliseconds (default 10000)
+        max_age_hours: Maximum age of cached content in hours before livecrawling.
+            0 = always livecrawl, -1 = never livecrawl (cache only)
         subpages: Number of subpages to crawl from each result
         subpage_target: Keywords to find specific subpages (string or array)
         extras: Additional options - object with links (int) and imageLinks (int)
@@ -304,6 +337,13 @@ async def exa_search(
         category="news",
         start_published_date="2024-01-01T00:00:00.000Z",
         text=True
+    )
+
+    # Search with highlights and content freshness
+    result = await exa_search(
+        query="AI safety research advances",
+        highlights={"maxCharacters": 4000},
+        max_age_hours=24,
     )
     """
     try:
@@ -374,12 +414,16 @@ async def exa_search(
         contents = {}
         if text is not None:
             contents["text"] = text
+        if highlights is not None:
+            contents["highlights"] = highlights
         if summary is not None:
             contents["summary"] = summary
         if livecrawl is not None:
             contents["livecrawl"] = livecrawl
         if livecrawl_timeout is not None:
             contents["livecrawlTimeout"] = livecrawl_timeout
+        if max_age_hours is not None:
+            contents["maxAgeHours"] = max_age_hours
         if subpages is not None:
             contents["subpages"] = subpages
         if subpage_target is not None:
@@ -427,9 +471,11 @@ async def exa_search(
 async def exa_get_contents(
     urls: List[str],
     text: Optional[Union[bool, Dict[str, Any]]] = None,
+    highlights: Optional[Union[bool, Dict[str, Any]]] = None,
     summary: Optional[Dict[str, Any]] = None,
     livecrawl: Optional[Literal["never", "fallback", "always", "preferred"]] = None,
     livecrawl_timeout: Optional[int] = None,
+    max_age_hours: Optional[int] = None,
     subpages: Optional[int] = None,
     subpage_target: Optional[Union[str, List[str]]] = None,
     extras: Optional[Dict[str, Any]] = None,
@@ -451,6 +497,7 @@ async def exa_get_contents(
 
     Content Options:
     - Text: Full page content with optional HTML tags and character limits
+    - Highlights: Token-efficient page excerpts
     - Summary: AI-generated summaries with optional structured schemas
     - Subpages: Crawl and extract content from related pages
     - Extras: Additional links and images from pages
@@ -461,6 +508,8 @@ async def exa_get_contents(
             - True: Extract full text with default settings
             - False: Disable text extraction
             - Object: Advanced options with maxCharacters (controls text length) and includeHtmlTags
+        highlights: Token-efficient page excerpts - True/False or object with maxCharacters
+            and optional query for guiding highlight extraction
         summary: Summary generation options:
             - query: Custom query for summary generation
             - schema: JSON schema for structured summary output
@@ -470,6 +519,8 @@ async def exa_get_contents(
             - "always": Always perform live crawl
             - "preferred": Try live crawl, fall back to cache if it fails
         livecrawl_timeout: Timeout for live crawling in milliseconds (default 10000)
+        max_age_hours: Maximum age of cached content in hours before livecrawling.
+            0 = always livecrawl, -1 = never livecrawl (cache only)
         subpages: Number of subpages to crawl from each URL
         subpage_target: Keywords to find specific subpages (string or list)
         extras: Extra content options:
@@ -525,9 +576,11 @@ async def exa_get_contents(
         payload = {
             "urls": urls,
             "text": text,
+            "highlights": highlights,
             "summary": summary,
             "livecrawl": livecrawl,
             "livecrawlTimeout": livecrawl_timeout,
+            "maxAgeHours": max_age_hours,
             "subpages": subpages,
             "subpageTarget": subpage_target,
             "extras": extras,

--- a/src/strands_tools/exa.py
+++ b/src/strands_tools/exa.py
@@ -435,7 +435,11 @@ async def exa_search(
             payload["contents"] = contents
 
         # Make API request
-        headers = {"x-api-key": api_key, "Content-Type": "application/json"}
+        headers = {
+            "x-api-key": api_key,
+            "Content-Type": "application/json",
+            "x-exa-integration": "aws-strands-agent",
+        }
         url = f"{EXA_API_BASE_URL}{EXA_SEARCH_ENDPOINT}"
 
         # Remove None values
@@ -588,7 +592,11 @@ async def exa_get_contents(
         }
 
         # Make API request
-        headers = {"x-api-key": api_key, "Content-Type": "application/json"}
+        headers = {
+            "x-api-key": api_key,
+            "Content-Type": "application/json",
+            "x-exa-integration": "aws-strands-agent",
+        }
         url = f"{EXA_API_BASE_URL}{EXA_CONTENTS_ENDPOINT}"
 
         # Remove None values

--- a/tests/test_exa.py
+++ b/tests/test_exa.py
@@ -30,6 +30,11 @@ def mock_aiohttp_response():
                 "favicon": "https://arxiv.org/favicon.ico",
                 "text": "Abstract Large Language Models (LLMs) have recently demonstrated remarkable capabilities...",
                 "summary": "This overview paper on Large Language Models (LLMs) highlights key developments...",
+                "highlights": [
+                    "Large Language Models (LLMs) have recently demonstrated remarkable capabilities",
+                    "This survey provides a comprehensive overview of recent advances in LLMs",
+                ],
+                "highlightScores": [0.95, 0.88],
             }
         ],
         "context": "Formatted context string...",
@@ -66,6 +71,11 @@ def mock_contents_response():
                 "id": "https://arxiv.org/abs/2307.06435",
                 "text": "Abstract Large Language Models (LLMs) have recently demonstrated remarkable capabilities...",
                 "summary": "This overview paper on Large Language Models (LLMs) highlights key developments...",
+                "highlights": [
+                    "Large Language Models (LLMs) have recently demonstrated remarkable capabilities",
+                    "This survey provides a comprehensive overview of recent advances in LLMs",
+                ],
+                "highlightScores": [0.95, 0.88],
             }
         ],
         "context": "Formatted context string...",
@@ -290,6 +300,57 @@ def test_format_contents_response():
     assert panel.title == "[bold blue]Exa Contents Results"
     assert "test-request-456" in panel.renderable
     assert "Successfully retrieved: 1 URLs" in panel.renderable
+
+
+def test_format_search_response_with_highlights():
+    """Test format_search_response renders highlights."""
+    data = {
+        "requestId": "test-hl-search",
+        "searchType": "auto",
+        "resolvedSearchType": "auto",
+        "results": [
+            {
+                "title": "Highlights Test",
+                "url": "https://example.com",
+                "author": "Author",
+                "publishedDate": "2024-01-01",
+                "highlights": [
+                    "First key excerpt from the page",
+                    "Second key excerpt from the page",
+                ],
+            }
+        ],
+        "costDollars": {"total": 0.005},
+    }
+
+    panel = exa.format_search_response(data)
+    rendered = panel.renderable
+    assert "Highlights:" in rendered
+    assert "First key excerpt from the page" in rendered
+    assert "Second key excerpt from the page" in rendered
+
+
+def test_format_contents_response_with_highlights():
+    """Test format_contents_response renders highlights."""
+    data = {
+        "requestId": "test-hl-contents",
+        "results": [
+            {
+                "title": "Highlights Test",
+                "url": "https://example.com",
+                "highlights": [
+                    "Key excerpt from contents",
+                ],
+            }
+        ],
+        "statuses": [{"id": "https://example.com", "status": "success", "error": None}],
+        "costDollars": {"total": 0.001},
+    }
+
+    panel = exa.format_contents_response(data)
+    rendered = panel.renderable
+    assert "Highlights:" in rendered
+    assert "Key excerpt from contents" in rendered
 
 
 def test_format_contents_response_with_errors():

--- a/tests/test_exa.py
+++ b/tests/test_exa.py
@@ -11,6 +11,19 @@ import pytest
 from strands_tools import exa
 
 
+class AsyncContextManager:
+    """Helper to wrap a value as an async context manager for mocking aiohttp."""
+
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *args):
+        pass
+
+
 @pytest.fixture
 def mock_aiohttp_response():
     """Create a mock aiohttp response for search."""
@@ -351,6 +364,108 @@ def test_format_contents_response_with_highlights():
     rendered = panel.renderable
     assert "Highlights:" in rendered
     assert "Key excerpt from contents" in rendered
+
+
+def _make_mock_session(captured, response_data):
+    """Build a mock aiohttp session that captures the payload and headers from post() calls."""
+    mock_resp = AsyncMock()
+    mock_resp.json.return_value = response_data
+
+    mock_post_ctx = AsyncMock()
+    mock_post_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_post_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    def fake_post(url, json=None, headers=None):
+        captured["url"] = url
+        captured["payload"] = json
+        captured["headers"] = headers
+        return mock_post_ctx
+
+    mock_session = AsyncMock()
+    mock_session.post = fake_post
+
+    mock_session_ctx = AsyncMock()
+    mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+    return mock_session_ctx
+
+
+SEARCH_RESPONSE = {
+    "requestId": "test",
+    "searchType": "auto",
+    "resolvedSearchType": "auto",
+    "results": [],
+    "costDollars": {"total": 0},
+}
+
+CONTENTS_RESPONSE = {
+    "requestId": "test",
+    "results": [],
+    "statuses": [],
+    "costDollars": {"total": 0},
+}
+
+
+def test_exa_search_payload_wires_highlights_and_max_age_hours():
+    """Test that exa_search correctly wires highlights and maxAgeHours into the contents dict."""
+    captured = {}
+    mock_session_ctx = _make_mock_session(captured, SEARCH_RESPONSE)
+
+    with (
+        patch.dict(os.environ, {"EXA_API_KEY": "test-key"}),
+        patch("aiohttp.ClientSession", return_value=mock_session_ctx),
+    ):
+        asyncio.run(exa.exa_search(query="test", highlights=True, max_age_hours=24))
+
+    contents = captured["payload"]["contents"]
+    assert contents["highlights"] is True
+    assert contents["maxAgeHours"] == 24
+
+
+def test_exa_search_payload_wires_highlights_dict():
+    """Test that exa_search passes a highlights dict through to the contents dict."""
+    captured = {}
+    mock_session_ctx = _make_mock_session(captured, SEARCH_RESPONSE)
+
+    with (
+        patch.dict(os.environ, {"EXA_API_KEY": "test-key"}),
+        patch("aiohttp.ClientSession", return_value=mock_session_ctx),
+    ):
+        asyncio.run(exa.exa_search(query="test", highlights={"maxCharacters": 4000}))
+
+    contents = captured["payload"]["contents"]
+    assert contents["highlights"] == {"maxCharacters": 4000}
+
+
+def test_exa_get_contents_payload_wires_highlights_and_max_age_hours():
+    """Test that exa_get_contents correctly wires highlights and maxAgeHours into the flat payload."""
+    captured = {}
+    mock_session_ctx = _make_mock_session(captured, CONTENTS_RESPONSE)
+
+    with (
+        patch.dict(os.environ, {"EXA_API_KEY": "test-key"}),
+        patch("aiohttp.ClientSession", return_value=mock_session_ctx),
+    ):
+        asyncio.run(exa.exa_get_contents(urls=["https://example.com"], highlights=True, max_age_hours=48))
+
+    payload = captured["payload"]
+    assert payload["highlights"] is True
+    assert payload["maxAgeHours"] == 48
+    assert "contents" not in payload
+
+
+def test_exa_search_payload_includes_integration_header():
+    """Test that exa_search sends the x-exa-integration header."""
+    captured = {}
+    mock_session_ctx = _make_mock_session(captured, SEARCH_RESPONSE)
+
+    with (
+        patch.dict(os.environ, {"EXA_API_KEY": "test-key"}),
+        patch("aiohttp.ClientSession", return_value=mock_session_ctx),
+    ):
+        asyncio.run(exa.exa_search(query="test"))
+
+    assert captured["headers"]["x-exa-integration"] == "aws-strands-agent"
 
 
 def test_format_contents_response_with_errors():


### PR DESCRIPTION
adds support for:
- **highlights** param on both `exa_search` and `exa_get_contents` — token-efficient page excerpts (bool or dict with maxCharacters/query)
- **max_age_hours** param — content freshness control (0=always livecrawl, -1=cache only, N=livecrawl if older than N hours). old livecrawl enum kept for backward compat
- **instant** search type — lowest latency option alongside auto/fast/deep
- **research paper** and **people** categories

also:
- renders highlights in both `format_search_response` and `format_contents_response`
- adds highlights to test fixtures and 2 new highlight rendering tests
- all pre-commit hooks pass (format, lint, type-lint, tests)