### PR TITLE
fix(code-interpreter): add blob support to write_files for binary file uploads

### DIFF
--- a/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
+++ b/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
@@ -479,7 +479,12 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
 
         logger.debug(f"Writing {len(action.content)} files to session '{session_name}'")
 
-        content_dicts = [{"path": fc.path, "text": fc.text} for fc in action.content]
+        content_dicts = []
+        for fc in action.content:
+            if fc.blob is not None:
+                content_dicts.append({"path": fc.path, "blob": fc.blob})
+            else:
+                content_dicts.append({"path": fc.path, "text": fc.text})
         params = {"content": content_dicts}
         response = self._sessions[session_name].client.invoke("writeFiles", params)
 

--- a/src/strands_tools/code_interpreter/models.py
+++ b/src/strands_tools/code_interpreter/models.py
@@ -8,7 +8,7 @@ with discriminated unions, ensuring required fields are present for each action 
 from enum import Enum
 from typing import List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class LanguageType(str, Enum):
@@ -24,7 +24,22 @@ class FileContent(BaseModel):
     updating files during code execution sessions."""
 
     path: str = Field(description="The file path where content should be written")
-    text: str = Field(description="Text content for the file")
+    text: Optional[str] = Field(
+        default=None,
+        description="Text content for the file",
+    )
+    blob: Optional[str] = Field(
+        default=None,
+        description="Base64-encoded binary content for the file",
+    )
+
+    @model_validator(mode="after")
+    def validate_content(self) -> "FileContent":
+        if self.text is None and self.blob is None:
+            raise ValueError("Either text or blob must be provided")
+        if self.text is not None and self.blob is not None:
+            raise ValueError("Only one of text or blob may be provided")
+        return self
 
 
 # Action-specific Pydantic models using discriminated unions

--- a/src/strands_tools/code_interpreter/models.py
+++ b/src/strands_tools/code_interpreter/models.py
@@ -28,7 +28,7 @@ class FileContent(BaseModel):
         default=None,
         description="Text content for the file",
     )
-    blob: Optional[str] = Field(
+    blob: Optional[bytes] = Field(
         default=None,
         description="Base64-encoded binary content for the file",
     )

--- a/tests/code_interpreter/test_agent_core_code_interpreter.py
+++ b/tests/code_interpreter/test_agent_core_code_interpreter.py
@@ -756,6 +756,37 @@ def test_write_files_success(interpreter, mock_client):
     )
 
 
+def test_write_files_action_with_blob(interpreter, mock_client):
+    """Test successful file writing with base64 blob content."""
+    session_info = SessionInfo(session_id="test-session-id-123", description="Test session", client=mock_client)
+    interpreter._sessions["test-session"] = session_info
+
+    action = WriteFilesAction(
+        type="writeFiles",
+        session_name="test-session",
+        content=[
+            FileContent(path="image.png", blob="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"),
+            FileContent(path="data.txt", text="Some data"),
+        ],
+    )
+
+    result = interpreter.write_files(action)
+
+    assert result["status"] == "success"
+    mock_client.invoke.assert_called_once_with(
+        "writeFiles",
+        {
+            "content": [
+                {
+                    "path": "image.png",
+                    "blob": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+                },
+                {"path": "data.txt", "text": "Some data"},
+            ]
+        },
+    )
+
+
 def test_create_tool_result_with_stream(interpreter):
     """Test _create_tool_result with stream response."""
     response = {"stream": [{"result": {"content": "Test output"}}], "isError": False}

--- a/tests/code_interpreter/test_agent_core_code_interpreter.py
+++ b/tests/code_interpreter/test_agent_core_code_interpreter.py
@@ -765,7 +765,7 @@ def test_write_files_action_with_blob(interpreter, mock_client):
         type="writeFiles",
         session_name="test-session",
         content=[
-            FileContent(path="image.png", blob="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"),
+            FileContent(path="image.png", blob=b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"),
             FileContent(path="data.txt", text="Some data"),
         ],
     )
@@ -779,7 +779,7 @@ def test_write_files_action_with_blob(interpreter, mock_client):
             "content": [
                 {
                     "path": "image.png",
-                    "blob": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+                    "blob": b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
                 },
                 {"path": "data.txt", "text": "Some data"},
             ]


### PR DESCRIPTION
fix(code-interpreter): add blob support to write_files for binary file uploads

## Description
`write_files` currently only passes `text` to the BedrockAgentCore SDK,
silently dropping any `blob` field. This means binary files (images,
compiled artifacts, etc.) cannot be written to the sandbox, but the SDK
supports `blob` on `writeFiles` but the tool never forwarded it.

Changes:
- Added `blob: Optional[str]` field to `FileContent` model with a
  `model_validator` enforcing that exactly one of `text` or `blob` is set
- Updated `write_files` in `AgentCoreCodeInterpreter` to forward `blob`
  to the SDK when present, falling back to `text`

Discovered this gap while using the tool in production to write binary 
files to a sandbox session. The BedrockAgentCore SDK already supports 
`blob` on `writeFiles` (see [SDK source](https://github.com/aws/bedrock-agentcore-sdk-python/blob/main/src/bedrock_agentcore/tools/code_interpreter_client.py#L516)), but the strands tool just 
wasn't surfacing it.

## Related Issues
Fixes #304

## Documentation PR
N/A

## Type of Change
Bug fix

## Testing
Added a test covering a mixed `content` list with both `text` and `blob`
entries flowing through the tool dispatch.

Verified that the BedrockAgentCore SDK already supports `blob` on
`writeFiles`: https://github.com/aws/bedrock-agentcore-sdk-python/blob/main/src/bedrock_agentcore/tools/code_interpreter_client.py#L516

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----
By submitting this pull request, I confirm that you can use, modify, copy,
and redistribute this contribution, under the terms of your choice.