### PR TITLE
fix: return text message for empty search results in file_read

### DIFF
--- a/src/strands_tools/file_read.py
+++ b/src/strands_tools/file_read.py
@@ -1193,7 +1193,12 @@ def file_read(tool: ToolUse, **kwargs: Any) -> ToolResult:
                         tool_input.get("search_pattern", ""),
                         tool_input.get("context_lines", file_read_context_lines_default),
                     )
-                    response_content.extend([{"text": r["context"]} for r in results])
+                    if not results:
+                        search_pattern = tool_input.get("search_pattern", "")
+                        no_results_msg = f"No search results found for pattern '{search_pattern}' in {file_path}"
+                        response_content.append({"text": no_results_msg})
+                    else:
+                        response_content.extend([{"text": r["context"]} for r in results])
 
                 elif mode == "diff":
                     comparison_path = tool_input.get("comparison_path")

--- a/tests/test_file_read.py
+++ b/tests/test_file_read.py
@@ -141,6 +141,26 @@ def test_file_read_tool_direct_search(temp_test_file):
     assert "More" in str(result["content"])
 
 
+def test_file_read_tool_direct_search_no_results(temp_test_file):
+    """Test that search mode returns a text message instead of empty list when no results found."""
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {
+            "path": temp_test_file,
+            "mode": "search",
+            "search_pattern": "pattern_that_does_not_exist",
+        },
+    }
+
+    result = file_read.file_read(tool=tool_use)
+
+    assert result["status"] == "success"
+    assert isinstance(result["content"], list)
+    assert len(result["content"]) > 0
+    # Should return a text message, not an empty content list
+    assert any("No search results found" in str(item.get("text", "")) for item in result["content"])
+
+
 def test_file_read_tool_direct_stats(temp_test_file):
     """Test direct invocation of the file_read tool in stats mode."""
     tool_use = {


### PR DESCRIPTION
## Summary

Fixes #303

When `file_read` in search mode finds no matching results, it previously returned an empty content list `{"content": []}`, which caused downstream Bedrock API errors.

## Changes

- **`src/strands_tools/file_read.py`**: Added a check for empty search results in the `search` mode code path. When no results are found, it now returns a helpful text message (`No search results found for pattern '<pattern>' in <file_path>`) instead of an empty content list, while maintaining `status: "success"`.
- **`tests/test_file_read.py`**: Added `test_file_read_tool_direct_search_no_results` test to verify the fix.

## Testing

All 19 existing tests pass, including the new test:
```
tests/test_file_read.py::test_file_read_tool_direct_search_no_results PASSED
```

## Before
```json
{"toolUseId": "...", "status": "success", "content": []}
```

## After
```json
{"toolUseId": "...", "status": "success", "content": [{"text": "No search results found for pattern 'xyz' in /path/to/file.txt"}]}
```