### PR TITLE
fix(code-interpreter): add blob support to write_files for binary file uploads

### DIFF
--- a/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
+++ b/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
@@ -3,7 +3,9 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
-from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter as BedrockAgentCoreCodeInterpreterClient
+from bedrock_agentcore.tools.code_interpreter_client import (
+    CodeInterpreter as BedrockAgentCoreCodeInterpreterClient,
+)
 
 from ..utils.aws_util import resolve_region
 from .code_interpreter import CodeInterpreter
@@ -252,7 +254,10 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
 
         # Check if session already exists in instance cache
         if session_name in self._sessions:
-            return {"status": "error", "content": [{"text": f"Session '{session_name}' already exists"}]}
+            return {
+                "status": "error",
+                "content": [{"text": f"Session '{session_name}' already exists"}],
+            }
 
         # Check if session name already in use (module-level cache)
         if session_name in _session_mapping:
@@ -322,7 +327,14 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
 
         return {
             "status": "success",
-            "content": [{"json": {"sessions": sessions_info, "totalSessions": len(sessions_info)}}],
+            "content": [
+                {
+                    "json": {
+                        "sessions": sessions_info,
+                        "totalSessions": len(sessions_info),
+                    }
+                }
+            ],
         }
 
     def _ensure_session(self, session_name: Optional[str]) -> tuple[str, Optional[Dict[str, Any]]]:
@@ -371,7 +383,9 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
                     client.session_id = aws_session_id
 
                     self._sessions[target_session] = SessionInfo(
-                        session_id=aws_session_id, description="Reconnected via module cache", client=client
+                        session_id=aws_session_id,
+                        description="Reconnected via module cache",
+                        client=client,
                     )
 
                     logger.info(f"Reconnected to existing session: {target_session}")
@@ -392,7 +406,9 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
             logger.info(f"Auto-creating session: {target_session}")
 
             init_action = InitSessionAction(
-                type="initSession", session_name=target_session, description="Auto-initialized session"
+                type="initSession",
+                session_name=target_session,
+                description="Auto-initialized session",
             )
             result = self.init_session(init_action)
 
@@ -414,7 +430,11 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
 
         logger.debug(f"Executing {action.language} code in session '{session_name}'")
 
-        params = {"code": action.code, "language": action.language.value, "clearContext": action.clear_context}
+        params = {
+            "code": action.code,
+            "language": action.language.value,
+            "clearContext": action.clear_context,
+        }
         response = self._sessions[session_name].client.invoke("executeCode", params)
 
         return self._create_tool_result(response)
@@ -479,7 +499,12 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
 
         logger.debug(f"Writing {len(action.content)} files to session '{session_name}'")
 
-        content_dicts = [{"path": fc.path, "text": fc.text} for fc in action.content]
+        content_dicts = []
+        for fc in action.content:
+            if fc.blob is not None:
+                content_dicts.append({"path": fc.path, "blob": fc.blob})
+            else:
+                content_dicts.append({"path": fc.path, "text": fc.text})
         params = {"content": content_dicts}
         response = self._sessions[session_name].client.invoke("writeFiles", params)
 
@@ -498,7 +523,10 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
                         "content": [{"text": str(result.get("content"))}],
                     }
 
-            return {"status": "error", "content": [{"text": f"Failed to create tool result: {str(response)}"}]}
+            return {
+                "status": "error",
+                "content": [{"text": f"Failed to create tool result: {str(response)}"}],
+            }
 
         return response
 

--- a/src/strands_tools/code_interpreter/models.py
+++ b/src/strands_tools/code_interpreter/models.py
@@ -8,7 +8,7 @@ with discriminated unions, ensuring required fields are present for each action 
 from enum import Enum
 from typing import List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class LanguageType(str, Enum):
@@ -24,7 +24,22 @@ class FileContent(BaseModel):
     updating files during code execution sessions."""
 
     path: str = Field(description="The file path where content should be written")
-    text: str = Field(description="Text content for the file")
+    text: Optional[str] = Field(
+        default=None,
+        description="Text content for the file",
+    )
+    blob: Optional[str] = Field(
+        default=None,
+        description="Base64-encoded binary content for the file",
+    )
+
+    @model_validator(mode="after")
+    def validate_content(self) -> "FileContent":
+        if self.text is None and self.blob is None:
+            raise ValueError("Either text or blob must be provided")
+        if self.text is not None and self.blob is not None:
+            raise ValueError("Only one of text or blob may be provided")
+        return self
 
 
 # Action-specific Pydantic models using discriminated unions
@@ -36,13 +51,15 @@ class InitSessionAction(BaseModel):
     type: Literal["initSession"] = Field(description="Initialize a new code interpreter session")
     description: str = Field(description="Required description of what this session will be used for")
     session_name: Optional[str] = Field(
-        default=None, description="Session name. If not provided, a default session will be used."
+        default=None,
+        description="Session name. If not provided, a default session will be used.",
     )
 
 
 class ListLocalSessionsAction(BaseModel):
     """View all active code interpreter sessions managed by this tool instance. Use this to see what sessions are
-    available, check their status, or find the session name you need for other operations."""
+    available, check their status, or find the session name you need for other operations.
+    """
 
     type: Literal["listLocalSessions"] = Field(description="List all local sessions managed by this tool instance")
 
@@ -60,18 +77,26 @@ class ExecuteCodeAction(BaseModel):
     )
 
     code: str = Field(description="Required code to execute")
-    language: LanguageType = Field(default=LanguageType.PYTHON, description="Programming language for code execution")
-    clear_context: bool = Field(default=False, description="Whether to clear the execution context before running code")
+    language: LanguageType = Field(
+        default=LanguageType.PYTHON,
+        description="Programming language for code execution",
+    )
+    clear_context: bool = Field(
+        default=False,
+        description="Whether to clear the execution context before running code",
+    )
 
 
 class ExecuteCommandAction(BaseModel):
     """Execute shell/terminal commands within the sandbox environment. Use this for system operations like installing
-    packages, running scripts, file management, or any command-line tasks that need to be performed in the session."""
+    packages, running scripts, file management, or any command-line tasks that need to be performed in the session.
+    """
 
     type: Literal["executeCommand"] = Field(description="Execute a shell command in the code interpreter")
 
     session_name: Optional[str] = Field(
-        default=None, description="Session name. If not provided, uses the default session."
+        default=None,
+        description="Session name. If not provided, uses the default session.",
     )
 
     command: str = Field(description="Required shell command to execute")
@@ -79,12 +104,14 @@ class ExecuteCommandAction(BaseModel):
 
 class ReadFilesAction(BaseModel):
     """Read the contents of one or more files from the sandbox file system. Use this to examine data files,
-    configuration files, code files, or any other files that have been created or uploaded to the session."""
+    configuration files, code files, or any other files that have been created or uploaded to the session.
+    """
 
     type: Literal["readFiles"] = Field(description="Read files from the code interpreter")
 
     session_name: Optional[str] = Field(
-        default=None, description="Session name. If not provided, uses the default session."
+        default=None,
+        description="Session name. If not provided, uses the default session.",
     )
 
     paths: List[str] = Field(description="List of file paths to read")
@@ -92,25 +119,32 @@ class ReadFilesAction(BaseModel):
 
 class ListFilesAction(BaseModel):
     """Browse and list files and directories within the sandbox file system. Use this to explore the directory
-    structure, find files, or understand what's available in the session before reading or manipulating files."""
+    structure, find files, or understand what's available in the session before reading or manipulating files.
+    """
 
     type: Literal["listFiles"] = Field(description="List files in a directory")
 
     session_name: Optional[str] = Field(
-        default=None, description="Session name. If not provided, uses the default session."
+        default=None,
+        description="Session name. If not provided, uses the default session.",
     )
 
-    path: str = Field(default=".", description="Directory path to list (defaults to current directory)")
+    path: str = Field(
+        default=".",
+        description="Directory path to list (defaults to current directory)",
+    )
 
 
 class RemoveFilesAction(BaseModel):
     """Delete one or more files from the sandbox file system. Use this to clean up temporary files, remove outdated
-    data, or manage storage space within the session. Be careful as this permanently removes files."""
+    data, or manage storage space within the session. Be careful as this permanently removes files.
+    """
 
     type: Literal["removeFiles"] = Field(description="Remove files from the code interpreter")
 
     session_name: Optional[str] = Field(
-        default=None, description="Session name. If not provided, uses the default session."
+        default=None,
+        description="Session name. If not provided, uses the default session.",
     )
 
     paths: List[str] = Field(description="Required list of file paths to remove")
@@ -118,12 +152,14 @@ class RemoveFilesAction(BaseModel):
 
 class WriteFilesAction(BaseModel):
     """Create or update multiple files in the sandbox file system with specified content. Use this to save data,
-    create configuration files, write code files, or store any text-based content that your code execution will need."""
+    create configuration files, write code files, or store any text-based content that your code execution will need.
+    """
 
     type: Literal["writeFiles"] = Field(description="Write files to the code interpreter")
 
     session_name: Optional[str] = Field(
-        default=None, description="Session name. If not provided, uses the default session."
+        default=None,
+        description="Session name. If not provided, uses the default session.",
     )
 
     content: List[FileContent] = Field(description="Required list of file content to write")

--- a/tests/code_interpreter/test_agent_core_code_interpreter.py
+++ b/tests/code_interpreter/test_agent_core_code_interpreter.py
@@ -38,7 +38,10 @@ def mock_client():
     client.start.return_value = None
     client.stop.return_value = None
     client.get_session.return_value = {"status": "READY"}
-    client.invoke.return_value = {"stream": [{"result": {"content": "Mock response"}}], "isError": False}
+    client.invoke.return_value = {
+        "stream": [{"result": {"content": "Mock response"}}],
+        "isError": False,
+    }
     return client
 
 
@@ -174,7 +177,10 @@ def test_ensure_session_module_cache_session_not_ready():
             interpreter = AgentCoreCodeInterpreter(region="us-west-2", persist_sessions=True, auto_create=True)
 
             with patch.object(interpreter, "init_session") as mock_init:
-                mock_init.return_value = {"status": "success", "content": [{"text": "Created"}]}
+                mock_init.return_value = {
+                    "status": "success",
+                    "content": [{"text": "Created"}],
+                }
 
                 session_name, error = interpreter._ensure_session("stale-session")
 
@@ -205,7 +211,10 @@ def test_ensure_session_module_cache_get_session_fails():
             interpreter = AgentCoreCodeInterpreter(region="us-west-2", persist_sessions=True, auto_create=True)
 
             with patch.object(interpreter, "init_session") as mock_init:
-                mock_init.return_value = {"status": "success", "content": [{"text": "Created"}]}
+                mock_init.return_value = {
+                    "status": "success",
+                    "content": [{"text": "Created"}],
+                }
 
                 session_name, error = interpreter._ensure_session("missing-session")
 
@@ -373,7 +382,11 @@ def test_cleanup_platform_with_persist_sessions_false(mock_client):
 
         interpreter._started = True
 
-        session_info = SessionInfo(session_id="test-session-id-123", description="Test session", client=mock_client)
+        session_info = SessionInfo(
+            session_id="test-session-id-123",
+            description="Test session",
+            client=mock_client,
+        )
         interpreter._sessions["test-session"] = session_info
 
         interpreter.cleanup_platform()
@@ -391,7 +404,11 @@ def test_cleanup_platform_with_exception_in_stop(mock_client):
         interpreter._started = True
         mock_client.stop.side_effect = Exception("Stop failed")
 
-        session_info = SessionInfo(session_id="test-session-id-123", description="Test session", client=mock_client)
+        session_info = SessionInfo(
+            session_id="test-session-id-123",
+            description="Test session",
+            client=mock_client,
+        )
         interpreter._sessions["test-session"] = session_info
 
         interpreter.cleanup_platform()
@@ -414,7 +431,9 @@ def test_init_session_success(mock_client_class, interpreter, mock_client):
 
     mock_client_class.assert_called_once_with(region="us-west-2")
     mock_client.start.assert_called_once_with(
-        identifier="aws.codeinterpreter.v1", name="my-session", session_timeout_seconds=900
+        identifier="aws.codeinterpreter.v1",
+        name="my-session",
+        session_timeout_seconds=900,
     )
 
     assert "my-session" in interpreter._sessions
@@ -438,7 +457,11 @@ def test_init_session_with_custom_identifier(mock_client_class, mock_client):
         custom_id = "my-custom-interpreter-abc123"
         interpreter = AgentCoreCodeInterpreter(region="us-west-2", identifier=custom_id)
 
-        action = InitSessionAction(type="initSession", description="Test session", session_name="custom-session")
+        action = InitSessionAction(
+            type="initSession",
+            description="Test session",
+            session_name="custom-session",
+        )
 
         result = interpreter.init_session(action)
 
@@ -469,7 +492,11 @@ def test_init_session_with_default_identifier(mock_client_class, mock_client):
 
         interpreter = AgentCoreCodeInterpreter(region="us-west-2")
 
-        action = InitSessionAction(type="initSession", description="Test session", session_name="default-session")
+        action = InitSessionAction(
+            type="initSession",
+            description="Test session",
+            session_name="default-session",
+        )
 
         result = interpreter.init_session(action)
 
@@ -480,7 +507,9 @@ def test_init_session_with_default_identifier(mock_client_class, mock_client):
 
         mock_client_class.assert_called_once_with(region="us-west-2")
         mock_client.start.assert_called_once_with(
-            identifier="aws.codeinterpreter.v1", name="default-session", session_timeout_seconds=900
+            identifier="aws.codeinterpreter.v1",
+            name="default-session",
+            session_timeout_seconds=900,
         )
 
         assert "default-session" in interpreter._sessions
@@ -500,13 +529,19 @@ def test_init_session_with_session_timeout(mock_client_class, mock_client):
 
         interpreter = AgentCoreCodeInterpreter(region="us-west-2", session_timeout_seconds=1800)
 
-        action = InitSessionAction(type="initSession", description="Test session", session_name="timeout-session")
+        action = InitSessionAction(
+            type="initSession",
+            description="Test session",
+            session_name="timeout-session",
+        )
 
         result = interpreter.init_session(action)
 
         assert result["status"] == "success"
         mock_client.start.assert_called_once_with(
-            identifier="aws.codeinterpreter.v1", name="timeout-session", session_timeout_seconds=1800
+            identifier="aws.codeinterpreter.v1",
+            name="timeout-session",
+            session_timeout_seconds=1800,
         )
 
 
@@ -519,13 +554,19 @@ def test_init_session_without_session_timeout(mock_client_class, mock_client):
 
         interpreter = AgentCoreCodeInterpreter(region="us-west-2")
 
-        action = InitSessionAction(type="initSession", description="Test session", session_name="no-timeout-session")
+        action = InitSessionAction(
+            type="initSession",
+            description="Test session",
+            session_name="no-timeout-session",
+        )
 
         result = interpreter.init_session(action)
 
         assert result["status"] == "success"
         mock_client.start.assert_called_once_with(
-            identifier="aws.codeinterpreter.v1", name="no-timeout-session", session_timeout_seconds=900
+            identifier="aws.codeinterpreter.v1",
+            name="no-timeout-session",
+            session_timeout_seconds=900,
         )
 
 
@@ -559,11 +600,29 @@ def test_init_session_multiple_identifiers_verification(mock_client_class, mock_
         assert mock_client.start.call_count == 3
         call_args_list = mock_client.start.call_args_list
 
-        assert call_args_list[0] == ((), {"identifier": custom_id1, "name": "session1", "session_timeout_seconds": 900})
-        assert call_args_list[1] == ((), {"identifier": custom_id2, "name": "session2", "session_timeout_seconds": 900})
+        assert call_args_list[0] == (
+            (),
+            {
+                "identifier": custom_id1,
+                "name": "session1",
+                "session_timeout_seconds": 900,
+            },
+        )
+        assert call_args_list[1] == (
+            (),
+            {
+                "identifier": custom_id2,
+                "name": "session2",
+                "session_timeout_seconds": 900,
+            },
+        )
         assert call_args_list[2] == (
             (),
-            {"identifier": "aws.codeinterpreter.v1", "name": "session3", "session_timeout_seconds": 900},
+            {
+                "identifier": "aws.codeinterpreter.v1",
+                "name": "session3",
+                "session_timeout_seconds": 900,
+            },
         )
 
 
@@ -639,14 +698,18 @@ def test_execute_code_success(interpreter, mock_client):
     interpreter._sessions["test-session"] = session_info
 
     action = ExecuteCodeAction(
-        type="executeCode", session_name="test-session", code="print('Hello, World!')", language=LanguageType.PYTHON
+        type="executeCode",
+        session_name="test-session",
+        code="print('Hello, World!')",
+        language=LanguageType.PYTHON,
     )
 
     result = interpreter.execute_code(action)
 
     assert result["status"] == "success"
     mock_client.invoke.assert_called_once_with(
-        "executeCode", {"code": "print('Hello, World!')", "language": "python", "clearContext": False}
+        "executeCode",
+        {"code": "print('Hello, World!')", "language": "python", "clearContext": False},
     )
 
 
@@ -657,7 +720,10 @@ def test_execute_code_session_not_found():
         interpreter = AgentCoreCodeInterpreter(region="us-west-2", auto_create=False)
 
         action = ExecuteCodeAction(
-            type="executeCode", session_name="non-existent", code="print('Hello')", language=LanguageType.PYTHON
+            type="executeCode",
+            session_name="non-existent",
+            code="print('Hello')",
+            language=LanguageType.PYTHON,
         )
 
         with pytest.raises(ValueError, match="Session 'non-existent' not found"):
@@ -756,6 +822,37 @@ def test_write_files_success(interpreter, mock_client):
     )
 
 
+def test_write_files_action_with_blob(interpreter, mock_client):
+    """Test successful file writing with base64 blob content."""
+    session_info = SessionInfo(session_id="test-session-id-123", description="Test session", client=mock_client)
+    interpreter._sessions["test-session"] = session_info
+
+    action = WriteFilesAction(
+        type="writeFiles",
+        session_name="test-session",
+        content=[
+            FileContent(path="image.png", blob="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"),
+            FileContent(path="data.txt", text="Some data"),
+        ],
+    )
+
+    result = interpreter.write_files(action)
+
+    assert result["status"] == "success"
+    mock_client.invoke.assert_called_once_with(
+        "writeFiles",
+        {
+            "content": [
+                {
+                    "path": "image.png",
+                    "blob": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+                },
+                {"path": "data.txt", "text": "Some data"},
+            ]
+        },
+    )
+
+
 def test_create_tool_result_with_stream(interpreter):
     """Test _create_tool_result with stream response."""
     response = {"stream": [{"result": {"content": "Test output"}}], "isError": False}
@@ -830,7 +927,10 @@ def test_execute_code_with_auto_session_creation(mock_client_class, interpreter)
     """Test code execution with automatic session creation."""
     mock_client = mock_client_class.return_value
     mock_client.session_id = "auto-session-id"
-    mock_client.invoke.return_value = {"stream": [{"result": {"content": "Success"}}], "isError": False}
+    mock_client.invoke.return_value = {
+        "stream": [{"result": {"content": "Success"}}],
+        "isError": False,
+    }
 
     action = ExecuteCodeAction(
         type="executeCode",
@@ -848,7 +948,8 @@ def test_execute_code_with_auto_session_creation(mock_client_class, interpreter)
     assert auto_created_session.startswith("session-")
 
     mock_client.invoke.assert_called_with(
-        "executeCode", {"code": "print('Auto session')", "language": "python", "clearContext": False}
+        "executeCode",
+        {"code": "print('Auto session')", "language": "python", "clearContext": False},
     )
 
 


### PR DESCRIPTION
fix(code-interpreter): add blob support to write_files for binary file uploads

## Description
`write_files` currently only passes `text` to the BedrockAgentCore SDK,
silently dropping any `blob` field. This means binary files (images,
compiled artifacts, etc.) cannot be written to the sandbox — the SDK
supports `blob` on `writeFiles` but the tool never forwarded it.

Changes:
- Added `blob: Optional[str]` field to `FileContent` model with a
  `model_validator` enforcing that exactly one of `text` or `blob` is set
- Updated `write_files` in `AgentCoreCodeInterpreter` to forward `blob`
  to the SDK when present, falling back to `text`

Discovered this gap while using the tool in production to write binary 
files to a sandbox session. The BedrockAgentCore SDK already supports 
`blob` on `writeFiles` (see [SDK source](https://github.com/aws/bedrock-agentcore-sdk-python/blob/main/src/bedrock_agentcore/tools/code_interpreter_client.py#L516)), but the strands tool just wasn't surfacing it.

## Related Issues
N/A

## Documentation PR
N/A

## Type of Change
Bug fix

## Testing
Added a test covering a mixed `content` list with both `text` and `blob`
entries flowing through the tool dispatch.

Verified that the BedrockAgentCore SDK already supports `blob` on
`writeFiles`: https://github.com/aws/bedrock-agentcore-sdk-python/blob/main/src/bedrock_agentcore/tools/code_interpreter_client.py#L516

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----
By submitting this pull request, I confirm that you can use, modify, copy,
and redistribute this contribution, under the terms of your choice.