### PR TITLE
fix: add default timeout to http_request to prevent indefinite blocking

### DIFF
--- a/src/strands_tools/http_request.py
+++ b/src/strands_tools/http_request.py
@@ -150,7 +150,7 @@ TOOL_SPEC = {
                 },
                 "timeout": {
                     "type": "number",
-                    "description": "Request timeout in seconds (default: 30). Set to None for no timeout.",
+                    "description": "Request timeout in seconds (default: 30). Use a very large value (e.g. 9999) for effectively no timeout.",
                 },
                 "convert_to_markdown": {
                     "type": "boolean",

--- a/src/strands_tools/http_request.py
+++ b/src/strands_tools/http_request.py
@@ -150,7 +150,7 @@ TOOL_SPEC = {
                 },
                 "timeout": {
                     "type": "number",
-                    "description": "Request timeout in seconds (default: 30). Use a very large value (e.g. 9999) for effectively no timeout.",
+                    "description": "Request timeout in seconds (default: 30). Use a large value for no timeout.",
                 },
                 "convert_to_markdown": {
                     "type": "boolean",

--- a/src/strands_tools/http_request.py
+++ b/src/strands_tools/http_request.py
@@ -148,6 +148,10 @@ TOOL_SPEC = {
                     "type": "integer",
                     "description": "Maximum number of redirects to follow (default: 30)",
                 },
+                "timeout": {
+                    "type": "number",
+                    "description": "Request timeout in seconds (default: 30). Set to None for no timeout.",
+                },
                 "convert_to_markdown": {
                     "type": "boolean",
                     "description": "Convert HTML responses to markdown format (default: False).",
@@ -879,6 +883,9 @@ def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
         if body:
             request_kwargs["data"] = body
 
+        # Set default timeout (30s) to prevent indefinite blocking
+        request_kwargs.setdefault("timeout", tool_input.get("timeout", 30))
+
         # Execute request with metrics
         start_time = time.time()
         response = session.request(**request_kwargs)
@@ -1022,3 +1029,4 @@ def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
             "status": "error",
             "content": [{"text": error_text}],
         }
+

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -1301,7 +1301,7 @@ def test_timeout_default_value_passed_to_request():
             mock_session.cookies = {}
             mock_get_session.return_value = mock_session
 
-            result = http_request.http_request(tool=tool_use)
+            http_request.http_request(tool=tool_use)
 
             # Verify timeout=30 was passed to session.request
             call_kwargs = mock_session.request.call_args[1]
@@ -1335,7 +1335,7 @@ def test_custom_timeout_value_passed_to_request():
             mock_session.cookies = {}
             mock_get_session.return_value = mock_session
 
-            result = http_request.http_request(tool=tool_use)
+            http_request.http_request(tool=tool_use)
 
             call_kwargs = mock_session.request.call_args[1]
             assert call_kwargs["timeout"] == 120

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -1186,12 +1186,125 @@ def test_proxy_support():
 
 @responses.activate
 def test_payment_required_header_in_response():
-    """Test that Payment-Required header is handled gracefully."""
+    """Test that Payment-Required header is captured in response."""
+    # Set up mock response with Payment-Required header
+    responses.add(
+        responses.GET,
+        "https://api.example.com/premium-feature",
+        json={"error": "payment required"},
+        status=402,
+        headers={"Payment-Required": "true"},
+        content_type="application/json",
+    )
+
+    tool_use = {
+        "toolUseId": "test-payment-required-id",
+        "input": {
+            "method": "GET",
+            "url": "https://api.example.com/premium-feature",
+        },
+    }
+
+    with patch("strands_tools.http_request.get_user_input") as mock_input:
+        mock_input.return_value = "y"
+        result = http_request.http_request(tool=tool_use)
+
+    assert result["status"] == "success"
+    result_text = extract_result_text(result)
+
+    # Verify Payment-Required header is in the response
+    assert "Payment-Required" in result_text
+    assert "true" in result_text
+    assert "Status Code: 402" in result_text
+
+
+@responses.activate
+def test_payment_required_header_with_other_headers():
+    """Test Payment-Required header is captured alongside other important headers."""
+    # Set up mock response with multiple important headers
+    responses.add(
+        responses.GET,
+        "https://api.example.com/data",
+        json={"data": "test"},
+        status=200,
+        headers={
+            "Date": "Mon, 24 Mar 2026 12:00:00 GMT",
+            "Server": "nginx/1.20.0",
+            "Payment-Required": "false",
+            "X-Custom-Header": "should-not-appear",
+        },
+        content_type="application/json",
+    )
+
+    tool_use = {
+        "toolUseId": "test-multiple-headers-id",
+        "input": {
+            "method": "GET",
+            "url": "https://api.example.com/data",
+        },
+    }
+
+    with patch("strands_tools.http_request.get_user_input") as mock_input:
+        mock_input.return_value = "y"
+        result = http_request.http_request(tool=tool_use)
+
+    assert result["status"] == "success"
+    result_text = extract_result_text(result)
+
+    # Verify important headers are present
+    assert "Content-Type" in result_text
+    assert "Server" in result_text
+    assert "Payment-Required" in result_text
+
+    # Verify custom headers are not included
+    assert "X-Custom-Header" not in result_text
+
+
+@responses.activate
+def test_payment_required_header_case_insensitive():
+    """Test that Payment-Required header is matched case-insensitively."""
+    # Set up mock response with lowercase payment-required header
+    responses.add(
+        responses.GET,
+        "https://api.example.com/check",
+        json={"status": "ok"},
+        status=200,
+        headers={"payment-required": "false"},
+        content_type="application/json",
+    )
+
+    tool_use = {
+        "toolUseId": "test-case-insensitive-id",
+        "input": {
+            "method": "GET",
+            "url": "https://api.example.com/check",
+        },
+    }
+
+    with patch("strands_tools.http_request.get_user_input") as mock_input:
+        mock_input.return_value = "y"
+        result = http_request.http_request(tool=tool_use)
+
+    assert result["status"] == "success"
+    result_text = extract_result_text(result)
+
+    # Verify the header is captured regardless of case
+    assert "payment-required" in result_text.lower()
+
+
+@responses.activate
+def test_payment_required_header_missing():
+    """Test response when Payment-Required header is not present."""
+    # Set up mock response without Payment-Required header
     responses.add(
         responses.GET,
         "https://api.example.com/free-feature",
-        json={"feature": "free"},
+        json={"data": "free content"},
         status=200,
+        headers={
+            "Server": "nginx",
+        },
+        content_type="application/json",
     )
 
     tool_use = {
@@ -1208,64 +1321,11 @@ def test_payment_required_header_in_response():
 
     assert result["status"] == "success"
     result_text = extract_result_text(result)
+
+    # Verify response is successful even without Payment-Required header
     assert "Status Code: 200" in result_text
+    # The headers dict should still be present but without Payment-Required
     assert "Headers:" in result_text
-
-
-@responses.activate
-def test_default_timeout():
-    """Test that a default timeout of 30s is applied when not specified."""
-    responses.add(
-        responses.GET,
-        "https://example.com/api/timeout-test",
-        json={"status": "ok"},
-        status=200,
-    )
-
-    tool_use = {
-        "toolUseId": "test-timeout-id",
-        "input": {
-            "method": "GET",
-            "url": "https://example.com/api/timeout-test",
-        },
-    }
-
-    http_request.SESSION_CACHE.clear()
-    with patch("strands_tools.http_request.get_user_input") as mock_input:
-        mock_input.return_value = "y"
-        result = http_request.http_request(tool=tool_use)
-
-    assert result["status"] == "success"
-    # The request should have been made (responses intercepts it)
-    assert len(responses.calls) == 1
-
-
-@responses.activate
-def test_custom_timeout():
-    """Test that a custom timeout overrides the default."""
-    responses.add(
-        responses.GET,
-        "https://example.com/api/custom-timeout",
-        json={"status": "ok"},
-        status=200,
-    )
-
-    tool_use = {
-        "toolUseId": "test-custom-timeout-id",
-        "input": {
-            "method": "GET",
-            "url": "https://example.com/api/custom-timeout",
-            "timeout": 60,
-        },
-    }
-
-    http_request.SESSION_CACHE.clear()
-    with patch("strands_tools.http_request.get_user_input") as mock_input:
-        mock_input.return_value = "y"
-        result = http_request.http_request(tool=tool_use)
-
-    assert result["status"] == "success"
-    assert len(responses.calls) == 1
 
 
 @responses.activate

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -1186,125 +1186,12 @@ def test_proxy_support():
 
 @responses.activate
 def test_payment_required_header_in_response():
-    """Test that Payment-Required header is captured in response."""
-    # Set up mock response with Payment-Required header
-    responses.add(
-        responses.GET,
-        "https://api.example.com/premium-feature",
-        json={"error": "payment required"},
-        status=402,
-        headers={"Payment-Required": "true"},
-        content_type="application/json",
-    )
-
-    tool_use = {
-        "toolUseId": "test-payment-required-id",
-        "input": {
-            "method": "GET",
-            "url": "https://api.example.com/premium-feature",
-        },
-    }
-
-    with patch("strands_tools.http_request.get_user_input") as mock_input:
-        mock_input.return_value = "y"
-        result = http_request.http_request(tool=tool_use)
-
-    assert result["status"] == "success"
-    result_text = extract_result_text(result)
-
-    # Verify Payment-Required header is in the response
-    assert "Payment-Required" in result_text
-    assert "true" in result_text
-    assert "Status Code: 402" in result_text
-
-
-@responses.activate
-def test_payment_required_header_with_other_headers():
-    """Test Payment-Required header is captured alongside other important headers."""
-    # Set up mock response with multiple important headers
-    responses.add(
-        responses.GET,
-        "https://api.example.com/data",
-        json={"data": "test"},
-        status=200,
-        headers={
-            "Date": "Mon, 24 Mar 2026 12:00:00 GMT",
-            "Server": "nginx/1.20.0",
-            "Payment-Required": "false",
-            "X-Custom-Header": "should-not-appear",
-        },
-        content_type="application/json",
-    )
-
-    tool_use = {
-        "toolUseId": "test-multiple-headers-id",
-        "input": {
-            "method": "GET",
-            "url": "https://api.example.com/data",
-        },
-    }
-
-    with patch("strands_tools.http_request.get_user_input") as mock_input:
-        mock_input.return_value = "y"
-        result = http_request.http_request(tool=tool_use)
-
-    assert result["status"] == "success"
-    result_text = extract_result_text(result)
-
-    # Verify important headers are present
-    assert "Content-Type" in result_text
-    assert "Server" in result_text
-    assert "Payment-Required" in result_text
-
-    # Verify custom headers are not included
-    assert "X-Custom-Header" not in result_text
-
-
-@responses.activate
-def test_payment_required_header_case_insensitive():
-    """Test that Payment-Required header is matched case-insensitively."""
-    # Set up mock response with lowercase payment-required header
-    responses.add(
-        responses.GET,
-        "https://api.example.com/check",
-        json={"status": "ok"},
-        status=200,
-        headers={"payment-required": "false"},
-        content_type="application/json",
-    )
-
-    tool_use = {
-        "toolUseId": "test-case-insensitive-id",
-        "input": {
-            "method": "GET",
-            "url": "https://api.example.com/check",
-        },
-    }
-
-    with patch("strands_tools.http_request.get_user_input") as mock_input:
-        mock_input.return_value = "y"
-        result = http_request.http_request(tool=tool_use)
-
-    assert result["status"] == "success"
-    result_text = extract_result_text(result)
-
-    # Verify the header is captured regardless of case
-    assert "payment-required" in result_text.lower()
-
-
-@responses.activate
-def test_payment_required_header_missing():
-    """Test response when Payment-Required header is not present."""
-    # Set up mock response without Payment-Required header
+    """Test that Payment-Required header is handled gracefully."""
     responses.add(
         responses.GET,
         "https://api.example.com/free-feature",
-        json={"data": "free content"},
+        json={"feature": "free"},
         status=200,
-        headers={
-            "Server": "nginx",
-        },
-        content_type="application/json",
     )
 
     tool_use = {
@@ -1321,8 +1208,134 @@ def test_payment_required_header_missing():
 
     assert result["status"] == "success"
     result_text = extract_result_text(result)
-
-    # Verify response is successful even without Payment-Required header
     assert "Status Code: 200" in result_text
-    # The headers dict should still be present but without Payment-Required
     assert "Headers:" in result_text
+
+
+@responses.activate
+def test_default_timeout():
+    """Test that a default timeout of 30s is applied when not specified."""
+    responses.add(
+        responses.GET,
+        "https://example.com/api/timeout-test",
+        json={"status": "ok"},
+        status=200,
+    )
+
+    tool_use = {
+        "toolUseId": "test-timeout-id",
+        "input": {
+            "method": "GET",
+            "url": "https://example.com/api/timeout-test",
+        },
+    }
+
+    http_request.SESSION_CACHE.clear()
+    with patch("strands_tools.http_request.get_user_input") as mock_input:
+        mock_input.return_value = "y"
+        result = http_request.http_request(tool=tool_use)
+
+    assert result["status"] == "success"
+    # The request should have been made (responses intercepts it)
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_custom_timeout():
+    """Test that a custom timeout overrides the default."""
+    responses.add(
+        responses.GET,
+        "https://example.com/api/custom-timeout",
+        json={"status": "ok"},
+        status=200,
+    )
+
+    tool_use = {
+        "toolUseId": "test-custom-timeout-id",
+        "input": {
+            "method": "GET",
+            "url": "https://example.com/api/custom-timeout",
+            "timeout": 60,
+        },
+    }
+
+    http_request.SESSION_CACHE.clear()
+    with patch("strands_tools.http_request.get_user_input") as mock_input:
+        mock_input.return_value = "y"
+        result = http_request.http_request(tool=tool_use)
+
+    assert result["status"] == "success"
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_timeout_default_value_passed_to_request():
+    """Test that default timeout=30 is actually passed to session.request."""
+    responses.add(
+        responses.GET,
+        "https://example.com/api/verify-timeout",
+        json={"status": "ok"},
+        status=200,
+    )
+
+    tool_use = {
+        "toolUseId": "test-verify-timeout-id",
+        "input": {
+            "method": "GET",
+            "url": "https://example.com/api/verify-timeout",
+        },
+    }
+
+    http_request.SESSION_CACHE.clear()
+    with patch("strands_tools.http_request.get_user_input") as mock_input:
+        mock_input.return_value = "y"
+        # Patch the session's request method to capture the timeout kwarg
+        with patch("strands_tools.http_request.get_cached_session") as mock_get_session:
+            mock_session = MagicMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {}
+            mock_response.content = b'{"status": "ok"}'
+            mock_response.cookies = {}
+            mock_session.request.return_value = mock_response
+            mock_session.cookies = {}
+            mock_get_session.return_value = mock_session
+
+            result = http_request.http_request(tool=tool_use)
+
+            # Verify timeout=30 was passed to session.request
+            call_kwargs = mock_session.request.call_args[1]
+            assert "timeout" in call_kwargs
+            assert call_kwargs["timeout"] == 30
+
+
+@responses.activate
+def test_custom_timeout_value_passed_to_request():
+    """Test that custom timeout value is passed to session.request."""
+    tool_use = {
+        "toolUseId": "test-custom-timeout-verify-id",
+        "input": {
+            "method": "GET",
+            "url": "https://example.com/api/custom-timeout-verify",
+            "timeout": 120,
+        },
+    }
+
+    http_request.SESSION_CACHE.clear()
+    with patch("strands_tools.http_request.get_user_input") as mock_input:
+        mock_input.return_value = "y"
+        with patch("strands_tools.http_request.get_cached_session") as mock_get_session:
+            mock_session = MagicMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {}
+            mock_response.content = b'{"status": "ok"}'
+            mock_response.cookies = {}
+            mock_session.request.return_value = mock_response
+            mock_session.cookies = {}
+            mock_get_session.return_value = mock_session
+
+            result = http_request.http_request(tool=tool_use)
+
+            call_kwargs = mock_session.request.call_args[1]
+            assert call_kwargs["timeout"] == 120


### PR DESCRIPTION
## Summary

The `http_request` tool was calling `session.request()` without a `timeout` parameter. The Python `requests` library defaults to no timeout, so a non-responsive server would block the agent indefinitely.

## Changes

- Add `timeout` to `TOOL_SPEC` input schema (default: 30 seconds)
- Set default timeout on `session.request()` call
- Allow per-request timeout override via input

## Code Changes

```python
# Before
response = session.request(**request_kwargs)

# After
request_kwargs.setdefault("timeout", tool_input.get("timeout", 30))
response = session.request(**request_kwargs)
```

## Testing

The fix is minimal and non-breaking:
- Default timeout of 30s matches industry standard
- Users can override per-request via `timeout` parameter
- Existing behavior unchanged for responsive servers

## Related Issue

Closes #442 - bug: http_request tool has no request timeout