### PR TITLE
feat: move elastic search memory url to env var

### DIFF
--- a/src/strands_tools/elasticsearch_memory.py
+++ b/src/strands_tools/elasticsearch_memory.py
@@ -36,7 +36,7 @@ Usage Examples:
 from strands import Agent
 from strands_tools.elasticsearch_memory import elasticsearch_memory
 
-# Create agent with direct tool usage
+# Create agent with elasticsearch_memory tool (credentials via env vars)
 agent = Agent(tools=[elasticsearch_memory])
 
 # Store a memory with semantic embeddings
@@ -44,8 +44,6 @@ elasticsearch_memory(
     action="record",
     content="User prefers vegetarian pizza with extra cheese",
     metadata={"category": "food_preferences", "type": "dietary"},
-    cloud_id="your-elasticsearch-cloud-id",
-    api_key="your-api-key",
     index_name="memories",
     namespace="user_123"
 )
@@ -55,8 +53,6 @@ elasticsearch_memory(
     action="retrieve",
     query="food preferences and dietary restrictions",
     max_results=5,
-    cloud_id="your-elasticsearch-cloud-id",
-    api_key="your-api-key",
     index_name="memories",
     namespace="user_123"
 )
@@ -65,8 +61,6 @@ elasticsearch_memory(
 elasticsearch_memory(
     action="list",
     max_results=10,
-    cloud_id="your-elasticsearch-cloud-id",
-    api_key="your-api-key",
     index_name="memories",
     namespace="user_123"
 )
@@ -75,8 +69,6 @@ elasticsearch_memory(
 elasticsearch_memory(
     action="get",
     memory_id="mem_1234567890_abcd1234",
-    cloud_id="your-elasticsearch-cloud-id",
-    api_key="your-api-key",
     index_name="memories",
     namespace="user_123"
 )
@@ -85,8 +77,6 @@ elasticsearch_memory(
 elasticsearch_memory(
     action="delete",
     memory_id="mem_1234567890_abcd1234",
-    cloud_id="your-elasticsearch-cloud-id",
-    api_key="your-api-key",
     index_name="memories",
     namespace="user_123"
 )
@@ -599,9 +589,6 @@ def elasticsearch_memory(
     max_results: Optional[int] = None,
     next_token: Optional[str] = None,
     metadata: Optional[Dict] = None,
-    cloud_id: Optional[str] = None,
-    api_key: Optional[str] = None,
-    es_url: Optional[str] = None,
     index_name: Optional[str] = None,
     namespace: Optional[str] = None,
     embedding_model: Optional[str] = None,
@@ -639,6 +626,10 @@ def elasticsearch_memory(
     - delete: Remove a specific memory
       Use this to delete memories that are no longer needed.
 
+    Connection credentials are read from environment variables:
+    - ELASTICSEARCH_CLOUD_ID or ELASTICSEARCH_URL for connection
+    - ELASTICSEARCH_API_KEY for authentication
+
     Args:
         action: The memory operation to perform (one of: "record", "retrieve", "list", "get", "delete")
         content: For record action: Text content to store as a memory
@@ -647,9 +638,6 @@ def elasticsearch_memory(
         max_results: Maximum number of results to return (optional, default: 10)
         next_token: Pagination token for list action (optional)
         metadata: Additional metadata to store with the memory (optional)
-        cloud_id: Elasticsearch Cloud ID for connection (optional if es_url provided)
-        api_key: Elasticsearch API key for authentication
-        es_url: Elasticsearch URL for serverless connection (optional if cloud_id provided)
         index_name: Name of the Elasticsearch index (defaults to 'strands_memory')
         namespace: Namespace for memory operations (defaults to 'default')
         embedding_model: Amazon Bedrock model for embeddings (defaults to Titan)
@@ -658,12 +646,11 @@ def elasticsearch_memory(
     Returns:
         Dict: Response containing the requested memory information or operation status
     """
-    try:
-        # Get values from environment variables if not provided
-        cloud_id = cloud_id or os.getenv("ELASTICSEARCH_CLOUD_ID")
-        es_url = es_url or os.getenv("ELASTICSEARCH_URL")
-        api_key = api_key or os.getenv("ELASTICSEARCH_API_KEY")
+    cloud_id = os.getenv("ELASTICSEARCH_CLOUD_ID")
+    es_url = os.getenv("ELASTICSEARCH_URL")
+    api_key = os.getenv("ELASTICSEARCH_API_KEY")
 
+    try:
         # Validate required parameters
         if not api_key:
             return {"status": "error", "content": [{"text": "api_key is required"}]}

--- a/tests/test_elasticsearch_memory.py
+++ b/tests/test_elasticsearch_memory.py
@@ -2,6 +2,7 @@
 Tests for the elasticsearch_memory tool.
 """
 
+import inspect
 import json
 import os
 from unittest import mock
@@ -11,6 +12,29 @@ import pytest
 from strands import Agent
 
 from src.strands_tools.elasticsearch_memory import elasticsearch_memory
+
+ES_ENV_VARS = {
+    "ELASTICSEARCH_CLOUD_ID": "test-cloud-id",
+    "ELASTICSEARCH_API_KEY": "test-api-key",
+    "ELASTICSEARCH_INDEX_NAME": "test_index",
+    "ELASTICSEARCH_NAMESPACE": "test_namespace",
+    "AWS_REGION": "us-east-1",
+}
+
+ES_URL_ENV_VARS = {
+    "ELASTICSEARCH_URL": "https://test-cluster.es.region.aws.elastic.cloud:443",
+    "ELASTICSEARCH_API_KEY": "test-api-key",
+    "ELASTICSEARCH_INDEX_NAME": "test_index",
+    "ELASTICSEARCH_NAMESPACE": "test_namespace",
+    "AWS_REGION": "us-east-1",
+}
+
+
+@pytest.fixture(autouse=True)
+def set_es_env_vars():
+    """Auto-set ES environment variables for all tests."""
+    with mock.patch.dict(os.environ, ES_ENV_VARS):
+        yield
 
 
 @pytest.fixture
@@ -74,29 +98,40 @@ def agent(mock_elasticsearch_client, mock_bedrock_client):
 
 @pytest.fixture
 def config():
-    """Configuration parameters for testing."""
+    """Configuration parameters for testing (non-credential params only)."""
     return {
-        "cloud_id": "test-cloud-id",
-        "api_key": "test-api-key",
         "index_name": "test_index",
         "namespace": "test_namespace",
-        "region": "us-east-1",
     }
 
 
+# --- Security Tests ---
+
+
+def test_credential_params_not_in_tool_signature():
+    """Verify that credential/connection parameters cannot be passed to the tool."""
+    sig = inspect.signature(elasticsearch_memory)
+    param_names = set(sig.parameters.keys())
+    assert "es_url" not in param_names
+    assert "cloud_id" not in param_names
+    assert "api_key" not in param_names
+
+
 def test_missing_required_params(mock_elasticsearch_client, mock_bedrock_client):
-    """Test tool with missing required parameters."""
+    """Test tool with missing required environment variables."""
     agent = Agent(tools=[elasticsearch_memory])
 
-    # Test missing both cloud_id and es_url
-    result = agent.tool.elasticsearch_memory(action="record", content="test", api_key="test-api-key")
-    assert result["status"] == "error"
-    assert "Either cloud_id or es_url is required" in result["content"][0]["text"]
+    # Test missing both cloud_id and es_url (no env vars set)
+    with mock.patch.dict(os.environ, {"ELASTICSEARCH_API_KEY": "test-api-key"}, clear=True):
+        result = agent.tool.elasticsearch_memory(action="record", content="test")
+        assert result["status"] == "error"
+        assert "Either cloud_id or es_url is required" in result["content"][0]["text"]
 
     # Test missing api_key
-    result = agent.tool.elasticsearch_memory(action="record", content="test", cloud_id="test-cloud-id")
-    assert result["status"] == "error"
-    assert "api_key is required" in result["content"][0]["text"]
+    with mock.patch.dict(os.environ, {"ELASTICSEARCH_CLOUD_ID": "test-cloud-id"}, clear=True):
+        result = agent.tool.elasticsearch_memory(action="record", content="test")
+        assert result["status"] == "error"
+        assert "api_key is required" in result["content"][0]["text"]
 
 
 def test_connection_failure(mock_elasticsearch_client, mock_bedrock_client):
@@ -106,9 +141,8 @@ def test_connection_failure(mock_elasticsearch_client, mock_bedrock_client):
     # Configure ping to return False (connection failure)
     mock_elasticsearch_client["client"].ping.return_value = False
 
-    result = agent.tool.elasticsearch_memory(
-        action="record", content="test", cloud_id="test-cloud-id", api_key="test-api-key"
-    )
+    with mock.patch.dict(os.environ, ES_ENV_VARS):
+        result = agent.tool.elasticsearch_memory(action="record", content="test")
 
     assert result["status"] == "error"
     assert "Unable to connect to Elasticsearch cluster" in result["content"][0]["text"]
@@ -121,7 +155,8 @@ def test_index_creation(mock_elasticsearch_client, mock_bedrock_client, config):
     # Configure mock responses
     mock_elasticsearch_client["client"].index.return_value = {"result": "created", "_id": "test_memory_id"}
 
-    agent.tool.elasticsearch_memory(action="record", content="Test content", **config)
+    with mock.patch.dict(os.environ, ES_ENV_VARS):
+        agent.tool.elasticsearch_memory(action="record", content="Test content", **config)
 
     # Verify index creation was called
     mock_elasticsearch_client["client"].indices.create.assert_called_once()
@@ -158,9 +193,10 @@ def test_record_memory(mock_elasticsearch_client, mock_bedrock_client, config):
     mock_elasticsearch_client["client"].index.return_value = {"result": "created", "_id": "test_memory_id"}
 
     # Call the tool
-    result = agent.tool.elasticsearch_memory(
-        action="record", content="Test memory content", metadata={"category": "test"}, **config
-    )
+    with mock.patch.dict(os.environ, ES_ENV_VARS):
+        result = agent.tool.elasticsearch_memory(
+            action="record", content="Test memory content", metadata={"category": "test"}, **config
+        )
 
     # Verify success response
     assert result["status"] == "success"
@@ -504,8 +540,6 @@ def test_agent_tool_usage(mock_elasticsearch_client, mock_bedrock_client):
     result = agent.tool.elasticsearch_memory(
         action="record",
         content="Test memory content",
-        cloud_id="test-cloud-id",
-        api_key="test-api-key",
         index_name="test_index",
         namespace="test_namespace",
     )
@@ -522,21 +556,20 @@ def test_agent_tool_usage(mock_elasticsearch_client, mock_bedrock_client):
 
 
 def test_es_url_connection(mock_elasticsearch_client, mock_bedrock_client):
-    """Test using es_url instead of cloud_id for connection."""
+    """Test using ELASTICSEARCH_URL instead of ELASTICSEARCH_CLOUD_ID for connection."""
     agent = Agent(tools=[elasticsearch_memory])
 
     # Configure mock responses
     mock_elasticsearch_client["client"].index.return_value = {"result": "created", "_id": "test_memory_id"}
 
-    # Call tool with es_url instead of cloud_id
-    result = agent.tool.elasticsearch_memory(
-        action="record",
-        content="Test memory content",
-        es_url="https://test-cluster.es.region.aws.elastic.cloud:443",
-        api_key="test-api-key",
-        index_name="test_index",
-        namespace="test_namespace",
-    )
+    # Override env vars to use URL instead of cloud_id
+    with mock.patch.dict(os.environ, ES_URL_ENV_VARS, clear=False):
+        result = agent.tool.elasticsearch_memory(
+            action="record",
+            content="Test memory content",
+            index_name="test_index",
+            namespace="test_namespace",
+        )
 
     # Verify success response
     assert result["status"] == "success"
@@ -558,7 +591,8 @@ def test_custom_embedding_model(mock_elasticsearch_client, mock_bedrock_client, 
 
     # Call tool with custom embedding model
     result = agent.tool.elasticsearch_memory(
-        action="record", content="Test memory content", embedding_model="amazon.titan-embed-text-v1:0", **config
+        action="record", content="Test memory content", embedding_model="amazon.titan-embed-text-v1:0",
+        index_name="test_index", namespace="test_namespace",
     )
 
     # Verify success response
@@ -583,7 +617,7 @@ def test_multiple_namespaces(mock_elasticsearch_client, mock_bedrock_client, con
         action="record",
         content="Alice likes Italian food",
         namespace="user_alice",
-        **{k: v for k, v in config.items() if k != "namespace"},
+        index_name="test_index",
     )
 
     # Store memory in system namespace
@@ -591,7 +625,7 @@ def test_multiple_namespaces(mock_elasticsearch_client, mock_bedrock_client, con
         action="record",
         content="System maintenance scheduled",
         namespace="system_global",
-        **{k: v for k, v in config.items() if k != "namespace"},
+        index_name="test_index",
     )
 
     # Verify both operations succeeded
@@ -626,13 +660,10 @@ def test_configuration_dictionary_pattern(mock_elasticsearch_client, mock_bedroc
         }
     }
 
-    # Create configuration dictionary
+    # Create configuration dictionary (non-credential params only)
     config = {
-        "cloud_id": "test-cloud-id",
-        "api_key": "test-api-key",
         "index_name": "memories",
         "namespace": "user_123",
-        "region": "us-east-1",
     }
 
     # Store memory using config dictionary
@@ -782,14 +813,13 @@ def test_security_scenarios(mock_elasticsearch_client, mock_bedrock_client):
     }
 
     # Test namespace validation - memory exists but not in requested namespace
-    result = agent.tool.elasticsearch_memory(
-        action="get",
-        memory_id="mem_123",
-        cloud_id="test-cloud-id",
-        api_key="test-api-key",
-        index_name="test_index",
-        namespace="correct_namespace",
-    )
+    with mock.patch.dict(os.environ, ES_ENV_VARS):
+        result = agent.tool.elasticsearch_memory(
+            action="get",
+            memory_id="mem_123",
+            index_name="test_index",
+            namespace="correct_namespace",
+        )
 
     assert result["status"] == "error"
     assert "not found in namespace correct_namespace" in result["content"][0]["text"]
@@ -819,8 +849,8 @@ def test_injection_prevention(mock_elasticsearch_client, mock_bedrock_client, co
     """Test that injection attempts via namespace are blocked."""
     agent = Agent(tools=[elasticsearch_memory])
 
-    # Remove namespace from config to avoid conflict
-    test_config = {k: v for k, v in config.items() if k != "namespace"}
+    # Config without namespace
+    test_config = {"index_name": "test_index"}
 
     # Test dict-based injection (analogous to MongoDB {"$ne": ""} attack)
     malicious_namespace = {"$ne": ""}
@@ -848,8 +878,8 @@ def test_namespace_validation_strict_rules(mock_elasticsearch_client, mock_bedro
     """Test strict namespace validation rules."""
     agent = Agent(tools=[elasticsearch_memory])
 
-    # Remove namespace from config to avoid conflict
-    test_config = {k: v for k, v in config.items() if k != "namespace"}
+    # Config without namespace
+    test_config = {"index_name": "test_index"}
 
     # Test invalid characters (should be rejected)
     invalid_namespaces = [
@@ -883,8 +913,8 @@ def test_valid_namespaces_accepted(mock_elasticsearch_client, mock_bedrock_clien
         }
     }
 
-    # Remove namespace from config
-    test_config = {k: v for k, v in config.items() if k != "namespace"}
+    # Config without namespace
+    test_config = {"index_name": "test_index"}
 
     valid_namespaces = [
         "default",


### PR DESCRIPTION
## Description

Remove `es_url`, `cloud_id`, and `api_key` from the `elasticsearch_memory` @tool function signature.

## Related Issues

N/A

## Documentation PR

N/A —
## Type of Change

Breaking change

Users who pass `es_url`, `cloud_id`, or `api_key` as keyword arguments to the tool will get `TypeError: unexpected keyword argument`. They must migrate to environment variables (`ELASTICSEARCH_URL`, `ELASTICSEARCH_CLOUD_ID`, `ELASTICSEARCH_API_KEY`).

## Testing

How have you tested the change?

- Verified `elasticsearch_memory(action="record", es_url="https://evil.com", content="x")` raises `TypeError`
- All 26 unit tests pass (`python -m pytest tests/test_elasticsearch_memory.py -v`)
- Added regression test (`test_credential_params_not_in_tool_signature`) that asserts `es_url`, `cloud_id`, `api_key` are not in the function signature

- [X] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
