### PR TITLE
fix(editor): normalize path in content history cache

### DIFF
--- a/src/strands_tools/editor.py
+++ b/src/strands_tools/editor.py
@@ -314,7 +314,7 @@ def editor(
     console = console_util.create()
 
     try:
-        path = os.path.expanduser(path)
+        path = os.path.abspath(os.path.expanduser(path))
 
         if not command:
             raise ValueError("Command is required")


### PR DESCRIPTION
## Summary

Fixes #345 - editor tool cache uses non-normalized paths

The `CONTENT_HISTORY` cache uses raw `path` as the key, which means the same file accessed via different path formats (`test.md`, `./test.md`, `/Users/xxx/test.md`) gets cached multiple times, defeating the purpose of the cache.

**Root cause**: Line 317 only does `os.path.expanduser(path)` but doesn't normalize to an absolute path.

**Fix**: Add `os.path.abspath()` to normalize all paths to absolute form before caching:

```python
# Before
path = os.path.expanduser(path)

# After  
path = os.path.abspath(os.path.expanduser(path))
```

This is a 1-line change that ensures `~/file.txt`, `./file.txt`, and `/Users/xxx/file.txt` all resolve to the same cache key.

## Changes
- `src/strands_tools/editor.py`: Wrap path normalization with `os.path.abspath()`
