### PR TITLE
fix: prevent code execution in calculator tool via restricted parse_expr

### DIFF
--- a/src/strands_tools/calculator.py
+++ b/src/strands_tools/calculator.py
@@ -72,6 +72,13 @@ from rich.panel import Panel
 from rich.table import Table
 from strands import tool
 
+from sympy.parsing.sympy_parser import (
+    convert_xor,
+    implicit_multiplication_application,
+    parse_expr,
+    standard_transformations,
+)
+
 from strands_tools.utils import console_util
 
 logger = logging.getLogger(__name__)
@@ -111,63 +118,127 @@ def create_error_panel(console: Console, error_message: str) -> None:
     )
 
 
+# Restricted namespace for parse_expr. Only math functions and constants are available.
+_SAFE_SYMPY_LOCALS: Dict[str, Any] = {
+    # Constants
+    "pi": sp.pi,
+    "e": sp.E,
+    "E": sp.E,
+    "I": sp.I,
+    "oo": sp.oo,
+    "inf": sp.oo,
+    "nan": sp.nan,
+    "zoo": sp.zoo,
+    "true": True,
+    "false": False,
+    "True": True,
+    "False": False,
+    # Trig
+    "sin": sp.sin,
+    "cos": sp.cos,
+    "tan": sp.tan,
+    "cot": sp.cot,
+    "sec": sp.sec,
+    "csc": sp.csc,
+    "asin": sp.asin,
+    "acos": sp.acos,
+    "atan": sp.atan,
+    "atan2": sp.atan2,
+    # Hyperbolic
+    "sinh": sp.sinh,
+    "cosh": sp.cosh,
+    "tanh": sp.tanh,
+    "asinh": sp.asinh,
+    "acosh": sp.acosh,
+    "atanh": sp.atanh,
+    # Exponential/logarithmic
+    "exp": sp.exp,
+    "log": sp.log,
+    "ln": sp.ln,
+    # Powers and roots
+    "sqrt": sp.sqrt,
+    "cbrt": sp.cbrt,
+    "Abs": sp.Abs,
+    "abs": sp.Abs,
+    "sign": sp.sign,
+    # Combinatorics
+    "factorial": sp.factorial,
+    "binomial": sp.binomial,
+    # Floor/ceiling
+    "floor": sp.floor,
+    "ceiling": sp.ceiling,
+    # Special functions
+    "gamma": sp.gamma,
+    "zeta": sp.zeta,
+    "erf": sp.erf,
+    # Min/Max
+    "Max": sp.Max,
+    "Min": sp.Min,
+    "max": sp.Max,
+    "min": sp.Min,
+    # Constructors
+    "Eq": sp.Eq,
+    "Matrix": sp.Matrix,
+    "Rational": sp.Rational,
+    "Integer": sp.Integer,
+    "Float": sp.Float,
+    "Symbol": sp.Symbol,
+    "symbols": sp.symbols,
+    "N": sp.N,
+    # Solving/simplification
+    "solve": sp.solve,
+    "simplify": sp.simplify,
+    "expand": sp.expand,
+    "factor": sp.factor,
+    "collect": sp.collect,
+    "cancel": sp.cancel,
+    "apart": sp.apart,
+    "together": sp.together,
+    "limit": sp.limit,
+    "diff": sp.diff,
+    "integrate": sp.integrate,
+    "series": sp.series,
+    "Sum": sp.Sum,
+    "Product": sp.Product,
+}
+
+# Restricted globals with builtins neutralized.
+# Only include Python builtins that SymPy's parser internals require.
+_SAFE_GLOBALS: Dict[str, Any] = {
+    "__builtins__": {},
+}
+
+
 def parse_expression(expr_str: str) -> Any:
-    """Parse a string expression into a SymPy expression."""
+    """Parse a string expression into a SymPy expression safely.
+
+    Uses sympy.parsing.sympy_parser.parse_expr with a restricted local_dict
+    and empty __builtins__ to prevent code execution via eval.
+    """
+    if not isinstance(expr_str, str):
+        raise ValueError("Expression must be a string")
+
+    transformations = standard_transformations + (
+        implicit_multiplication_application,
+        convert_xor,
+    )
+
     try:
-        # Validate expression string
-        if not isinstance(expr_str, str):
-            raise ValueError("Expression must be a string")
-
-        # Replace common mathematical notations
-        expr_str = expr_str.replace("^", "**")
-
-        # Handle logarithm notations
-        if "log(" in expr_str:
-            expr_str = expr_str.replace("log(", "ln(")  # Convert to natural log
-
-        # Pre-process pi and e for better evaluation - using word boundaries to avoid replacing 'e' in function names
-        expr_str = expr_str.replace(" pi ", " " + str(sp.N(sp.pi, 50)) + " ")
-        expr_str = expr_str.replace("(pi)", "(" + str(sp.N(sp.pi, 50)) + ")")
-        expr_str = expr_str.replace("pi+", str(sp.N(sp.pi, 50)) + "+")
-        expr_str = expr_str.replace("pi-", str(sp.N(sp.pi, 50)) + "-")
-        expr_str = expr_str.replace("pi*", str(sp.N(sp.pi, 50)) + "*")
-        expr_str = expr_str.replace("pi/", str(sp.N(sp.pi, 50)) + "/")
-        expr_str = expr_str.replace("pi)", str(sp.N(sp.pi, 50)) + ")")
-
-        # Handle standalone 'e' constant but preserve function names like 'exp'
-        expr_str = expr_str.replace(" e ", " " + str(sp.N(sp.E, 50)) + " ")
-        expr_str = expr_str.replace("(e)", "(" + str(sp.N(sp.E, 50)) + ")")
-        expr_str = expr_str.replace("e+", str(sp.N(sp.E, 50)) + "+")
-        expr_str = expr_str.replace("e-", str(sp.N(sp.E, 50)) + "-")
-        expr_str = expr_str.replace("e*", str(sp.N(sp.E, 50)) + "*")
-        expr_str = expr_str.replace("e/", str(sp.N(sp.E, 50)) + "/")
-        expr_str = expr_str.replace("e)", str(sp.N(sp.E, 50)) + ")")
-
-        # Basic validation for common invalid patterns
-        if "//" in expr_str:  # Catch integer division which is not supported
-            raise ValueError("Invalid operator: //. Use / for division.")
-
-        if "**/" in expr_str:  # Catch power/division confusion
-            raise ValueError("Invalid operator sequence: **/")
-
-        if any(op in expr_str for op in ["&&", "||", "&", "|"]):  # Catch logical operators
-            raise ValueError("Logical operators are not supported in mathematical expressions")
-
-        try:
-            # First try parsing with pre-evaluated constants
-            expr = sp.sympify(expr_str, evaluate=True)  # type: ignore
-
-            # If we got any symbolic constants, substitute their values
-            if expr.has(sp.pi) or expr.has(sp.E):
-                expr = expr.subs({sp.pi: sp.N(sp.pi, 50), sp.E: sp.N(sp.E, 50)})
-
-            return expr
-
-        except sp.SympifyError as e:
-            raise ValueError(f"Invalid mathematical expression: {str(e)}") from e
-
+        expr = parse_expr(
+            expr_str,
+            local_dict=_SAFE_SYMPY_LOCALS,
+            global_dict=_SAFE_GLOBALS,
+            transformations=transformations,
+            evaluate=True,
+        )
     except Exception as e:
-        raise ValueError(f"Invalid expression: {str(e)}") from e
+        raise ValueError(f"Invalid mathematical expression: {str(e)}") from e
+
+    # Substitute numeric values for symbolic constants for consistent evaluation
+    if isinstance(expr, sp.Basic) and (expr.has(sp.pi) or expr.has(sp.E)):
+        expr = expr.subs({sp.pi: sp.N(sp.pi, 50), sp.E: sp.N(sp.E, 50)})
+
+    return expr
 
 
 def get_precision_level(num: Union[float, int, sp.Expr]) -> int:
@@ -448,11 +519,11 @@ def evaluate_expression(
 def solve_equation(expr: Any, precision: int) -> Any:
     """Solve an equation or system of equations."""
     try:
-        # Handle system of equations
-        if isinstance(expr, list):
+        # Handle system of equations (list or tuple from comma-separated input)
+        if isinstance(expr, (list, tuple)):
             # Get all variables in the system
             variables = set().union(*[eq.free_symbols for eq in expr])
-            solution = sp.solve(expr, list(variables))
+            solution = sp.solve(list(expr), list(variables))
             return solution
 
         # Single equation
@@ -528,7 +599,7 @@ def calculate_limit(expr: Any, var: str, point: str) -> Any:
             raise ValueError(f"Cannot calculate limit of an undefined expression: {expr}") from None
 
         var_sym = sp.Symbol(var)
-        point_val = sp.sympify(point)
+        point_val = parse_expression(point)
         return sp.limit(expr, var_sym, point_val)
     except Exception as e:
         raise ValueError(f"Limit calculation error: {str(e)}") from e
@@ -548,7 +619,7 @@ def calculate_series(expr: Any, var: str, point: str, order: int) -> Any:
             raise ValueError(f"Cannot expand series of an undefined expression: {expr}") from None
 
         var_sym = sp.Symbol(var)
-        point_val = sp.sympify(point)
+        point_val = parse_expression(point)
         return sp.series(expr, var_sym, point_val, order)
     except Exception as e:
         raise ValueError(f"Series expansion error: {str(e)}") from e

--- a/src/strands_tools/calculator.py
+++ b/src/strands_tools/calculator.py
@@ -71,7 +71,6 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 from strands import tool
-
 from sympy.parsing.sympy_parser import (
     convert_xor,
     implicit_multiplication_application,
@@ -202,8 +201,9 @@ _SAFE_SYMPY_LOCALS: Dict[str, Any] = {
     "Product": sp.Product,
 }
 
-# Restricted globals with builtins neutralized.
-# Only include Python builtins that SymPy's parser internals require.
+# Restricted globals with builtins neutralized to prevent code execution.
+# Setting __builtins__ to an empty dict ensures __import__, eval, exec, open,
+# and all other Python builtins are inaccessible during eval.
 _SAFE_GLOBALS: Dict[str, Any] = {
     "__builtins__": {},
 }

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -146,16 +146,17 @@ def test_parse_expression_edge_cases():
     with pytest.raises(ValueError, match="Expression must be a string"):
         parse_expression(123)
 
-    # Test with invalid operators
-    with pytest.raises(ValueError, match="Invalid operator"):
-        parse_expression("2 // 3")
-
-    with pytest.raises(ValueError, match="Invalid operator sequence"):
+    # Test with invalid syntax
+    with pytest.raises(ValueError, match="Invalid"):
         parse_expression("2 **/ 3")
 
-    # Test with logical operators
-    with pytest.raises(ValueError, match="Logical operators are not supported"):
+    # Test with logical operators (invalid Python syntax)
+    with pytest.raises(ValueError, match="Invalid"):
         parse_expression("x && y")
+
+    # Test that floor division is handled (parse_expr supports it)
+    result = parse_expression("2 // 3")
+    assert result == 0
 
     # Test logarithm notation
     result = parse_expression("log(10)")
@@ -189,8 +190,10 @@ def test_parse_expression_edge_cases():
         result = parse_expression(case)
         assert isinstance(result, sp.Basic)
 
-    # Test sympify error handling
-    with mock.patch("sympy.sympify", side_effect=sp.SympifyError("Test error")):
+    # Test parse_expr error handling
+    with mock.patch(
+        "src.strands_tools.calculator.parse_expr", side_effect=SyntaxError("Test error")
+    ):
         with pytest.raises(ValueError, match="Invalid mathematical expression"):
             parse_expression("x + y")
 
@@ -642,3 +645,18 @@ def test_error_handling(agent):
     result_text = extract_result_text(result)
     # Should either give an error or solve in terms of y
     assert "Error" in result_text or "y" in result_text
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "__import__('os').getpid()",
+        "eval('1+1')",
+        "open('/dev/null')",
+    ],
+)
+def test_code_execution_blocked(payload):
+    """Verify that malicious payloads cannot achieve code execution via parse_expression."""
+    result = calculator_func(expression=payload, mode="evaluate")
+    assert result["status"] == "error"
+    assert "Invalid mathematical expression:" in result["content"][0]["text"]

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -191,9 +191,7 @@ def test_parse_expression_edge_cases():
         assert isinstance(result, sp.Basic)
 
     # Test parse_expr error handling
-    with mock.patch(
-        "src.strands_tools.calculator.parse_expr", side_effect=SyntaxError("Test error")
-    ):
+    with mock.patch("src.strands_tools.calculator.parse_expr", side_effect=SyntaxError("Test error")):
         with pytest.raises(ValueError, match="Invalid mathematical expression"):
             parse_expression("x + y")
 
@@ -648,15 +646,17 @@ def test_error_handling(agent):
 
 
 @pytest.mark.parametrize(
-    "payload",
+    "payload,mock_target",
     [
-        "__import__('os').getpid()",
-        "eval('1+1')",
-        "open('/dev/null')",
+        ("__import__('os').getpid()", "os.getpid"),
+        ("open('/dev/null')", "builtins.open"),
+        ("eval('__import__(\"os\").getpid()')", "os.getpid"),
     ],
 )
-def test_code_execution_blocked(payload):
+def test_code_execution_blocked(payload, mock_target):
     """Verify that malicious payloads cannot achieve code execution via parse_expression."""
-    result = calculator_func(expression=payload, mode="evaluate")
-    assert result["status"] == "error"
-    assert "Invalid mathematical expression:" in result["content"][0]["text"]
+    with mock.patch(mock_target) as mock_fn:
+        result = calculator_func(expression=payload, mode="evaluate")
+        assert result["status"] == "error"
+        assert "Invalid mathematical expression:" in result["content"][0]["text"]
+        mock_fn.assert_not_called()


### PR DESCRIPTION
## Description

The calculator tool passes LLM-controlled expression strings to `sympy.sympify()` which internally calls Python's `eval()`. This allows arbitrary code execution via payloads like `__import__('os').system(...)` with no consent gate or sandbox.

This PR replaces `sympify()` with `parse_expr` using a restricted namespace:
- `local_dict`: allowlist of safe math functions and constants (sin, cos, pi, etc.)
- `global_dict`: `{"__builtins__": {}}` which neutralizes access to `__import__`, `eval`, `exec`, `open`, and all other Python builtins

The same fix is applied to the `point` parameter in `calculate_limit` and `calculate_series`, which also called `sympify` directly on user input.

## Side Effects

The `local_dict` allowlist (`_SAFE_SYMPY_LOCALS`) defines which SymPy functions and constants are available to expressions. If an LLM generates an expression using a SymPy function not in the allowlist, it will fail with an error rather than being evaluated. The failure mode is safe (the function becomes an inert Symbol instead of executing), but it means we may need to expand `_SAFE_SYMPY_LOCALS` over time as we discover math functions that are missing. The current list covers trig, hyperbolic, exponential/log, roots, combinatorics, floor/ceiling, special functions, min/max, solving, simplification, and calculus, which covers all existing tests and documented usage.

## Type of Change

Bug fix

## Testing

- All 40 unit tests pass (37 existing + 3 new security regression tests)
- Security regression test uses `mock.patch` to confirm `os.getpid`, `builtins.open`, and nested `eval` payloads never execute the target function
- Comprehensive battle test covering all 7 modes, all parameters, 13 security payloads, and 63 functional cases
- Verified the marker-file-based RCE proof-of-concept no longer creates the file

```
$ python -m pytest tests/test_calculator.py tests/test_calculator_precision.py -q
40 passed in 1.76s
```

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] My changes generate no new warnings