### PR TITLE
fix(workflow): remove unused MIN_THREADS / CPU_THRESHOLD env vars

### DIFF
--- a/src/strands_tools/workflow.py
+++ b/src/strands_tools/workflow.py
@@ -7,7 +7,7 @@ Built on modern Strands SDK patterns with rich monitoring and robust error handl
 Key Features:
 -------------
 1. Advanced Task Management:
-   • Parallel execution with dynamic thread pooling
+   • Parallel execution with a fixed-size thread pool
    • Priority-based scheduling (1-5 levels)
    • Complex dependency resolution with validation
    • Timeout and resource controls per task
@@ -25,11 +25,8 @@ Key Features:
    • Automatic tool filtering and validation
    • Support for any combination of tools per task
 
-4. Resource Optimization:
-   • Automatic thread pool scaling (2-8 threads)
-   • Rate limiting with exponential backoff
-   • Resource-aware task distribution
-   • CPU usage monitoring and optimization
+4. Rate Limiting:
+   • Exponential backoff on retries
 
 5. Reliability Features:
    • Persistent state storage with real-time monitoring
@@ -130,9 +127,7 @@ WORKFLOW_DIR = Path(os.getenv("STRANDS_WORKFLOW_DIR", Path.home() / ".strands" /
 os.makedirs(WORKFLOW_DIR, exist_ok=True)
 
 # Default thread pool settings
-MIN_THREADS = int(os.getenv("STRANDS_WORKFLOW_MIN_THREADS", "2"))
 MAX_THREADS = int(os.getenv("STRANDS_WORKFLOW_MAX_THREADS", "8"))
-CPU_THRESHOLD = int(os.getenv("STRANDS_WORKFLOW_CPU_THRESHOLD", "80"))  # CPU usage threshold for scaling down
 
 # Rate limiting configuration
 _rate_limit_lock = RLock()
@@ -157,10 +152,9 @@ class WorkflowFileHandler(FileSystemEventHandler):
 
 
 class TaskExecutor:
-    """Advanced task executor with dynamic scaling and resource monitoring."""
+    """Task executor that runs workflow tasks in a fixed-size thread pool."""
 
-    def __init__(self, min_workers=MIN_THREADS, max_workers=MAX_THREADS):
-        self.min_workers = min_workers
+    def __init__(self, max_workers=MAX_THREADS):
         self.max_workers = max_workers
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
         self.task_queue = Queue()


### PR DESCRIPTION
## Description

Issue #327 reported that `MIN_THREADS` (`STRANDS_WORKFLOW_MIN_THREADS`) and `CPU_THRESHOLD` (`STRANDS_WORKFLOW_CPU_THRESHOLD`) are defined in `workflow.py` but never read, and that the module/class docstrings advertise behaviors the implementation doesn't have ("automatic thread pool scaling 2-8 threads", "CPU usage monitoring and optimization", "dynamic scaling and resource monitoring" on `TaskExecutor`).

Per the maintainer's suggestion on the issue (Option 1), this PR deletes the dead code rather than implementing the advertised features:

- Drop `MIN_THREADS` and `CPU_THRESHOLD` module constants.
- Drop the unused `min_workers` parameter and `self.min_workers` attribute on `TaskExecutor` (verified internal-only via grep; the single call site `TaskExecutor()` passes no args).
- Fix the module-level docstring: change "dynamic thread pooling" → "fixed-size thread pool"; replace the inaccurate "Resource Optimization" section with a "Rate Limiting" section reflecting what's actually implemented.
- Fix the `TaskExecutor` class docstring.

`MAX_THREADS` / `STRANDS_WORKFLOW_MAX_THREADS` (the one env var that does flow through to `ThreadPoolExecutor`) is preserved unchanged.

Note that this removes two environment variables. Any user who currently sets `STRANDS_WORKFLOW_MIN_THREADS` or `STRANDS_WORKFLOW_CPU_THRESHOLD` is already getting silently no-op'd today, so the observable behavior doesn't change.

## Related Issues

Fixes #327

## Type of Change

Bug fix

## Testing

Ran `hatch run prepare` end-to-end via `python:3.12` in Docker:

```
docker run --rm -v "$PWD:/work" -w /work python:3.12 bash -c \
  "git config --global --add safe.directory /work && pip install --quiet hatch && hatch run prepare"
```

- `format`: clean (no changes)
- `lint`: clean
- `test-lint` (`ruff format --check`): clean
- `test`: 1210 passed, 33 skipped, 1 failure

The single failure is `tests/test_file_write.py::test_file_write_error_handling`. I verified it reproduces on `main` without this PR (same Python 3.12 / hatch environment), so it's pre-existing and unrelated to this change.

- [x] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works (no new tests needed — change is removal of unused code; the existing 32 `test_workflow.py` tests cover `TaskExecutor()`)
- [x] I have updated the documentation accordingly (the module/class docstrings; no separate user-facing docs reference these env vars)
- [x] I have added an appropriate example to the documentation to outline the feature (N/A — removal, not new feature)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published