### PR TITLE
feat(mem0_memory)!: upgrade to mem0ai 2.x and remove Neptune graph backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,8 +1148,8 @@ The Mem0 Memory Tool supports three different backend configurations:
    - Uses FAISS as the local vector store backend
    - Requires faiss-cpu package for local vector storage
 
-4. **Neptune Analytics** (Optional Graph backend for search enhancement):
-   - Uses Neptune Analytics as the graph store backend to enhance memory recall.
+4. **Neptune Analytics** (Optional vector store backend):
+   - Uses Neptune Analytics as the vector store backend.
    - Requires AWS credentials and Neptune Analytics configuration
    ```
    # Configure your Neptune Analytics graph ID in the .env file:
@@ -1180,7 +1180,7 @@ The Mem0 Memory Tool supports three different backend configurations:
 - If `MEM0_API_KEY` is set, the tool will use the Mem0 Platform
 - If `OPENSEARCH_HOST` is set, the tool will use OpenSearch
 - If neither is set, the tool will default to FAISS (requires `faiss-cpu` package)
-- If `NEPTUNE_ANALYTICS_GRAPH_IDENTIFIER` is set, the tool will configure Neptune Analytics as graph store to enhance memory search
+- If `NEPTUNE_ANALYTICS_GRAPH_IDENTIFIER` is set (and `OPENSEARCH_HOST` is not), the tool will configure Neptune Analytics as the vector store
 - LLM configuration applies to all backend modes and allows customization of the language model used for memory processing
 
 #### Bright Data Tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
     "pytest>=8.0.0,<10.0.0",
     "ruff>=0.13.0,<0.14.0",
     "responses>=0.6.1,<1.0.0",
-    "mem0ai>=0.1.104,<1.0.0",
+    "mem0ai>=2.0.0,<3.0.0",
     "opensearch-py>=2.8.0,<3.0.0",
     "nest-asyncio>=1.5.0,<2.0.0",
     "playwright>=1.42.0,<2.0.0",
@@ -85,7 +85,7 @@ docs = [
 ]
 mem0-memory = [
     # Need to be optional as a fix for https://github.com/strands-agents/docs/issues/19
-    "mem0ai>=0.1.99,<1.0.0",
+    "mem0ai>=2.0.0,<3.0.0",
     "opensearch-py>=2.8.0,<3.0.0",
 ]
 local-chromium-browser = ["nest-asyncio>=1.5.0,<2.0.0", "playwright>=1.42.0,<2.0.0"]
@@ -149,6 +149,8 @@ extra-dependencies = [
     "pytest-xdist>=3.0.0,<4.0.0",
     "responses>=0.6.1,<1.0.0",
     "pytest_asyncio>=0.25.0,<2.0.0",
+    # Local FAISS vector store used by the mem0_memory e2e test (tests_integ).
+    "faiss-cpu>=1.8.0,<2.0.0",
 ]
 extra-args = ["-n", "auto", '-vv']
 

--- a/src/strands_tools/mem0_memory.py
+++ b/src/strands_tools/mem0_memory.py
@@ -209,32 +209,16 @@ class Mem0ServiceClient:
             logger.debug("Using FAISS backend (Mem0Memory with FAISS)")
             merged_config = self._append_faiss_config(config)
 
-        # Graph backend providers
-
-        # Graph backend providers
-        if os.environ.get("NEPTUNE_ANALYTICS_GRAPH_IDENTIFIER") and os.environ.get("NEPTUNE_DATABASE_ENDPOINT"):
-            raise RuntimeError("""Conflicting backend configurations:
-                Both NEPTUNE_ANALYTICS_GRAPH_IDENTIFIER and NEPTUNE_DATABASE_ENDPOINT environment variables are set.
-                Please specify only one graph backend.""")
-
-        if os.environ.get("NEPTUNE_ANALYTICS_GRAPH_IDENTIFIER"):
-            logger.debug("Using Neptune Analytics graph backend (Mem0Memory with Neptune Analytics)")
-            merged_config = self._append_neptune_analytics_graph_config(merged_config)
-
-        elif os.environ.get("NEPTUNE_DATABASE_ENDPOINT"):
-            logger.debug("Using Neptune Database graph backend (Mem0Memory with Neptune Database)")
-            merged_config = self._append_neptune_database_backend(merged_config)
-
         return Mem0Memory.from_config(config_dict=merged_config)
 
     def _append_neptune_analytics_vector_config(self, config: Optional[Dict] = None) -> Dict:
-        """Update incoming configuration dictionary to include the configuration of Neptune Analytics vector backend.
+        """Update incoming configuration dictionary to include the Neptune Analytics vector backend.
 
         Args:
             config: Optional configuration dictionary to override defaults.
 
         Returns:
-            An configuration dict with graph backend.
+            A configuration dict with Neptune Analytics as the vector store.
         """
         config = config or {}
         config["vector_store"] = {
@@ -245,26 +229,6 @@ class Mem0ServiceClient:
             },
         }
         return self._merge_config(config)
-
-    def _append_neptune_database_backend(self, config: Optional[Dict] = None) -> Dict:
-        """Update incoming configuration dictionary to include the configuration of Neptune Database graph backend.
-
-        Args:
-            config: Optional configuration dictionary to override defaults.
-
-        Returns:
-            An configuration dict with graph backend.
-        """
-        config = config or {}
-        config["graph_store"] = {
-            "provider": "neptunedb",
-            "config": {"endpoint": f"neptune-db://{os.environ.get('NEPTUNE_DATABASE_ENDPOINT')}"},
-        }
-        # To retrieve cosine similarity score instead for Faiss.
-        if "faiss" == config.get("vector_store", {}).get("provider"):
-            config["vector_store"]["config"]["distance_strategy"] = "cosine"
-
-        return config
 
     def _append_opensearch_config(self, config: Optional[Dict] = None) -> Dict:
         """Update incoming configuration dictionary to include the configuration of OpenSearch vector backend.
@@ -338,21 +302,6 @@ class Mem0ServiceClient:
         }
         return merged_config
 
-    def _append_neptune_analytics_graph_config(self, config: Dict) -> Dict:
-        """Update incoming configuration dictionary to include the configuration of Neptune Analytics graph backend.
-
-        Args:
-            config: Configuration dictionary to add Neptune Analytics graph backend
-
-        Returns:
-            An configuration dict with graph backend.
-        """
-        config["graph_store"] = {
-            "provider": "neptune",
-            "config": {"endpoint": f"neptune-graph://{os.environ.get('NEPTUNE_ANALYTICS_GRAPH_IDENTIFIER')}"},
-        }
-        return config
-
     def _merge_config(self, config: Optional[Dict] = None) -> Dict:
         """Merge user-provided configuration with default configuration.
 
@@ -398,14 +347,30 @@ class Mem0ServiceClient:
         if not user_id and not agent_id:
             raise ValueError("Either user_id or agent_id must be provided")
 
-        return self.mem0.get_all(user_id=user_id, agent_id=agent_id)
+        # mem0 >=2.0 requires entity ids to be passed via `filters` rather than as
+        # top-level keyword arguments.
+        filters = self._build_entity_filters(user_id, agent_id)
+        return self.mem0.get_all(filters=filters)
 
     def search_memories(self, query: str, user_id: Optional[str] = None, agent_id: Optional[str] = None):
         """Search memories using semantic search."""
         if not user_id and not agent_id:
             raise ValueError("Either user_id or agent_id must be provided")
 
-        return self.mem0.search(query=query, user_id=user_id, agent_id=agent_id)
+        # mem0 >=2.0 requires entity ids to be passed via `filters` rather than as
+        # top-level keyword arguments.
+        filters = self._build_entity_filters(user_id, agent_id)
+        return self.mem0.search(query=query, filters=filters)
+
+    @staticmethod
+    def _build_entity_filters(user_id: Optional[str], agent_id: Optional[str]) -> Dict[str, str]:
+        """Build a mem0 `filters` dict from the provided entity ids."""
+        filters: Dict[str, str] = {}
+        if user_id:
+            filters["user_id"] = user_id
+        if agent_id:
+            filters["agent_id"] = agent_id
+        return filters
 
     def delete_memory(self, memory_id: str):
         """Delete a memory by ID."""
@@ -520,48 +485,6 @@ def format_retrieve_response(memories: List[Dict]) -> Panel:
     return Panel(table, title="[bold green]Search Results", border_style="green")
 
 
-def format_retrieve_graph_response(memories: List[Dict]) -> Panel:
-    """Format retrieve response for graph data"""
-    if not memories:
-        return Panel(
-            "No graph memories found matching the query.", title="[bold yellow]No Matches", border_style="yellow"
-        )
-
-    table = Table(title="Search Results", show_header=True, header_style="bold magenta")
-    table.add_column("Source", style="cyan", width=25)
-    table.add_column("Relationship", style="yellow", width=45)
-    table.add_column("Destination", style="green", width=30)
-
-    for memory in memories:
-        source = memory.get("source", "N/A")
-        relationship = memory.get("relationship", "N/A")
-        destination = memory.get("destination", "N/A")
-
-        table.add_row(source, relationship, destination)
-
-    return Panel(table, title="[bold green]Search Results (Graph)", border_style="green")
-
-
-def format_list_graph_response(memories: List[Dict]) -> Panel:
-    """Format list response for graph data"""
-    if not memories:
-        return Panel("No graph memories found.", title="[bold yellow]No Memories", border_style="yellow")
-
-    table = Table(title="Graph Memories", show_header=True, header_style="bold magenta")
-    table.add_column("Source", style="cyan", width=25)
-    table.add_column("Relationship", style="yellow", width=45)
-    table.add_column("Target", style="green", width=30)
-
-    for memory in memories:
-        source = memory.get("source", "N/A")
-        relationship = memory.get("relationship", "N/A")
-        destination = memory.get("target", "N/A")
-
-        table.add_row(source, relationship, destination)
-
-    return Panel(table, title="[bold green]Memories List (Graph)", border_style="green")
-
-
 def format_history_response(history: List[Dict]) -> Panel:
     """Format memory history response."""
     if not history:
@@ -609,26 +532,6 @@ def format_store_response(results: List[Dict]) -> Panel:
         table.add_row(event, content_preview)
 
     return Panel(table, title="[bold green]Memory Stored", border_style="green")
-
-
-def format_store_graph_response(memories: List[Dict]) -> Panel:
-    """Format store response for graph data"""
-    if not memories:
-        return Panel("No graph memories stored.", title="[bold yellow]No Memories Stored", border_style="yellow")
-
-    table = Table(title="Graph Memories Stored", show_header=True, header_style="bold magenta")
-    table.add_column("Source", style="cyan", width=25)
-    table.add_column("Relationship", style="yellow", width=45)
-    table.add_column("Target", style="green", width=30)
-
-    for memory in memories:
-        source = memory[0].get("source", "N/A")
-        relationship = memory[0].get("relationship", "N/A")
-        destination = memory[0].get("target", "N/A")
-
-        table.add_row(source, relationship, destination)
-
-    return Panel(table, title="[bold green]Memories Stored (Graph)", border_style="green")
 
 
 def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
@@ -743,13 +646,6 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
                 panel = format_store_response(results_list)
                 console.print(panel)
 
-            # Process graph relations (If any)
-            if "relations" in results:
-                relationships_list = results.get("relations").get("added_entities", [])
-                results_list.extend(relationships_list)
-                panel_graph = format_store_graph_response(relationships_list)
-                console.print(panel_graph)
-
             return ToolResult(
                 toolUseId=tool_use_id,
                 status="success",
@@ -774,13 +670,6 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
             panel = format_list_response(results_list)
             console.print(panel)
 
-            # Process graph relations (If any)
-            if "relations" in memories:
-                relationships_list = memories.get("relations", [])
-                results_list.extend(relationships_list)
-                panel_graph = format_list_graph_response(relationships_list)
-                console.print(panel_graph)
-
             return ToolResult(
                 toolUseId=tool_use_id,
                 status="success",
@@ -800,13 +689,6 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
             results_list = memories if isinstance(memories, list) else memories.get("results", [])
             panel = format_retrieve_response(results_list)
             console.print(panel)
-
-            # Process graph relations (If any)
-            if "relations" in memories:
-                relationships_list = memories.get("relations", [])
-                results_list.extend(relationships_list)
-                panel_graph = format_retrieve_graph_response(relationships_list)
-                console.print(panel_graph)
 
             return ToolResult(
                 toolUseId=tool_use_id,

--- a/tests/test_mem0.py
+++ b/tests/test_mem0.py
@@ -436,7 +436,7 @@ def test_mem0_service_client_init(mock_opensearch, mock_mem0_memory, mock_sessio
         with pytest.raises(RuntimeError):
             Mem0ServiceClient()
 
-    # Test with Neptune Analytics for both vector and graph
+    # Test with Neptune Analytics as the vector store
     with patch.dict(
         os.environ,
         {
@@ -444,18 +444,6 @@ def test_mem0_service_client_init(mock_opensearch, mock_mem0_memory, mock_sessio
         },
     ):
         client = Mem0ServiceClient()
-        assert client.mem0 is not None
-
-    # Test with Neptune Database with OpenSearch
-    with patch.dict(
-        os.environ,
-        {
-            "OPENSEARCH_HOST": "test.opensearch.amazonaws.com",
-            "NEPTUNE_DATABASE_ENDPOINT": "xxx.us-west-2.neptune.amazonaws.com",
-        },
-    ):
-        client = Mem0ServiceClient()
-        assert client.region == os.environ.get("AWS_REGION", "us-west-2")
         assert client.mem0 is not None
 
     # Test with custom config (OpenSearch)

--- a/tests_integ/test_mem0_memory_e2e.py
+++ b/tests_integ/test_mem0_memory_e2e.py
@@ -1,0 +1,104 @@
+"""
+End-to-end test for the mem0_memory tool against the real mem0 (>=2.0) library.
+
+This exercises the OSS ``Memory`` code path (local FAISS vector store) where the
+mem0 2.x breaking change lives: ``get_all``/``search`` now require entity ids to
+be passed via ``filters=`` instead of as top-level keyword arguments. A mocked
+test cannot catch that regression, so this runs the real store -> search -> list
+-> get -> history -> delete cycle.
+
+Backend: OpenAI embedder + LLM (so it runs locally without AWS). The OpenAI
+embedder is pinned to ``embedding_dims=1024`` to match the tool's hardcoded FAISS
+index dimension. The test skips itself when ``OPENAI_API_KEY`` is not set.
+
+Requires ``faiss-cpu`` to be installed (the ``mem0-memory`` extra does not pull
+it). Run via: ``hatch run test-integ tests_integ/test_mem0_memory_e2e.py``
+"""
+
+import glob
+import os
+import uuid
+from typing import Any, Dict, List
+
+import pytest
+
+from strands_tools.mem0_memory import Mem0ServiceClient
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set; skipping real mem0 2.x e2e",
+)
+
+# Matches the path hardcoded in Mem0ServiceClient._append_faiss_config.
+_FAISS_PATH = "/tmp/mem0_384_faiss"
+
+OPENAI_CONFIG = {
+    "embedder": {
+        "provider": "openai",
+        "config": {"model": "text-embedding-3-small", "embedding_dims": 1024},
+    },
+    "llm": {"provider": "openai", "config": {"model": "gpt-4o-mini"}},
+}
+
+
+def _results(resp: Any) -> List[Dict[str, Any]]:
+    """Normalize a mem0 response into a list of memory dicts."""
+    if isinstance(resp, list):
+        return resp
+    return resp.get("results", [])
+
+
+@pytest.fixture
+def fresh_faiss_store():
+    """Remove any stale local FAISS index so the 1024-dim index is created clean."""
+    for path in glob.glob(f"{_FAISS_PATH}*"):
+        try:
+            os.remove(path)
+        except (IsADirectoryError, OSError):
+            import shutil
+
+            shutil.rmtree(path, ignore_errors=True)
+    yield
+
+
+@pytest.fixture
+def client(fresh_faiss_store):
+    # No MEM0_API_KEY / OPENSEARCH_HOST / NEPTUNE_* env vars -> default FAISS path.
+    return Mem0ServiceClient(config=OPENAI_CONFIG)
+
+
+def test_mem0_memory_full_cycle(client):
+    """store -> search -> list -> get -> history -> delete against real mem0 2.x."""
+    user_id = f"e2e_user_{uuid.uuid4().hex[:8]}"
+    fact = "My name is Alex and I love hiking in the Swiss Alps every summer."
+
+    # store
+    store_resp = client.store_memory(content=fact, user_id=user_id)
+    assert _results(store_resp), "store should create at least one memory"
+
+    # search -- this is the call that raised the 2.x ValueError before the
+    # filters= fix. Assert the stored fact is actually retrievable.
+    search_resp = client.search_memories(query="What are my outdoor hobbies?", user_id=user_id)
+    search_results = _results(search_resp)
+    assert search_results, "search should return the stored memory"
+    assert any("hik" in (m.get("memory", "").lower()) for m in search_results), (
+        f"expected a hiking-related memory, got: {[m.get('memory') for m in search_results]}"
+    )
+
+    # list -- also goes through get_all(filters=...)
+    list_results = _results(client.list_memories(user_id=user_id))
+    assert list_results, "list should return the stored memory"
+    memory_id = list_results[0]["id"]
+
+    # get
+    got = client.get_memory(memory_id)
+    assert got.get("id") == memory_id
+
+    # history
+    history = client.get_memory_history(memory_id)
+    assert isinstance(history, list)
+
+    # delete -> confirm it is gone
+    client.delete_memory(memory_id)
+    remaining_ids = [m["id"] for m in _results(client.list_memories(user_id=user_id))]
+    assert memory_id not in remaining_ids


### PR DESCRIPTION
## Description

mem0ai 2.x introduces two incompatibilities for this tool, addressed here together:

1. **`get_all()` / `search()` filters API.** mem0 2.x rejects top-level `user_id` / `agent_id` and requires `filters={...}` instead (enforced internally by `_reject_top_level_entity_params`). The current pin to `mem0ai<1.0.0` keeps this tool on the 0.1.x line and prevents upgrade. This PR rewrites `Mem0ServiceClient.list_memories` and `Mem0ServiceClient.search_memories` to use the `filters=` form, then bumps the pin in both the `dev` and `mem0-memory` extras to `mem0ai>=2.0.0,<3.0.0`. `add()`, `get()`, `delete()`, `history()` are unchanged in 2.x.

2. **Graph memory removed from OSS mem0.** mem0 2.x's `MemoryConfig` has no `graph_store` field and OSS no longer ships a graph provider. The tool's two Neptune **graph** backends (`_append_neptune_analytics_graph_config`, `_append_neptune_database_backend`) and the `"relations"` rendering paths (`format_retrieve_graph_response`, `format_list_graph_response`, `format_store_graph_response`) cannot work on 2.x and are removed.

The Neptune Analytics **vector** store path is preserved — it shares the `NEPTUNE_ANALYTICS_GRAPH_IDENTIFIER` env var with the (now-removed) graph backend but is a separate, still-supported feature.

**Behavior change:** `NEPTUNE_DATABASE_ENDPOINT` alone is no longer recognized — it only ever wired the now-removed graph backend.

Net diff: ~+28 / −156 lines across `src/strands_tools/mem0_memory.py`, `tests/test_mem0.py`, `README.md`, `pyproject.toml`, plus a new `tests_integ/test_mem0_memory_e2e.py`.

## Related Issues

N/A — no open issue tracks the mem0 2.x upgrade.

## Documentation PR

N/A — only `README.md` in this repo touches mem0 backend docs; it is updated in this PR.

## Type of Change

Breaking change

## Testing

- New end-to-end integration test `tests_integ/test_mem0_memory_e2e.py` runs the real CRUD cycle (`store → retrieve → list → get → history → delete`) against `mem0ai==2.0.4` with FAISS + OpenAI, proving the `filters=` rewrite works against the actual library. Passed locally (~10s warm, ~26s cold).
- Unit suite (`tests/test_mem0.py`): all 12 tests pass.
- `ruff check` and `ruff format --check` clean on changed files.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published