### PR TITLE
fix: add AST validation to prevent code execution in calculator tool

### DIFF
--- a/src/strands_tools/calculator.py
+++ b/src/strands_tools/calculator.py
@@ -287,7 +287,7 @@ def _validate_expression_ast(expr_str: str) -> None:
     try:
         tree = ast.parse(expr_str, mode="eval")
     except SyntaxError as e:
-        raise ValueError(f"Invalid mathematical expression: {e.msg}")
+        raise ValueError(f"Invalid mathematical expression: {e.msg}") from e
 
     for node in ast.walk(tree):
         if type(node) not in _ALLOWED_AST_NODES:
@@ -712,7 +712,6 @@ def calculate_series(expr: Any, var: str, point: str, order: int) -> Any:
         return sp.series(expr, var_sym, point_val, order)
     except Exception as e:
         raise ValueError(f"Series expansion error: {str(e)}") from e
-
 
 
 @tool

--- a/src/strands_tools/calculator.py
+++ b/src/strands_tools/calculator.py
@@ -1,10 +1,16 @@
 """
 Calculator tool powered by SymPy for comprehensive mathematical operations.
 
-This module provides a powerful mathematical calculation engine built on SymPy
+This module provides a mathematical calculation engine built on SymPy
 that can handle everything from basic arithmetic to advanced calculus, equation solving,
-and matrix operations. It's designed to provide formatted, precise results with
+and matrix operations. It provides formatted, precise results with
 proper error handling and robust type conversion.
+
+Security:
+    All expressions are validated against an AST allowlist before evaluation.
+    Only mathematical syntax (operators, function calls, literals, names, containers)
+    is permitted. Attribute access, subscripts, lambdas, comprehensions, and imports
+    are rejected, preventing code execution via eval.
 
 Key Features:
 1. Expression Evaluation:
@@ -19,7 +25,7 @@ Key Features:
    • Integration (indefinite integrals)
    • Limit calculation (at specified points or infinity)
    • Series expansions (Taylor and Laurent series)
-   • Matrix operations (determinants, multiplication, etc.)
+   • Matrix operations (det, transpose, trace, arithmetic)
 
 3. Display and Formatting:
    • Configurable precision for numeric results
@@ -34,7 +40,7 @@ from strands_tools import calculator
 
 agent = Agent(tools=[calculator])
 
-# Basic arithmetic evaluation
+# Basic arithmetic (expressions must be valid Python with explicit operators)
 agent.tool.calculator(expression="2 * sin(pi/4) + log(e**2)")
 
 # Equation solving
@@ -54,6 +60,9 @@ agent.tool.calculator(
     mode="integrate",
     wrt="x"
 )
+
+# Matrix determinant
+agent.tool.calculator(expression="det(Matrix([[1, 2], [3, 4]]))")
 ```
 
 See the calculator function docstring for more details on available modes and parameters.
@@ -184,6 +193,10 @@ _SAFE_SYMPY_LOCALS: Dict[str, Any] = {
     "Symbol": sp.Symbol,
     "symbols": sp.symbols,
     "N": sp.N,
+    # Matrix operations
+    "det": sp.det,
+    "transpose": sp.transpose,
+    "trace": sp.trace,
     # Solving/simplification
     "solve": sp.solve,
     "simplify": sp.simplify,
@@ -209,14 +222,90 @@ _SAFE_GLOBALS: Dict[str, Any] = {
 }
 
 
+_ALLOWED_AST_NODES = {
+    # Structural
+    ast.Expression,
+    # Literals
+    ast.Constant,
+    # Names and loading
+    ast.Name,
+    ast.Load,
+    # Expressions
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.BoolOp,
+    ast.Compare,
+    ast.IfExp,
+    ast.Call,
+    # Operators
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.FloorDiv,
+    ast.Mod,
+    ast.Pow,
+    ast.USub,
+    ast.UAdd,
+    ast.BitXor,  # used for exponentiation via convert_xor
+    # Comparisons (needed for Eq() style expressions)
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+    # Containers (for Matrix([[...]]), function args, etc.)
+    ast.Tuple,
+    ast.List,
+    # Boolean
+    ast.And,
+    ast.Or,
+    ast.Not,
+    # Star args (for function calls like Max(*values))
+    ast.Starred,
+    # keyword arguments (for Symbol('x', positive=True) style calls)
+    ast.keyword,
+}
+
+
+def _validate_expression_ast(expr_str: str) -> None:
+    """Reject expressions containing attribute access, subscripts, or other unsafe syntax.
+
+    This blocks attacks like:
+        solve.__globals__['__builtins__']['__import__']('os').system('...')
+
+    Only pure mathematical expressions (calls, operators, literals, names, containers)
+    are permitted. Inputs that are not valid Python are rejected outright.
+
+    Args:
+        expr_str: The raw expression string to validate.
+
+    Raises:
+        ValueError: If the expression contains disallowed syntax or is not valid Python.
+    """
+    try:
+        tree = ast.parse(expr_str, mode="eval")
+    except SyntaxError as e:
+        raise ValueError(f"Invalid mathematical expression: {e.msg}")
+
+    for node in ast.walk(tree):
+        if type(node) not in _ALLOWED_AST_NODES:
+            raise ValueError(f"Invalid mathematical expression: unsupported syntax '{type(node).__name__}'")
+
+
 def parse_expression(expr_str: str) -> Any:
     """Parse a string expression into a SymPy expression safely.
 
-    Uses sympy.parsing.sympy_parser.parse_expr with a restricted local_dict
+    Validates the expression AST against an allowlist of safe node types,
+    then uses sympy.parsing.sympy_parser.parse_expr with a restricted local_dict
     and empty __builtins__ to prevent code execution via eval.
     """
     if not isinstance(expr_str, str):
         raise ValueError("Expression must be a string")
+
+    # Validate AST before eval to block attribute traversal attacks
+    _validate_expression_ast(expr_str)
 
     transformations = standard_transformations + (
         implicit_multiplication_application,
@@ -625,37 +714,6 @@ def calculate_series(expr: Any, var: str, point: str, order: int) -> Any:
         raise ValueError(f"Series expansion error: {str(e)}") from e
 
 
-def parse_matrix_expression(expr_str: str) -> Any:
-    """Parse matrix expression and perform operations."""
-    try:
-        # Function to safely convert string to matrix
-        def safe_matrix_from_str(matrix_str: str) -> Any:
-            # Use ast.literal_eval for safe evaluation of matrix literals
-            try:
-                matrix_data = ast.literal_eval(matrix_str.strip())
-                return sp.Matrix(matrix_data)
-            except (ValueError, SyntaxError) as e:
-                raise ValueError(f"Invalid matrix format: {str(e)}") from e
-
-        # Split into parts for operations
-        parts = expr_str.split("*")
-        if len(parts) == 2:
-            # Handle multiplication
-            matrix1 = safe_matrix_from_str(parts[0])
-            matrix2 = safe_matrix_from_str(parts[1])
-            return matrix1 * matrix2
-        elif "+" in expr_str:
-            # Handle addition
-            parts = expr_str.split("+")
-            matrix1 = safe_matrix_from_str(parts[0])
-            matrix2 = safe_matrix_from_str(parts[1])
-            return matrix1 + matrix2
-        else:
-            # Single matrix operations
-            return safe_matrix_from_str(expr_str)
-    except Exception as e:
-        raise ValueError(f"Matrix parsing error: {str(e)}") from e
-
 
 @tool
 def calculator(
@@ -706,9 +764,11 @@ def calculator(
     - Data science: Matrix operations and statistical calculations
 
     Args:
-        expression: The mathematical expression to evaluate, such as "2 + 2 * 3",
-            "x**2 + 2*x + 1", or "sin(pi/2)". For matrix operations, use array
-            notation like "[[1, 2], [3, 4]]".
+        expression: A SymPy-compatible mathematical expression written in valid Python
+            syntax. Use explicit operators and SymPy function names (e.g., "2*x + 1",
+            "sin(pi/2)", "factorial(5)", "Abs(x)", "Eq(x**2, 4)").
+            For matrix operations, use Matrix() with functions like det(),
+            transpose(), or trace().
         mode: The calculation mode to use. Options are:
             - "evaluate": Compute the value of the expression (default)
             - "solve": Solve an equation or system of equations
@@ -768,10 +828,7 @@ def calculator(
         variables = variables or {}
 
         # Parse the expression
-        if mode == "matrix":
-            expr = parse_matrix_expression(expression)
-        else:
-            expr = parse_expression(expression)
+        expr = parse_expression(expression)
 
         # Process based on mode
         additional_info = {}

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -24,7 +24,6 @@ from src.strands_tools.calculator import (
     get_precision_level,
     numeric_evaluation,
     parse_expression,
-    parse_matrix_expression,
     preprocess_expression,
     solve_equation,
 )
@@ -109,20 +108,20 @@ def test_equation_solving(agent):
 def test_matrix_operations(agent):
     """Test matrix operations."""
     # Test matrix addition
-    result = agent.tool.calculator(expression="[[1, 2], [3, 4]] + [[5, 6], [7, 8]]", mode="matrix")
+    result = agent.tool.calculator(expression="Matrix([[1, 2], [3, 4]]) + Matrix([[5, 6], [7, 8]])", mode="matrix")
     result_text = extract_result_text(result)
     assert "6" in result_text and "8" in result_text and "10" in result_text and "12" in result_text
 
     # Test matrix multiplication
-    result = agent.tool.calculator(expression="[[1, 2], [3, 4]] * [[5, 6], [7, 8]]", mode="matrix")
+    result = agent.tool.calculator(expression="Matrix([[1, 2], [3, 4]]) * Matrix([[5, 6], [7, 8]])", mode="matrix")
     result_text = extract_result_text(result)
     # Result should be [[19, 22], [43, 50]]
     assert "19" in result_text and "22" in result_text and "43" in result_text and "50" in result_text
 
-    # Test determinant (implicitly)
-    result = agent.tool.calculator(expression="[[1, 2], [3, 4]]", mode="matrix")
+    # Test determinant
+    result = agent.tool.calculator(expression="det(Matrix([[1, 2], [3, 4]]))")
     result_text = extract_result_text(result)
-    assert "Matrix" in result_text or "1" in result_text  # Either the matrix itself or its determinant
+    assert "-2" in result_text
 
 
 def test_scientific_notation_and_precision(agent):
@@ -147,11 +146,11 @@ def test_parse_expression_edge_cases():
         parse_expression(123)
 
     # Test with invalid syntax
-    with pytest.raises(ValueError, match="Invalid"):
+    with pytest.raises(ValueError):
         parse_expression("2 **/ 3")
 
     # Test with logical operators (invalid Python syntax)
-    with pytest.raises(ValueError, match="Invalid"):
+    with pytest.raises(ValueError):
         parse_expression("x && y")
 
     # Test that floor division is handled (parse_expr supports it)
@@ -397,17 +396,6 @@ def test_create_error_panel():
     mock_console.print.assert_called_once()
 
 
-def test_parse_matrix_expression_errors():
-    """Test error handling in parse_matrix_expression function."""
-    # Test with invalid matrix format
-    with pytest.raises(ValueError, match="Invalid matrix format"):
-        parse_matrix_expression("[[1, 2], [3]]")
-
-    # Test with general error
-    with pytest.raises(ValueError, match="Matrix parsing error"):
-        parse_matrix_expression("not_a_matrix")
-
-
 def test_evaluate_expression_comprehensive():
     """Test comprehensive evaluation of expressions."""
     # Test basic numeric evaluation
@@ -437,11 +425,6 @@ def test_edge_case_error_handling(agent):
     """Test more edge cases for error handling."""
     # Test with unsupported operators
     result = agent.tool.calculator(expression="x && y")
-    result_text = extract_result_text(result)
-    assert "Error" in result_text
-
-    # Test with invalid matrix input
-    result = agent.tool.calculator(expression="[[1, 2], [3]]", mode="matrix")
     result_text = extract_result_text(result)
     assert "Error" in result_text
 
@@ -654,9 +637,64 @@ def test_error_handling(agent):
     ],
 )
 def test_code_execution_blocked(payload, mock_target):
-    """Verify that malicious payloads cannot achieve code execution via parse_expression."""
+    """Verify that malicious payloads cannot achieve code execution via the calculator tool."""
     with mock.patch(mock_target) as mock_fn:
         result = calculator_func(expression=payload, mode="evaluate")
         assert result["status"] == "error"
-        assert "Invalid mathematical expression:" in result["content"][0]["text"]
+        assert "Invalid mathematical expression" in result["content"][0]["text"]
         mock_fn.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # Attribute traversal via __globals__
+        "solve.__globals__['__builtins__']['__import__']('os').system('id')",
+        "simplify.__globals__['__builtins__']['__import__']('os').getpid()",
+        "N.__globals__['__builtins__']['__import__']('subprocess').run(['id'])",
+        # Attribute traversal via __class__
+        "solve.__class__.__bases__[0].__subclasses__()",
+        "(1).__class__.__bases__[0].__subclasses__()",
+        # Direct attribute access
+        "solve.__module__",
+        "solve.__name__",
+        # Subscript access
+        "solve.__globals__['os']",
+        # Lambda and comprehensions
+        "(lambda: __import__('os'))()",
+        "[x for x in ().__class__.__bases__[0].__subclasses__()]",
+        # Invalid Python (implicit multiplication, assignment, import)
+        "2x",
+        "2sin(x)",
+        "x = 5",
+        "import os",
+    ],
+)
+def test_ast_validation_rejects_unsafe_input(payload):
+    """Verify that AST validation rejects unsafe or non-Python syntax."""
+    with pytest.raises(ValueError, match="Invalid mathematical expression"):
+        parse_expression(payload)
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "2 + 3",
+        "sin(pi/4)",
+        "sqrt(2)",
+        "factorial(10)",
+        "Matrix([[1,2],[3,4]])",
+        "Eq(x**2, 4)",
+        "Max(1, 2, 3)",
+        "2^10",
+        "2*x + 3*y",
+        "log(e**2) + sin(pi)",
+        "det(Matrix([[1, 2], [3, 4]]))",
+        "transpose(Matrix([[1, 2], [3, 4]]))",
+        "trace(Matrix([[1, 0], [0, 5]]))",
+    ],
+)
+def test_ast_validation_allows_legitimate_math(expression):
+    """Verify that AST validation permits valid mathematical expressions."""
+    result = parse_expression(expression)
+    assert result is not None


### PR DESCRIPTION
## Description

The calculator tool's `parse_expression` function passes user input to sympy's `parse_expr`, which internally calls `eval()`. While `__builtins__` was set to `{}` in the global dict, function objects exposed in the local namespace (solve, simplify, N, etc.) could be used to traverse `__globals__` and reach `__builtins__['__import__']`, achieving arbitrary code execution.

This PR adds AST validation that runs before `parse_expr`. Only a strict allowlist of node types (operators, calls, literals, names, containers) is permitted. Attribute access, subscripts, lambdas, comprehensions, and imports are all rejected.

Additionally:
- Adds `det`, `transpose`, and `trace` as standalone functions so matrix operations work without method-style attribute access
- Removes the now-unused `parse_matrix_expression` function
- Updates the tool description to clarify that expressions must be valid Python with explicit operators

## Consequences

**Breaking change:** implicit multiplication (`2x`, `2sin(x)`) is no longer supported. Expressions must use explicit operators (`2*x`, `2*sin(x)`). In practice, models already write explicit operators when the tool description asks for them, and self-correct within one retry if they don't.

**Matrix operations:** method-style calls like `Matrix(...).det()` are blocked (attribute access). Models use functional style instead: `det(Matrix(...))`, `transpose(Matrix(...))`, `trace(Matrix(...))`. For inverse, `Matrix(...)**(-1)` works via the exponent operator.

**`eval()` remains in the chain:** sympy's `parse_expr` still calls `eval()` internally. The AST validation guarantees that only safe node types reach it, so there is no reachable path to code execution.

## Type of Change

Bug fix

## Testing

- Added 14 parametrized attack vector tests covering globals traversal, class traversal, subscript access, lambdas, comprehensions, and invalid syntax
- Added 13 parametrized legitimate-expression tests including matrix functions
- Retained 3 end-to-end tests that mock dangerous functions and verify they are never called
- All 61 tests pass
- Verified with a live agent that the model correctly formats expressions with the updated tool description

- [x] I ran tests via `python -m pytest tests/test_calculator.py`

## Checklist
- [x] I have added necessary tests that prove my fix is effective
- [x] I have updated the documentation accordingly (module docstring, tool description)
- [x] My changes generate no new warnings