### PR TITLE
fix(retrieve): break long parametrize line to fix E501 lint error

### DIFF
--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -162,7 +162,12 @@ def test_format_results_for_display():
             "KENDRA",
             "https://kendra.aws/documents/doc-12345",
         ),
-        ("sqlLocation", {"query": "SELECT * FROM documents WHERE id = 1"}, "SQL", "SELECT * FROM documents WHERE id = 1"),
+        (
+            "sqlLocation",
+            {"query": "SELECT * FROM documents WHERE id = 1"},
+            "SQL",
+            "SELECT * FROM documents WHERE id = 1",
+        ),
     ],
 )
 def test_format_results_for_display_location_types(location_key, location_data, location_type, expected_doc_id):


### PR DESCRIPTION
Fixes the remaining E501 lint error flagged in the [latest review](https://github.com/strands-agents/tools/pull/465#discussion_r3249273684) on PR #465.

Line 165 in `tests/test_retrieve.py` was 122 characters, exceeding the 120 character limit. Reformatted the `sqlLocation` parametrize entry to match the multi-line tuple style used by all other entries.

All 30 tests pass ✅

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.