### PR TITLE
fix(retrieve): break long parametrize line to satisfy E501 lint rule

### DIFF
--- a/src/strands_tools/retrieve.py
+++ b/src/strands_tools/retrieve.py
@@ -205,6 +205,20 @@ def filter_results_by_score(results: List[Dict[str, Any]], min_score: float) -> 
     return [result for result in results if result.get("score", 0.0) >= min_score]
 
 
+# Mapping of RetrievalResultLocation types to their document identifier fields.
+# See: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_RetrievalResultLocation.html
+_LOCATION_FIELD_MAP = {
+    "customDocumentLocation": "id",
+    "s3Location": "uri",
+    "webLocation": "url",
+    "confluenceLocation": "url",
+    "salesforceLocation": "url",
+    "sharePointLocation": "url",
+    "kendraDocumentLocation": "uri",
+    "sqlLocation": "query",
+}
+
+
 def format_results_for_display(results: List[Dict[str, Any]], enable_metadata: bool = False) -> str:
     """
     Format retrieval results for readable display.
@@ -229,22 +243,10 @@ def format_results_for_display(results: List[Dict[str, Any]], enable_metadata: b
         # Extract document location - handle all RetrievalResultLocation types
         location = result.get("location", {})
         doc_id = "Unknown"
-        if "customDocumentLocation" in location:
-            doc_id = location["customDocumentLocation"].get("id", "Unknown")
-        elif "s3Location" in location:
-            doc_id = location["s3Location"].get("uri", "")
-        elif "webLocation" in location:
-            doc_id = location["webLocation"].get("url", "")
-        elif "confluenceLocation" in location:
-            doc_id = location["confluenceLocation"].get("url", "")
-        elif "salesforceLocation" in location:
-            doc_id = location["salesforceLocation"].get("url", "")
-        elif "sharePointLocation" in location:
-            doc_id = location["sharePointLocation"].get("url", "")
-        elif "kendraDocumentLocation" in location:
-            doc_id = location["kendraDocumentLocation"].get("uri", "")
-        elif "sqlLocation" in location:
-            doc_id = location["sqlLocation"].get("query", "")
+        for loc_key, field in _LOCATION_FIELD_MAP.items():
+            if loc_key in location:
+                doc_id = location[loc_key].get(field, "Unknown")
+                break
         score = result.get("score", 0.0)
         formatted.append(f"\nScore: {score:.4f}")
         formatted.append(f"Document ID: {doc_id}")

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -134,118 +134,49 @@ def test_format_results_for_display():
     assert "Content: S3 content" in s3_formatted
 
 
-def test_format_results_for_display_web_location():
-    """Test format_results_for_display with webLocation."""
+@pytest.mark.parametrize(
+    "location_key,location_data,location_type,expected_doc_id",
+    [
+        ("webLocation", {"url": "https://example.com/docs/page.html"}, "WEB", "https://example.com/docs/page.html"),
+        (
+            "confluenceLocation",
+            {"url": "https://mycompany.atlassian.net/wiki/spaces/DOC/pages/123"},
+            "CONFLUENCE",
+            "https://mycompany.atlassian.net/wiki/spaces/DOC/pages/123",
+        ),
+        (
+            "salesforceLocation",
+            {"url": "https://mycompany.salesforce.com/articles/KB001"},
+            "SALESFORCE",
+            "https://mycompany.salesforce.com/articles/KB001",
+        ),
+        (
+            "sharePointLocation",
+            {"url": "https://mycompany.sharepoint.com/sites/docs/page.aspx"},
+            "SHAREPOINT",
+            "https://mycompany.sharepoint.com/sites/docs/page.aspx",
+        ),
+        (
+            "kendraDocumentLocation",
+            {"uri": "https://kendra.aws/documents/doc-12345"},
+            "KENDRA",
+            "https://kendra.aws/documents/doc-12345",
+        ),
+        ("sqlLocation", {"query": "SELECT * FROM documents WHERE id = 1"}, "SQL", "SELECT * FROM documents WHERE id = 1"),
+    ],
+)
+def test_format_results_for_display_location_types(location_key, location_data, location_type, expected_doc_id):
+    """Test format_results_for_display with all supported RetrievalResultLocation types."""
     test_results = [
         {
-            "content": {"text": "Web content", "type": "TEXT"},
-            "location": {
-                "webLocation": {"url": "https://example.com/docs/page.html"},
-                "type": "WEB",
-            },
-            "score": 0.85,
-        }
-    ]
-
-    formatted = retrieve.format_results_for_display(test_results)
-    assert "Score: 0.8500" in formatted
-    assert "Document ID: https://example.com/docs/page.html" in formatted
-    assert "Content: Web content" in formatted
-
-
-def test_format_results_for_display_confluence_location():
-    """Test format_results_for_display with confluenceLocation."""
-    test_results = [
-        {
-            "content": {"text": "Confluence content", "type": "TEXT"},
-            "location": {
-                "confluenceLocation": {"url": "https://mycompany.atlassian.net/wiki/spaces/DOC/pages/123"},
-                "type": "CONFLUENCE",
-            },
-            "score": 0.78,
-        }
-    ]
-
-    formatted = retrieve.format_results_for_display(test_results)
-    assert "Score: 0.7800" in formatted
-    assert "Document ID: https://mycompany.atlassian.net/wiki/spaces/DOC/pages/123" in formatted
-    assert "Content: Confluence content" in formatted
-
-
-def test_format_results_for_display_salesforce_location():
-    """Test format_results_for_display with salesforceLocation."""
-    test_results = [
-        {
-            "content": {"text": "Salesforce content", "type": "TEXT"},
-            "location": {
-                "salesforceLocation": {"url": "https://mycompany.salesforce.com/articles/KB001"},
-                "type": "SALESFORCE",
-            },
-            "score": 0.72,
-        }
-    ]
-
-    formatted = retrieve.format_results_for_display(test_results)
-    assert "Score: 0.7200" in formatted
-    assert "Document ID: https://mycompany.salesforce.com/articles/KB001" in formatted
-    assert "Content: Salesforce content" in formatted
-
-
-def test_format_results_for_display_sharepoint_location():
-    """Test format_results_for_display with sharePointLocation."""
-    test_results = [
-        {
-            "content": {"text": "SharePoint content", "type": "TEXT"},
-            "location": {
-                "sharePointLocation": {"url": "https://mycompany.sharepoint.com/sites/docs/page.aspx"},
-                "type": "SHAREPOINT",
-            },
+            "content": {"text": "Test content", "type": "TEXT"},
+            "location": {location_key: location_data, "type": location_type},
             "score": 0.80,
         }
     ]
-
     formatted = retrieve.format_results_for_display(test_results)
-    assert "Score: 0.8000" in formatted
-    assert "Document ID: https://mycompany.sharepoint.com/sites/docs/page.aspx" in formatted
-    assert "Content: SharePoint content" in formatted
-
-
-def test_format_results_for_display_kendra_location():
-    """Test format_results_for_display with kendraDocumentLocation."""
-    test_results = [
-        {
-            "content": {"text": "Kendra content", "type": "TEXT"},
-            "location": {
-                "kendraDocumentLocation": {"uri": "https://kendra.aws/documents/doc-12345"},
-                "type": "KENDRA",
-            },
-            "score": 0.91,
-        }
-    ]
-
-    formatted = retrieve.format_results_for_display(test_results)
-    assert "Score: 0.9100" in formatted
-    assert "Document ID: https://kendra.aws/documents/doc-12345" in formatted
-    assert "Content: Kendra content" in formatted
-
-
-def test_format_results_for_display_sql_location():
-    """Test format_results_for_display with sqlLocation."""
-    test_results = [
-        {
-            "content": {"text": "SQL content", "type": "TEXT"},
-            "location": {
-                "sqlLocation": {"query": "SELECT * FROM documents WHERE id = 1"},
-                "type": "SQL",
-            },
-            "score": 0.65,
-        }
-    ]
-
-    formatted = retrieve.format_results_for_display(test_results)
-    assert "Score: 0.6500" in formatted
-    assert "Document ID: SELECT * FROM documents WHERE id = 1" in formatted
-    assert "Content: SQL content" in formatted
+    assert f"Document ID: {expected_doc_id}" in formatted
+    assert "Content: Test content" in formatted
 
 
 def test_format_results_for_display_unknown_location():

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -162,7 +162,12 @@ def test_format_results_for_display():
             "KENDRA",
             "https://kendra.aws/documents/doc-12345",
         ),
-        ("sqlLocation", {"query": "SELECT * FROM documents WHERE id = 1"}, "SQL", "SELECT * FROM documents WHERE id = 1"),
+        (
+            "sqlLocation",
+            {"query": "SELECT * FROM documents WHERE id = 1"},
+            "SQL",
+            "SELECT * FROM documents WHERE id = 1",
+        ),
     ],
 )
 def test_format_results_for_display_location_types(location_key, location_data, location_type, expected_doc_id):


### PR DESCRIPTION
## Description

Fixes the E501 lint failure on PR #465.

Line 165 in `tests/test_retrieve.py` was 122 characters, exceeding the 120 char limit.
Reformatted the `sqlLocation` test tuple to multi-line format, consistent with the other `@pytest.mark.parametrize` entries.

## Changes

- Break single-line `sqlLocation` parametrize tuple into multi-line format
- No logic changes

## Verification

```
$ ruff check tests/test_retrieve.py src/strands_tools/retrieve.py
All checks passed!
```