### PR TITLE
fix(browser): make navigation wait strategy configurable

### DIFF
--- a/src/strands_tools/browser/browser.py
+++ b/src/strands_tools/browser/browser.py
@@ -365,8 +365,7 @@ class Browser(ABC):
             return {"status": "error", "content": [{"text": "Error: No active page for session"}]}
 
         try:
-            await page.goto(action.url)
-            await page.wait_for_load_state("networkidle")
+            await page.goto(action.url, wait_until=action.wait_until)
             return {"status": "success", "content": [{"text": f"Navigated to {action.url}"}]}
         except Exception as e:
             error_str = str(e)
@@ -653,8 +652,7 @@ class Browser(ABC):
             return {"status": "error", "content": [{"text": "Error: No active page for session"}]}
 
         try:
-            await page.reload()
-            await page.wait_for_load_state("networkidle")
+            await page.reload(wait_until=action.wait_until)
             return {"status": "success", "content": [{"text": "Page refreshed"}]}
         except Exception as e:
             logger.debug("exception=<%s> | refresh action failed", str(e))
@@ -676,8 +674,7 @@ class Browser(ABC):
             return {"status": "error", "content": [{"text": "Error: No active page for session"}]}
 
         try:
-            await page.go_back()
-            await page.wait_for_load_state("networkidle")
+            await page.go_back(wait_until=action.wait_until)
             return {"status": "success", "content": [{"text": "Navigated back"}]}
         except Exception as e:
             logger.debug("exception=<%s> | back action failed", str(e))
@@ -699,8 +696,7 @@ class Browser(ABC):
             return {"status": "error", "content": [{"text": "Error: No active page for session"}]}
 
         try:
-            await page.go_forward()
-            await page.wait_for_load_state("networkidle")
+            await page.go_forward(wait_until=action.wait_until)
             return {"status": "success", "content": [{"text": "Navigated forward"}]}
         except Exception as e:
             logger.debug("exception=<%s> | forward action failed", str(e))

--- a/src/strands_tools/browser/models.py
+++ b/src/strands_tools/browser/models.py
@@ -12,6 +12,8 @@ from playwright.async_api import Browser as PlaywrightBrowser
 from playwright.async_api import BrowserContext, Page
 from pydantic import BaseModel, Field
 
+WaitUntil = Literal["load", "domcontentloaded", "networkidle", "commit"]
+
 
 @dataclass
 class BrowserSession:
@@ -104,6 +106,10 @@ class NavigateAction(BaseModel):
     type: Literal["navigate"] = Field(description="Navigate to a URL")
     session_name: str = Field(description="Required session name from a previous init_session call")
     url: str = Field(description="URL to navigate to")
+    wait_until: WaitUntil = Field(
+        default="load",
+        description="Playwright wait_until value for navigation. Defaults to 'load' to preserve Playwright's navigation behavior without brittle extra 'networkidle' waits.",
+    )
 
 
 class ClickAction(BaseModel):
@@ -176,6 +182,10 @@ class RefreshAction(BaseModel):
 
     type: Literal["refresh"] = Field(description="Refresh the current page")
     session_name: str = Field(description="Required session name from a previous init_session call")
+    wait_until: WaitUntil = Field(
+        default="load",
+        description="Playwright wait_until value for reload. Defaults to 'load' to preserve Playwright's navigation behavior without brittle extra 'networkidle' waits.",
+    )
 
 
 class BackAction(BaseModel):
@@ -184,6 +194,10 @@ class BackAction(BaseModel):
 
     type: Literal["back"] = Field(description="Navigate back in browser history")
     session_name: str = Field(description="Required session name from a previous init_session call")
+    wait_until: WaitUntil = Field(
+        default="load",
+        description="Playwright wait_until value for back navigation. Defaults to 'load' to preserve Playwright's navigation behavior without brittle extra 'networkidle' waits.",
+    )
 
 
 class ForwardAction(BaseModel):
@@ -192,6 +206,10 @@ class ForwardAction(BaseModel):
 
     type: Literal["forward"] = Field(description="Navigate forward in browser history")
     session_name: str = Field(description="Required session name from a previous init_session call")
+    wait_until: WaitUntil = Field(
+        default="load",
+        description="Playwright wait_until value for forward navigation. Defaults to 'load' to preserve Playwright's navigation behavior without brittle extra 'networkidle' waits.",
+    )
 
 
 class NewTabAction(BaseModel):

--- a/tests/browser/test_wait_until.py
+++ b/tests/browser/test_wait_until.py
@@ -1,0 +1,73 @@
+"""
+Tests for wait_until configuration on navigation-style browser actions.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+from strands_tools.browser.browser import Browser
+from strands_tools.browser.models import BackAction, BrowserSession, ForwardAction, NavigateAction, RefreshAction
+
+
+class MockBrowser(Browser):
+    def start_platform(self) -> None:
+        pass
+
+    def close_platform(self) -> None:
+        pass
+
+    async def create_browser_session(self):
+        return Mock()
+
+
+def _make_browser_with_page(mock_page):
+    browser = MockBrowser()
+    session = BrowserSession(session_name="test-session-0001", description="test", page=mock_page)
+    session.add_tab("main", mock_page)
+    browser._sessions[session.session_name] = session
+    return browser
+
+
+def test_navigate_default_wait_until_load():
+    action = NavigateAction(session_name="test-session-0001", url="https://example.com")
+    assert action.wait_until == "load"
+
+
+def test_navigate_uses_wait_until_on_goto():
+    mock_page = Mock()
+    mock_page.goto = AsyncMock()
+    mock_page.wait_for_load_state = AsyncMock()
+
+    browser = _make_browser_with_page(mock_page)
+    action = NavigateAction(session_name="test-session-0001", url="https://example.com", wait_until="load")
+    browser.navigate(action)
+
+    mock_page.goto.assert_awaited_once_with("https://example.com", wait_until="load")
+    mock_page.wait_for_load_state.assert_not_awaited()
+
+
+def test_refresh_uses_wait_until_on_reload():
+    mock_page = Mock()
+    mock_page.reload = AsyncMock()
+    mock_page.wait_for_load_state = AsyncMock()
+
+    browser = _make_browser_with_page(mock_page)
+    action = RefreshAction(session_name="test-session-0001", wait_until="commit")
+    browser.refresh(action)
+
+    mock_page.reload.assert_awaited_once_with(wait_until="commit")
+    mock_page.wait_for_load_state.assert_not_awaited()
+
+
+def test_back_forward_use_wait_until():
+    mock_page = Mock()
+    mock_page.go_back = AsyncMock()
+    mock_page.go_forward = AsyncMock()
+    mock_page.wait_for_load_state = AsyncMock()
+
+    browser = _make_browser_with_page(mock_page)
+    browser.back(BackAction(session_name="test-session-0001", wait_until="domcontentloaded"))
+    browser.forward(ForwardAction(session_name="test-session-0001", wait_until="networkidle"))
+
+    mock_page.go_back.assert_awaited_once_with(wait_until="domcontentloaded")
+    mock_page.go_forward.assert_awaited_once_with(wait_until="networkidle")
+    mock_page.wait_for_load_state.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Add a `wait_until` option to browser navigation-style actions (`navigate`, `refresh`, `back`, `forward`).
- Default to Playwright's regular `load` behavior instead of forcing `networkidle` after every navigation.
- Cover the default behavior and ensure navigation does not add an extra unconditional `wait_for_load_state("networkidle")` call.

## Why
Fixes #287.

The browser tool currently waits for `networkidle` after navigation, which can hang on modern pages with long-lived requests. This keeps the default conservative while allowing callers to opt into `domcontentloaded`, `networkidle`, or `commit` when needed.

## Validation
- `python3 -m py_compile src/strands_tools/browser/browser.py src/strands_tools/browser/models.py tests/browser/test_wait_until.py`

Full pytest was not run locally because this checkout does not have the required Python test dependencies installed.
