### PR TITLE
fix(workflow): respect tools=[] and avoid recursion

### DIFF
--- a/src/strands_tools/workflow.py
+++ b/src/strands_tools/workflow.py
@@ -326,17 +326,20 @@ class WorkflowManager:
 
             # Configure tools
             filtered_tools = []
-            if task_tools and self.parent_agent and hasattr(self.parent_agent, "tool_registry"):
+            tools_specified = "tools" in task
+            if tools_specified and self.parent_agent and hasattr(self.parent_agent, "tool_registry"):
                 # Filter parent agent tools to only include specified tool names
                 available_tools = self.parent_agent.tool_registry.registry
-                for tool_name in task_tools:
+                for tool_name in (task_tools or []):
                     if tool_name in available_tools:
                         filtered_tools.append(available_tools[tool_name])
                     else:
                         logger.warning(f"Tool '{tool_name}' not found in parent agent's tool registry")
             elif self.parent_agent and hasattr(self.parent_agent, "tool_registry"):
-                # Inherit all tools from parent if none specified
-                filtered_tools = list(self.parent_agent.tool_registry.registry.values())
+                # Inherit all tools from parent if none specified, but exclude workflow to avoid recursion.
+                filtered_tools = [
+                    tool for tool_name, tool in self.parent_agent.tool_registry.registry.items() if tool_name != "workflow"
+                ]
 
             # Configure model
             selected_model = None

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -390,6 +390,25 @@ class TestWorkflowManager:
             assert len(call_kwargs["tools"]) == 2
             assert call_kwargs["system_prompt"] == "You are a test assistant."
 
+    def test_create_task_agent_with_explicit_empty_tools(self, mock_parent_agent):
+        """Test task agent creation with an explicit empty tools list."""
+        with patch("strands_tools.workflow.Agent") as mock_agent_class:
+            mock_task_agent = MagicMock()
+            mock_agent_class.return_value = mock_task_agent
+
+            manager = workflow_module.WorkflowManager(mock_parent_agent)
+
+            task = {
+                "task_id": "test_task",
+                "description": "Test task",
+                "tools": [],
+            }
+
+            manager._create_task_agent(task)
+
+            call_kwargs = mock_agent_class.call_args.kwargs
+            assert call_kwargs["tools"] == []
+
     def test_create_task_agent_with_model_provider(self, mock_parent_agent):
         """Test task agent creation with custom model provider."""
         with (


### PR DESCRIPTION
## Summary

- Respect explicit `tools: []` on a task (no tools) instead of inheriting the parent agent’s tool registry.
- When a task omits `tools`, inherit parent tools **except** `workflow` to avoid recursive workflow invocations.

## Related Issues

Fixes #383

## Testing

- `python -m py_compile src/strands_tools/workflow.py tests/test_workflow.py`
