### PR TITLE
fix(browser): add max_length param to GetHtmlAction (fixes #407)

### DIFF
--- a/src/strands_tools/browser/browser.py
+++ b/src/strands_tools/browser/browser.py
@@ -595,7 +595,8 @@ class Browser(ABC):
                     }
 
             # Truncate long HTML content
-            truncated_result = result[:1000] + "..." if len(result) > 1000 else result
+            max_len = action.max_length if action.max_length > 0 else len(result)
+            truncated_result = result[:max_len] + "..." if len(result) > max_len else result
             return {"status": "success", "content": [{"text": truncated_result}]}
         except Exception as e:
             logger.debug("exception=<%s> | get HTML action failed", str(e))

--- a/src/strands_tools/browser/models.py
+++ b/src/strands_tools/browser/models.py
@@ -159,6 +159,7 @@ class GetHtmlAction(BaseModel):
     type: Literal["get_html"] = Field(description="Get HTML content")
     session_name: str = Field(description="Required session name from a previous init_session call")
     selector: Optional[str] = Field(default=None, description="CSS selector for specific element (optional)")
+    max_length: int = Field(default=10000, description="Maximum number of characters to return (default: 10000)")
 
 
 class ScreenshotAction(BaseModel):


### PR DESCRIPTION
## Summary

Fixes #407 - `get_html` was hard-coded to truncate at 1,000 characters, returning broken HTML fragments for any page larger than that.

## Changes

1. **models.py**: Added `max_length` field to `GetHtmlAction` with default of 10,000 characters
2. **browser.py**: Updated `_async_get_html` to use `action.max_length` instead of hardcoded 1000

## Behavior

- Default max_length: 10,000 (was 1,000)
- Set `max_length: 0` to disable truncation entirely
- Backward compatible: existing callers without `max_length` get the larger default