### PR TITLE
fix(browser): register event loop on current thread in _execute_async

### DIFF
--- a/src/strands_tools/browser/browser.py
+++ b/src/strands_tools/browser/browser.py
@@ -946,6 +946,14 @@ class Browser(ABC):
             return {"status": "error", "content": [{"text": f"Error: {str(e)}"}]}
 
     def _execute_async(self, action_coro) -> Any:
+        # Ensure the event loop is registered on the current thread.
+        # When stream_async() dispatches this method to a worker thread,
+        # the loop created in __init__ may not be set as the current
+        # thread's event loop, causing run_until_complete to fail with
+        # "RuntimeError: There is no current event loop in thread".
+        # See: strands-agents/tools#453
+        asyncio.set_event_loop(self._loop)
+
         # Apply nest_asyncio if not already applied
         if not self._nest_asyncio_applied:
             nest_asyncio.apply()


### PR DESCRIPTION
## Summary

Fixes #453

When `stream_async()` dispatches `_execute_async` to a worker thread, the event loop created in `Browser.__init__()` is not registered on that thread. This causes `self._loop.run_until_complete()` to fail with:

```
RuntimeError: There is no current event loop in thread 'asyncio_0'
```

## Root Cause

- `__init__` calls `asyncio.set_event_loop(self._loop)` on the **creating** thread
- `_execute_async` is a synchronous method that Strands dispatches to a **different** thread via `_stream`
- The worker thread has no event loop registered, so `run_until_complete` raises

## Fix

Add `asyncio.set_event_loop(self._loop)` at the start of `_execute_async` to ensure the loop is registered on whichever thread executes the method. This is idempotent and safe - if the loop is already set, it's a no-op.

## Testing

- Verified that `AgentCoreBrowser` works with `agent.stream_async()` when called from within an already-running async event loop
- Existing sync `agent()` calls continue to work unchanged

Closes #453
