### PR TITLE
fix: redact sensitive credentials in use_aws responses

### DIFF
--- a/src/strands_tools/use_aws.py
+++ b/src/strands_tools/use_aws.py
@@ -47,18 +47,19 @@ Key Features:
 Security Recommendations:
 
    The IAM role attached to the agent's execution environment should follow
-   least-privilege principles. Restrict the role to only the services and
-   operations the agent actually needs. In particular:
+   least-privilege principles. Grant only the services and operations the
+   agent needs to fulfill its purpose.
 
-   • Avoid granting sts:GetSessionToken, sts:AssumeRole, or
-     secretsmanager:GetSecretValue unless the agent requires them.
-   • Add explicit Deny statements for credential-returning operations that
-     the agent should never call.
-   • Use IAM condition keys (e.g., aws:SourceIp, aws:VpcSourceIp) to limit
-     where credentials can be used if they are disclosed.
+   • Scope the role policy to specific resources and actions rather than
+     using wildcards.
+   • Add explicit Deny statements for operations the agent should never
+     call (e.g., credential-returning or destructive APIs).
+   • Use IAM condition keys (e.g., aws:SourceIp, aws:RequestedRegion) to
+     further constrain what the role can do and from where.
 
-   The tool redacts known credential fields from responses, but IAM scoping
-   remains the primary defense against unauthorized access.
+   The tool provides response redaction and consent prompts as defense-in-depth,
+   but IAM policy scoping remains the primary mechanism for controlling what
+   an agent can access.
 
 See the use_aws function docstring for more details on parameters and usage.
 """

--- a/src/strands_tools/use_aws.py
+++ b/src/strands_tools/use_aws.py
@@ -15,6 +15,8 @@ Key Features:
 
 2. Safety Features:
    • Confirmation prompts for mutative operations (create, update, delete)
+   • Confirmation prompts for credential-returning operations (STS, Secrets Manager, ECR)
+   • Response redaction of known sensitive keys (SecretAccessKey, SessionToken, etc.)
    • Parameter validation with helpful error messages
    • Automatic schema generation for invalid requests
    • Error handling with detailed feedback
@@ -41,6 +43,22 @@ Key Features:
        label="List all S3 buckets"
    )
    ```
+
+Security Recommendations:
+
+   The IAM role attached to the agent's execution environment should follow
+   least-privilege principles. Restrict the role to only the services and
+   operations the agent actually needs. In particular:
+
+   • Avoid granting sts:GetSessionToken, sts:AssumeRole, or
+     secretsmanager:GetSecretValue unless the agent requires them.
+   • Add explicit Deny statements for credential-returning operations that
+     the agent should never call.
+   • Use IAM condition keys (e.g., aws:SourceIp, aws:VpcSourceIp) to limit
+     where credentials can be used if they are disclosed.
+
+   The tool redacts known credential fields from responses, but IAM scoping
+   remains the primary defense against unauthorized access.
 
 See the use_aws function docstring for more details on parameters and usage.
 """

--- a/src/strands_tools/use_aws.py
+++ b/src/strands_tools/use_aws.py
@@ -94,6 +94,73 @@ MUTATIVE_OPERATIONS = [
     "accept",
 ]
 
+# Operations that return credentials or secrets and require user consent
+# even though they are not mutative. These operations disclose sensitive
+# material that should not be exposed to the LLM context without explicit
+# human approval.
+SENSITIVE_OPERATIONS = {
+    ("sts", "get_session_token"),
+    ("sts", "assume_role"),
+    ("sts", "assume_role_with_saml"),
+    ("sts", "assume_role_with_web_identity"),
+    ("sts", "get_federation_token"),
+    ("secretsmanager", "get_secret_value"),
+    ("secretsmanager", "batch_get_secret_value"),
+    ("ecr", "get_authorization_token"),
+    ("ecr-public", "get_authorization_token"),
+    ("redshift", "get_cluster_credentials"),
+    ("redshift", "get_cluster_credentials_with_iam"),
+    ("codeartifact", "get_authorization_token"),
+    ("cognito-identity", "get_credentials_for_identity"),
+    ("cognito-identity", "get_open_id_token"),
+    ("cognito-identity", "get_open_id_token_for_developer_identity"),
+    ("cognito-idp", "initiate_auth"),
+    ("cognito-idp", "admin_initiate_auth"),
+}
+
+# Response keys whose values must be redacted before returning to LLM context.
+# These are exact key names (compared case-insensitively) known to carry secrets.
+# Avoid overly generic names like "token" which collide with pagination tokens.
+SENSITIVE_RESPONSE_KEYS = {
+    "secretaccesskey",
+    "sessiontoken",
+    "secretstring",
+    "secretbinary",
+    "authorizationtoken",
+    "password",
+    "accesstoken",
+    "refreshtoken",
+    "idtoken",
+    "apikey",
+    "clientsecret",
+    "keymaterial",
+    "privatekey",
+    "sharedsecret",
+    "dbpassword",
+    "masteruserpassword",
+}
+
+def redact_sensitive_values(obj: Any) -> Any:
+    """Recursively redact values of known sensitive keys from an AWS response.
+
+    Args:
+        obj: The object (dict, list, or scalar) to scrub.
+
+    Returns:
+        A copy of the object with sensitive values replaced by a placeholder.
+    """
+    if isinstance(obj, dict):
+        redacted = {}
+        for key, value in obj.items():
+            if key.lower() in SENSITIVE_RESPONSE_KEYS:
+                redacted[key] = "**REDACTED**"
+            else:
+                redacted[key] = redact_sensitive_values(value)
+        return redacted
+    elif isinstance(obj, list):
+        return [redact_sensitive_values(item) for item in obj]
+    return obj
+
 
 def get_boto3_client(
     service_name: str,
@@ -310,12 +377,22 @@ def use_aws(tool: ToolUse, **kwargs: Any) -> ToolResult:
     # Check if the operation is potentially mutative
     is_mutative = any(op in operation_name.lower() for op in MUTATIVE_OPERATIONS)
 
-    if is_mutative and not STRANDS_BYPASS_TOOL_CONSENT:
-        # Prompt for confirmation before executing the operation
-        confirm = get_user_input(
-            f"<yellow><bold>The operation '{operation_name}' is potentially mutative. "
-            f"Do you want to proceed?</bold> [y/*]</yellow>"
-        )
+    # Check if the operation returns credentials or secrets
+    is_sensitive = (service_name.lower(), operation_name.lower()) in SENSITIVE_OPERATIONS
+
+    if (is_mutative or is_sensitive) and not STRANDS_BYPASS_TOOL_CONSENT:
+        if is_sensitive:
+            prompt_message = (
+                f"<yellow><bold>The operation '{service_name}.{operation_name}' may return "
+                f"sensitive credentials or secrets. Do you want to proceed?</bold> [y/*]</yellow>"
+            )
+        else:
+            prompt_message = (
+                f"<yellow><bold>The operation '{operation_name}' is potentially mutative. "
+                f"Do you want to proceed?</bold> [y/*]</yellow>"
+            )
+
+        confirm = get_user_input(prompt_message)
         if confirm.lower() != "y":
             return {
                 "toolUseId": tool_use_id,
@@ -356,6 +433,7 @@ def use_aws(tool: ToolUse, **kwargs: Any) -> ToolResult:
         response = operation_method(**parameters)
         response = handle_streaming_body(response)
         response = convert_datetime_to_str(response)
+        response = redact_sensitive_values(response)
 
         return {
             "toolUseId": tool_use_id,

--- a/tests/test_use_aws.py
+++ b/tests/test_use_aws.py
@@ -551,7 +551,7 @@ def test_redact_sensitive_values_nested_dict():
     """Sensitive keys nested inside dicts are redacted."""
     response = {
         "Credentials": {
-            "AccessKeyId": "ASIAXXXXXXXXXEXAMPLE",
+            "AccessKeyId": "EXAMPLE_KEY_ID_12345678",
             "SecretAccessKey": "secret-key-value",
             "SessionToken": "session-token-value",
             "Expiration": "2026-05-13T18:00:00Z",
@@ -561,7 +561,7 @@ def test_redact_sensitive_values_nested_dict():
 
     assert result == {
         "Credentials": {
-            "AccessKeyId": "ASIAXXXXXXXXXEXAMPLE",
+            "AccessKeyId": "EXAMPLE_KEY_ID_12345678",
             "SecretAccessKey": "**REDACTED**",
             "SessionToken": "**REDACTED**",
             "Expiration": "2026-05-13T18:00:00Z",
@@ -665,7 +665,7 @@ def test_use_aws_sensitive_operations_bypass_consent(mock_input):
     mock_client = MagicMock()
     mock_client.get_session_token.return_value = {
         "Credentials": {
-            "AccessKeyId": "ASIAXXXXXXXXXEXAMPLE",
+            "AccessKeyId": "EXAMPLE_KEY_ID_12345678",
             "SecretAccessKey": "secret-key-value",
             "SessionToken": "session-token-value",
             "Expiration": "2026-05-13T18:00:00Z",

--- a/tests/test_use_aws.py
+++ b/tests/test_use_aws.py
@@ -513,3 +513,183 @@ def test_get_user_input_new_loop(mock_set_event_loop, mock_new_event_loop, mock_
     mock_new_event_loop.assert_called_once()
     mock_set_event_loop.assert_called_once_with(mock_loop)
     assert result == "y"
+
+
+# --- Credential redaction and sensitive operation consent gate tests ---
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("SecretAccessKey", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+        ("SessionToken", "FwoGZXIvYXdzEBYaDHmKHt..."),
+        ("SecretString", '{"password": "hunter2"}'),
+        ("SecretBinary", b"\x00\x01\x02"),
+        ("authorizationToken", "QVdTOnN1cGVyc2VjcmV0"),
+        ("Password", "super-secret"),
+        ("AccessToken", "eyJraWQiOi..."),
+        ("RefreshToken", "eyJjdHkiOi..."),
+        ("IdToken", "eyJraWQiOi..."),
+        ("ApiKey", "abc123apikey"),
+        ("ClientSecret", "client-secret-value"),
+        ("KeyMaterial", "-----BEGIN RSA PRIVATE KEY-----"),
+        ("PrivateKey", "-----BEGIN PRIVATE KEY-----"),
+        ("SharedSecret", "shared-secret-123"),
+        ("DbPassword", "db-pass-456"),
+        ("MasterUserPassword", "master-pass-789"),
+    ],
+)
+def test_redact_sensitive_values_key_redacted(key, value):
+    """Each sensitive key should be redacted regardless of nesting depth."""
+    response = {key: value, "SafeField": "visible"}
+    result = use_aws.redact_sensitive_values(response)
+
+    assert result == {key: "**REDACTED**", "SafeField": "visible"}
+
+
+def test_redact_sensitive_values_nested_dict():
+    """Sensitive keys nested inside dicts are redacted."""
+    response = {
+        "Credentials": {
+            "AccessKeyId": "ASIAXXXXXXXXXEXAMPLE",
+            "SecretAccessKey": "secret-key-value",
+            "SessionToken": "session-token-value",
+            "Expiration": "2026-05-13T18:00:00Z",
+        }
+    }
+    result = use_aws.redact_sensitive_values(response)
+
+    assert result == {
+        "Credentials": {
+            "AccessKeyId": "ASIAXXXXXXXXXEXAMPLE",
+            "SecretAccessKey": "**REDACTED**",
+            "SessionToken": "**REDACTED**",
+            "Expiration": "2026-05-13T18:00:00Z",
+        }
+    }
+
+
+def test_redact_sensitive_values_nested_list():
+    """Sensitive keys inside list elements are redacted."""
+    response = {
+        "authorizationData": [
+            {"authorizationToken": "token-1", "proxyEndpoint": "https://endpoint-1"},
+            {"authorizationToken": "token-2", "proxyEndpoint": "https://endpoint-2"},
+        ]
+    }
+    result = use_aws.redact_sensitive_values(response)
+
+    assert result == {
+        "authorizationData": [
+            {"authorizationToken": "**REDACTED**", "proxyEndpoint": "https://endpoint-1"},
+            {"authorizationToken": "**REDACTED**", "proxyEndpoint": "https://endpoint-2"},
+        ]
+    }
+
+
+@pytest.mark.parametrize("obj", [{}, [], None, "string", 42, 3.14, True])
+def test_redact_sensitive_values_edge_cases(obj):
+    """Empty containers and scalars pass through without error."""
+    result = use_aws.redact_sensitive_values(obj)
+    assert result == obj
+
+
+@pytest.mark.parametrize(
+    "service,operation",
+    [
+        ("sts", "get_session_token"),
+        ("secretsmanager", "get_secret_value"),
+        ("ecr", "get_authorization_token"),
+    ],
+)
+@patch("strands_tools.use_aws.get_user_input", return_value="n")
+def test_use_aws_sensitive_operations_blocked_on_denial(mock_input, service, operation):
+    """Sensitive operations are blocked when user declines consent."""
+    with (
+        patch("strands_tools.use_aws.get_available_services", return_value=[service]),
+        patch("strands_tools.use_aws.get_available_operations", return_value=[operation]),
+        patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "false"}),
+    ):
+        tool_use = {
+            "toolUseId": "test-id",
+            "input": {
+                "service_name": service,
+                "operation_name": operation,
+                "parameters": {},
+                "region": "us-east-1",
+                "label": "Test",
+            },
+        }
+        result = use_aws.use_aws(tool=tool_use)
+
+        mock_input.assert_called_once()
+        assert result["status"] == "error"
+        assert "Operation canceled by user" in result["content"][0]["text"]
+
+
+@patch("strands_tools.use_aws.get_user_input", return_value="y")
+def test_use_aws_sensitive_operations_proceeds_with_redaction(mock_input):
+    """Sensitive operation proceeds on consent but response is still redacted."""
+    mock_client = MagicMock()
+    mock_client.get_secret_value.return_value = {
+        "Name": "my-secret",
+        "SecretString": "top-secret-value",
+    }
+
+    with (
+        patch("strands_tools.use_aws.get_available_services", return_value=["secretsmanager"]),
+        patch("strands_tools.use_aws.get_available_operations", return_value=["get_secret_value"]),
+        patch("strands_tools.use_aws.get_boto3_client", return_value=mock_client),
+        patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "false"}),
+    ):
+        tool_use = {
+            "toolUseId": "test-id",
+            "input": {
+                "service_name": "secretsmanager",
+                "operation_name": "get_secret_value",
+                "parameters": {"SecretId": "my-secret"},
+                "region": "us-east-1",
+                "label": "Test",
+            },
+        }
+        result = use_aws.use_aws(tool=tool_use)
+
+        assert result["status"] == "success"
+        assert "**REDACTED**" in result["content"][0]["text"]
+        assert "top-secret-value" not in result["content"][0]["text"]
+
+
+@patch("strands_tools.use_aws.get_user_input")
+def test_use_aws_sensitive_operations_bypass_consent(mock_input):
+    """BYPASS_TOOL_CONSENT=true skips consent for sensitive operations."""
+    mock_client = MagicMock()
+    mock_client.get_session_token.return_value = {
+        "Credentials": {
+            "AccessKeyId": "ASIAXXXXXXXXXEXAMPLE",
+            "SecretAccessKey": "secret-key-value",
+            "SessionToken": "session-token-value",
+            "Expiration": "2026-05-13T18:00:00Z",
+        },
+    }
+
+    with (
+        patch("strands_tools.use_aws.get_available_services", return_value=["sts"]),
+        patch("strands_tools.use_aws.get_available_operations", return_value=["get_session_token"]),
+        patch("strands_tools.use_aws.get_boto3_client", return_value=mock_client),
+        patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "true"}),
+    ):
+        tool_use = {
+            "toolUseId": "test-id",
+            "input": {
+                "service_name": "sts",
+                "operation_name": "get_session_token",
+                "parameters": {},
+                "region": "us-east-1",
+                "label": "Test",
+            },
+        }
+        result = use_aws.use_aws(tool=tool_use)
+
+        mock_input.assert_not_called()
+        assert result["status"] == "success"
+        assert "**REDACTED**" in result["content"][0]["text"]


### PR DESCRIPTION
## Description

The `use_aws` tool returns boto3 responses verbatim to LLM context with no redaction. Credential-returning read operations (e.g., `sts.get_session_token`, `secretsmanager.get_secret_value`, `ecr.get_authorization_token`) bypass the existing mutative-operation consent gate, allowing credentials to land in conversation history, telemetry spans, and session storage.

This PR adds two layers of defense:

1. **Response redaction**: A recursive function scrubs known credential keys (`SecretAccessKey`, `SessionToken`, `SecretString`, `authorizationToken`, `Password`, etc.) from all boto3 responses before returning to LLM context. Redaction applies unconditionally, including when `BYPASS_TOOL_CONSENT` is set.

2. **Consent gate for sensitive reads**: A set of `(service, operation)` tuples that return credentials now triggers user confirmation even though they are not mutative. This adds friction for the accidental case where an LLM innocently calls a credential-returning API.

3. **IAM security guidance**: Updated the module docstring with recommendations for least-privilege IAM policies.

Note: agents with shell access can retrieve credentials via `aws configure export-credentials` or instance metadata regardless of this fix. The primary value here is data hygiene (preventing credentials from persisting in logs/context), not access control against adversarial prompt injection.

## Type of Change

Bug fix

## Testing

- All 49 unit tests pass
- Live tested against real AWS: confirmed ECR `authorizationToken` and SecretsManager `SecretString` are redacted in actual responses
- Confirmed `NextToken` and other pagination fields are NOT redacted (no false positives)
- Confirmed `BYPASS_TOOL_CONSENT=true` skips prompt but redaction still applies

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.