### PR TITLE
fix(browser): set event loop on calling thread before nest_asyncio.apply

### DIFF
--- a/src/strands_tools/browser/browser.py
+++ b/src/strands_tools/browser/browser.py
@@ -938,6 +938,8 @@ class Browser(ABC):
     def _execute_async(self, action_coro) -> Any:
         # Apply nest_asyncio if not already applied
         if not self._nest_asyncio_applied:
+            # Ensure the event loop is correctly referenced on the active thread.
+            asyncio.set_event_loop(self._loop)
             nest_asyncio.apply()
             self._nest_asyncio_applied = True
 

--- a/tests/browser/test_browser.py
+++ b/tests/browser/test_browser.py
@@ -2,6 +2,8 @@
 Unit tests for the Browser base class using MockBrowser.
 """
 
+import asyncio
+import concurrent.futures
 from unittest.mock import AsyncMock, Mock, patch
 
 from playwright.async_api import Browser as PlaywrightBrowser
@@ -81,3 +83,21 @@ def test_browser_tool_integration(mock_async_playwright):
     tool_func = browser.browser
     assert hasattr(tool_func, "__name__")
     assert tool_func.__name__ == "browser"
+
+
+def test_execute_async_works_from_foreign_thread():
+    """_execute_async must work when called from a thread other than the one that ran __init__.
+
+    The strands SDK dispatches sync tools via asyncio.to_thread, which runs the tool
+    on a worker thread. Without setting the event loop on that thread,
+    nest_asyncio.apply() fails with 'There is no current event loop in thread'.
+    """
+    browser = MockBrowser()
+
+    async def dummy():
+        return "ok"
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        result = pool.submit(browser._execute_async, dummy()).result(timeout=5)
+
+    assert result == "ok"


### PR DESCRIPTION
## Description

Fix a bug in the browser tool that causes it to fail when invoked async. See issue for more information. 

The solution is to verify that the event loop is set on the thread that executes the browser tool so that it doesn't matter what thread executes the tool. 

## Related Issues

[<!-- Link to related issues using #issue-number format -->](https://github.com/strands-agents/tools/issues/453)

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

- Added a unit test to simulate the scenario. 
- Patched the import in agent code using browser, and confirmed it works e2e. 

patch code used:
```

loop = browser_instance._loop
original = browser_instance._execute_async

def _patched(coro):
   asyncio.set_event_loop(loop)
   return original(coro)
 
browser_instance._execute_async = _patched
```

which is effectively the underlying implementation. 

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
