### PR TITLE
fix(workflow): enforce per-task timeout in workflow execution

### DIFF
--- a/src/strands_tools/workflow.py
+++ b/src/strands_tools/workflow.py
@@ -581,6 +581,28 @@ class WorkflowManager:
         ready_tasks.sort(key=lambda x: x.get("priority", 3), reverse=True)
         return ready_tasks
 
+    def _get_task_timeout(self, workflow: Dict, task_id: str) -> float:
+        """Return the configured timeout (seconds) for a task, defaulting to 300."""
+        for task in workflow["tasks"]:
+            if task["task_id"] == task_id:
+                return task.get("timeout", 300)
+        return 300
+
+    def _next_task_deadline(self, active_futures: Dict, workflow: Dict) -> Optional[float]:
+        """Return seconds until the soonest active-task deadline, or None if no active tasks."""
+        if not active_futures:
+            return None
+        now = time.time()
+        soonest = None
+        for namespaced_task_id in active_futures:
+            task_id = namespaced_task_id.split(":", 1)[1] if ":" in namespaced_task_id else namespaced_task_id
+            task_timeout = self._get_task_timeout(workflow, task_id)
+            start_time = self.task_executor.start_times.get(namespaced_task_id, now)
+            deadline_remaining = (start_time + task_timeout) - now
+            if soonest is None or deadline_remaining < soonest:
+                soonest = deadline_remaining
+        return max(0.0, soonest) if soonest is not None else None
+
     def start_workflow(self, workflow_id: str) -> Dict:
         """Start or resume workflow execution with true parallel processing."""
         try:
@@ -633,19 +655,22 @@ class WorkflowManager:
                     active_futures.update(new_futures)
                     logger.debug(f"📤 Submitted {len(tasks_to_submit)} tasks for execution")
 
-                # Wait for any task to complete
+                # Wait for any task to complete, but no longer than the next task deadline
                 if active_futures:
-                    done, _ = wait(active_futures.values(), return_when=FIRST_COMPLETED)
+                    wait_timeout = self._next_task_deadline(active_futures, workflow)
+                    done, _ = wait(active_futures.values(), return_when=FIRST_COMPLETED, timeout=wait_timeout)
 
-                    # Process completed tasks
-                    completed_task_ids = []
+                    # Process completed and timed-out tasks
+                    finished_namespaced_ids = []
+                    now = time.time()
                     for namespaced_task_id, future in active_futures.items():
+                        # Extract original task_id from namespaced version
+                        task_id = (
+                            namespaced_task_id.split(":", 1)[1] if ":" in namespaced_task_id else namespaced_task_id
+                        )
+
                         if future in done:
-                            # Extract original task_id from namespaced version
-                            task_id = (
-                                namespaced_task_id.split(":", 1)[1] if ":" in namespaced_task_id else namespaced_task_id
-                            )
-                            completed_task_ids.append(namespaced_task_id)
+                            finished_namespaced_ids.append(namespaced_task_id)
                             try:
                                 result = future.result()
 
@@ -676,9 +701,27 @@ class WorkflowManager:
                                 }
                                 completed_tasks.add(task_id)
                                 logger.error(f"❌ Task '{task_id}' failed: {str(e)}")
+                        else:
+                            # Still-running future: enforce per-task timeout. We can't reliably
+                            # terminate the worker thread (Python lacks a portable mechanism),
+                            # but we mark the task failed so dependent tasks and the overall
+                            # workflow can make progress instead of blocking indefinitely.
+                            task_timeout = self._get_task_timeout(workflow, task_id)
+                            start_time = self.task_executor.start_times.get(namespaced_task_id, now)
+                            if (now - start_time) >= task_timeout:
+                                future.cancel()
+                                workflow["task_results"][task_id] = {
+                                    **workflow["task_results"][task_id],
+                                    "status": "error",
+                                    "result": [{"text": f"Task execution timeout after {task_timeout}s"}],
+                                    "completed_at": datetime.now(timezone.utc).isoformat(),
+                                }
+                                completed_tasks.add(task_id)
+                                logger.error(f"⏱️ Task '{task_id}' timed out after {task_timeout}s")
+                                finished_namespaced_ids.append(namespaced_task_id)
 
-                    # Remove completed tasks from active futures
-                    for task_id in completed_task_ids:
+                    # Remove completed and timed-out tasks from active futures
+                    for task_id in finished_namespaced_ids:
                         del active_futures[task_id]
 
                 # Store updated workflow state

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -4,6 +4,8 @@ Tests for the workflow tool using the Agent interface.
 
 import json
 import tempfile
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -259,6 +261,69 @@ class TestWorkflowExecution:
 
         extracted_id = namespaced_task_id.split(":", 1)[1] if ":" in namespaced_task_id else namespaced_task_id
         assert extracted_id == "task1"
+
+    def test_start_workflow_enforces_task_timeout(self, mock_parent_agent):
+        """A task that exceeds its configured timeout is marked as error so the workflow can finish."""
+        # WorkflowManager is a singleton (__new__-based), so reset it before AND after
+        # this test to avoid leaking our patched execute_task / shut-down TaskExecutor
+        # into other tests.
+        workflow_module.WorkflowManager._instance = None
+        try:
+            with (
+                tempfile.TemporaryDirectory() as temp_dir,
+                patch.object(workflow_module, "WORKFLOW_DIR", Path(temp_dir)),
+            ):
+                manager = workflow_module.WorkflowManager(mock_parent_agent)
+
+                # execute_task replacement that sleeps far longer than the configured task timeout
+                def hanging_execute_task(task, workflow):
+                    time.sleep(2.0)
+                    return {"status": "success", "content": [{"text": "should not be reached"}]}
+
+                manager.execute_task = hanging_execute_task
+
+                workflow_id = "timeout_test"
+                workflow_data = {
+                    "workflow_id": workflow_id,
+                    "created_at": datetime.now(timezone.utc).isoformat(),
+                    "status": "created",
+                    "tasks": [
+                        {
+                            "task_id": "slow_task",
+                            "description": "Hangs longer than its timeout",
+                            "timeout": 0.2,
+                            "priority": 3,
+                            "dependencies": [],
+                        }
+                    ],
+                    "task_results": {
+                        "slow_task": {
+                            "status": "pending",
+                            "result": None,
+                            "priority": 3,
+                            "model_provider": None,
+                            "tools": [],
+                        }
+                    },
+                    "parallel_execution": True,
+                }
+                manager.store_workflow(workflow_id, workflow_data)
+
+                started = time.time()
+                result = manager.start_workflow(workflow_id)
+                elapsed = time.time() - started
+
+                # Workflow should give up on the hung task well before its 2.0s sleep completes
+                assert elapsed < 1.5, f"start_workflow blocked on a hung task ({elapsed:.2f}s)"
+                assert result["status"] == "success"
+
+                task_result = manager.get_workflow(workflow_id)["task_results"]["slow_task"]
+                assert task_result["status"] == "error"
+                timeout_text = task_result["result"][0]["text"]
+                assert "timeout" in timeout_text.lower()
+                assert "0.2" in timeout_text
+        finally:
+            workflow_module.WorkflowManager._instance = None
 
 
 class TestWorkflowStatus:


### PR DESCRIPTION
## Description

Issue #326 reported that the `workflow` tool accepts a per-task `timeout` field (and applies a 300s default in `create`) but never enforces it. A hung task blocks the entire workflow loop indefinitely, since `wait(active_futures.values(), return_when=FIRST_COMPLETED)` is called without a timeout and `future.result()` is likewise unbounded.

This PR enforces the per-task timeout in two places:

- **Bound the wait.** Compute the soonest active-task deadline (`start_time + timeout` minimum across all active futures) and pass it as `timeout=` to `wait()`. The loop now wakes up no later than the next task limit, even if no future completes.
- **Mark timed-out futures as error.** After `wait()` returns, iterate every active future. Done futures process as before. Still-running futures get checked against their per-task timeout — if exceeded, the task is marked `status: "error"` with `"Task execution timeout after Ns"`, added to `completed_tasks`, and removed from `active_futures`. `future.cancel()` is called as a best effort.

Two small helpers are added to `WorkflowManager`: `_get_task_timeout(workflow, task_id)` and `_next_task_deadline(active_futures, workflow)`.

## Caveats (worth surfacing for review)

1. **Worker thread can't be terminated.** Python doesn't expose a portable way to kill a running thread, so `future.cancel()` on a started future returns `False` and the worker function keeps running until it returns. This PR only unblocks the **workflow loop and dependent tasks**; a runaway tool function still consumes CPU until it finishes. An inline comment in `start_workflow` explains the constraint. The reporter's example (a `time.sleep(120)` tool with `timeout: 30`) is handled correctly under this constraint: the workflow finishes around 30s, the underlying sleep keeps running another ~90s in the background.

2. **Related to issue #325 (deadlock on failed tasks) but doesn't fix it.** The reporter noted that without timeout enforcement, hung tasks never fail and so never trigger the dependent-task-deadlock condition described in #325. This PR makes hung tasks fail, which *exposes* #325 — dependent tasks may now be blocked instead of the workflow itself. #325 should be tracked separately.

## Related Issues

Fixes #326

## Type of Change

Bug fix

## Testing

Ran `hatch run prepare` end-to-end via `python:3.12` in Docker:

```
docker run --rm -v "$PWD:/work" -w /work python:3.12 bash -c \
  "git config --global --add safe.directory /work && pip install --quiet hatch && hatch run prepare"
```

- `format`: clean (no changes to PR files)
- `lint`: clean
- `test-lint` (`ruff format --check`): clean
- `test`: 1211 passed, 33 skipped, 1 failure

The single failure is `tests/test_file_write.py::test_file_write_error_handling`. I verified it reproduces on `main` without this PR (same Python 3.12 / hatch environment), so it's pre-existing and unrelated.

Added `test_start_workflow_enforces_task_timeout` (in `TestWorkflowExecution`): installs a hung `execute_task` that sleeps 2.0s, configures `timeout: 0.2`, asserts the workflow completes in under 1.5s with the task marked `status: "error"` and the result text containing the timeout. Resets the `WorkflowManager` singleton around the test to avoid leaking the patched `execute_task` / shut-down `TaskExecutor` into other tests.

- [x] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly (inline comment in `start_workflow` explaining the thread-termination caveat)
- [x] I have added an appropriate example to the documentation to outline the feature (N/A — bug fix to existing behavior)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published