### PR TITLE
fix(shell): drive non_interactive mode from environment variable

### DIFF
--- a/src/strands_tools/shell.py
+++ b/src/strands_tools/shell.py
@@ -416,7 +416,6 @@ def shell(
     ignore_errors: bool = False,
     timeout: int = None,
     work_dir: str = None,
-    non_interactive: bool = False,
 ) -> Dict[str, Any]:
     """Interactive shell with PTY support for real-time command execution and interaction. Features:
 
@@ -482,16 +481,13 @@ def shell(
         ignore_errors: Continue execution even if some commands fail (default: False)
         timeout: Timeout in seconds for each command (default: controlled by SHELL_DEFAULT_TIMEOUT environment variable)
         work_dir: Working directory for command execution (default: current)
-        non_interactive: Run in non-interactive mode without user prompts (default: False)
 
     Returns:
         Dict containing status and response content
     """
     console = console_util.create()
 
-    is_strands_non_interactive = os.environ.get("STRANDS_NON_INTERACTIVE", "").lower() == "true"
-    # Here we keep both doors open, but we only prompt env STRANDS_NON_INTERACTIVE in our doc.
-    non_interactive_mode = is_strands_non_interactive or non_interactive
+    non_interactive_mode = os.environ.get("STRANDS_NON_INTERACTIVE", "").lower() == "true"
 
     # Validate command parameter
     if command is None:

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -823,8 +823,9 @@ def test_shell_with_json_array_string(mock_execute_commands):
             "status": "success",
         },
     ]
-    # Call the shell function with new @tool decorator signature and non_interactive=True to skip confirmation
-    shell.shell('["cmd1", "cmd2"]', non_interactive=True)
+    # Call the shell function with STRANDS_NON_INTERACTIVE env var to skip confirmation
+    with patch.dict(os.environ, {"STRANDS_NON_INTERACTIVE": "true"}):
+        shell.shell('["cmd1", "cmd2"]')
 
     # Verify execute_commands was called with parsed array
     mock_execute_commands.assert_called_once()
@@ -846,8 +847,9 @@ def test_shell_with_invalid_json_array_string(mock_execute_commands):
         }
     ]
 
-    # Call the shell function with new @tool decorator signature and non_interactive=True
-    shell.shell("[invalid json array]", non_interactive=True)
+    # Call the shell function with STRANDS_NON_INTERACTIVE env var to skip confirmation
+    with patch.dict(os.environ, {"STRANDS_NON_INTERACTIVE": "true"}):
+        shell.shell("[invalid json array]")
 
     # Verify execute_commands was called with the original string (fallback)
     mock_execute_commands.assert_called_once()
@@ -870,9 +872,10 @@ def test_shell_with_complex_command_objects(mock_execute_commands):
         }
     ]
 
-    # Call the shell function with new @tool decorator signature - complex command object
+    # Call the shell function with STRANDS_NON_INTERACTIVE env var - complex command object
     command_obj = {"command": "git clone", "timeout": 120}
-    shell.shell(command_obj, non_interactive=True)
+    with patch.dict(os.environ, {"STRANDS_NON_INTERACTIVE": "true"}):
+        shell.shell(command_obj)
 
     # Verify execute_commands was called with the complex object
     mock_execute_commands.assert_called_once()
@@ -936,8 +939,9 @@ def test_shell_console_output(mock_console_util):
         # Reset mock for non-interactive test
         mock_console.reset_mock()
 
-        # Call with non_interactive_mode=True
-        shell.shell("echo test", non_interactive=True)
+        # Call with STRANDS_NON_INTERACTIVE env var
+        with patch.dict(os.environ, {"STRANDS_NON_INTERACTIVE": "true"}):
+            shell.shell("echo test")
 
         # Verify console.print was not called for UI elements in non-interactive mode
         assert mock_console.print.call_count == 0
@@ -967,32 +971,11 @@ def test_shell_exception_ui_output(mock_execute_commands, mock_get_user_input, m
         # Reset mock for non-interactive test
         mock_console.reset_mock()
 
-        # Call with non_interactive_mode=True
-        shell.shell("echo test", non_interactive=True)
+        # Call with STRANDS_NON_INTERACTIVE env var
+        with patch.dict(os.environ, {"STRANDS_NON_INTERACTIVE": "true"}):
+            shell.shell("echo test")
 
         # Verify console.print was not called in non-interactive mode
         assert mock_console.print.call_count == 0
 
 
-@patch("strands_tools.shell.execute_commands")
-@patch("strands_tools.shell.get_user_input")
-def test_shell_non_interactive_parameter(mock_get_user_input, mock_execute_commands):
-    """Test shell tool with non_interactive parameter."""
-    # Mock execute_commands to return a successful result
-    mock_execute_commands.return_value = [
-        {
-            "command": "echo test",
-            "exit_code": 0,
-            "output": "test\n",
-            "error": "",
-            "status": "success",
-        }
-    ]
-
-    # Call the shell function with non_interactive=True
-    result = shell.shell("echo test", non_interactive=True)
-
-    assert result["status"] == "success"
-
-    # Verify that get_user_input was not called because non_interactive=True
-    mock_get_user_input.assert_not_called()


### PR DESCRIPTION
## Description

The `non_interactive` parameter on the shell tool function was redundant with the `STRANDS_NON_INTERACTIVE` environment variable. This removes the parameter and consolidates non-interactive mode to be driven exclusively from the environment variable, matching the pattern already used by `BYPASS_TOOL_CONSENT`.

## Related Issues

N/A

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`
- All 27 non-pty shell tests pass
- Verified that `STRANDS_NON_INTERACTIVE=true` continues to suppress prompts
- Verified that without the env var, the consent prompt is shown as expected

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.