### PR TITLE
fix: pass _default_context_options into new_context

### DIFF
--- a/src/strands_tools/browser/browser.py
+++ b/src/strands_tools/browser/browser.py
@@ -60,6 +60,12 @@ class Browser(ABC):
         asyncio.set_event_loop(self._loop)
         self._nest_asyncio_applied = False
         self._sessions: Dict[str, BrowserSession] = {}
+        # Subclasses may populate this (e.g. LocalChromiumBrowser does
+        # from its context_options constructor arg). It is unpacked into
+        # every new browser context created by _setup_session_from_browser
+        # so things like viewport, user_agent, storage_state, locale etc.
+        # round-trip through the public API. See strands-agents/tools#414.
+        self._default_context_options: Dict[str, Any] = {}
 
     @tool
     def browser(self, browser_input: BrowserInput) -> Dict[str, Any]:
@@ -236,9 +242,13 @@ class Browser(ABC):
             Tuple of (browser, context, page)
         """
         if isinstance(browser_or_context, PlaywrightBrowser):
-            # Normal non-persistent case
+            # Normal non-persistent case. Pass through the configured
+            # context options (viewport, user_agent, storage_state,
+            # locale, timezone, permissions, ...) so values supplied
+            # to the browser subclass's constructor actually take
+            # effect. See strands-agents/tools#414.
             session_browser = browser_or_context
-            session_context = await session_browser.new_context()
+            session_context = await session_browser.new_context(**self._default_context_options)
             session_page = await session_context.new_page()
         else:
             # Persistent context case


### PR DESCRIPTION
Fixes #414.

## Problem

`LocalChromiumBrowser` accepts a `context_options` kwarg in its constructor, merges it into `self._default_context_options`, and stores it correctly. But the base class `Browser._setup_session_from_browser` ignores the dict and calls `new_context()` with no arguments:

```python
if isinstance(browser_or_context, PlaywrightBrowser):
    session_browser = browser_or_context
    session_context = await session_browser.new_context()   # ← drops options
    session_page = await session_context.new_page()
```

Result: `viewport`, `user_agent`, `storage_state`, `locale`, `timezone_id`, `geolocation`, `permissions`, `color_scheme`, …all silently ignored. The reporter's proof script shows `viewport = 1280x720` (Playwright default) instead of the requested `1920x1080`.

Particularly impactful for `storage_state`, the standard Playwright mechanism for reusing authentication across browser contexts. There is no public-API workaround; users today have to subclass and override `_setup_session_from_browser`.

## Fix

- Initialize `_default_context_options: Dict[str, Any] = {}` on the base `Browser.__init__` (empty default → no behaviour change for subclasses that don't populate it).
- Pass `**self._default_context_options` into `session_browser.new_context(...)` in the non-persistent branch of `_setup_session_from_browser`.

`LocalChromiumBrowser` already populates the dict during `start_platform()`, so users who passed `context_options` to its constructor now actually see those options applied.

## Back-compat

- The persistent-context branch is untouched (it receives an already-constructed context from the caller).
- Subclasses that don't set `_default_context_options` get the empty-dict default, so `new_context(**{})` is a no-op equivalent to today's `new_context()`.

Signed off per DCO.
