### PR TITLE
fix: make get_html truncation configurable instead of hard-coded

### DIFF
--- a/src/strands_tools/browser/browser.py
+++ b/src/strands_tools/browser/browser.py
@@ -594,9 +594,10 @@ class Browser(ABC):
                         ],
                     }
 
-            # Truncate long HTML content
-            truncated_result = result[:1000] + "..." if len(result) > 1000 else result
-            return {"status": "success", "content": [{"text": truncated_result}]}
+            # Optionally truncate long HTML content
+            if action.max_length is not None and len(result) > action.max_length:
+                result = result[:action.max_length] + "...[truncated]"
+            return {"status": "success", "content": [{"text": result}]}
         except Exception as e:
             logger.debug("exception=<%s> | get HTML action failed", str(e))
             return {"status": "error", "content": [{"text": f"Error: {str(e)}"}]}

--- a/src/strands_tools/browser/models.py
+++ b/src/strands_tools/browser/models.py
@@ -159,6 +159,7 @@ class GetHtmlAction(BaseModel):
     type: Literal["get_html"] = Field(description="Get HTML content")
     session_name: str = Field(description="Required session name from a previous init_session call")
     selector: Optional[str] = Field(default=None, description="CSS selector for specific element (optional)")
+    max_length: Optional[int] = Field(default=None, description="Maximum characters to return. If None, returns full HTML content. Set to limit response size.")
 
 
 class ScreenshotAction(BaseModel):


### PR DESCRIPTION
## Problem

The `get_html` browser action had a hard-coded 1,000-character truncation limit that returned broken HTML fragments:

```python
truncated_result = result[:1000] + "..." if len(result) > 1000 else result
```

This caused issues because:
1. 1,000 characters is too small for most real-world HTML content
2. Truncating at a character boundary breaks HTML structure (mid-tag)
3. Users had no way to control or disable the truncation

## Fix

- Add optional `max_length` parameter to `GetHtmlAction` model
- Only truncate when `max_length` is explicitly set by the user  
- Default is `None` (no truncation, return full content)
- Truncation message now includes `"...[truncated]"` indicator for clarity

### Before
```python
# Hard-coded truncation at 1000 chars
truncated_result = result[:1000] + "..." if len(result) > 1000 else result
```

### After
```python
# Only truncate if user explicitly sets max_length
if action.max_length is not None and len(result) > action.max_length:
    result = result[:action.max_length] + "...[truncated]"
```

## Testing

Existing tests pass. The browser tests require `bedrock_agentcore` which is not available in the test environment (pre-existing issue).

Fixes #407