### PR TITLE
fix: normalize paths in editor cache to prevent stale content

### DIFF
--- a/src/strands_tools/editor.py
+++ b/src/strands_tools/editor.py
@@ -315,6 +315,8 @@ def editor(
 
     try:
         path = os.path.expanduser(path)
+        if path:
+            path = os.path.abspath(path)
 
         if not command:
             raise ValueError("Command is required")


### PR DESCRIPTION
## Problem

The editor tool's content cache used raw path parameters as cache keys. When the same file was accessed via different path formats (relative vs absolute), separate cache entries were created:

```python
# View with relative path - caches as 'test.md'
editor(command='view', path='test.md')

# Replace with absolute path - caches as '/full/path/test.md'  
editor(command='str_replace', path='/full/path/test.md', ...)

# View with relative path again - returns STALE content from 'test.md' key!
editor(command='view', path='test.md')  # Returns old content
```

This caused agents to retry edits unnecessarily, wasting LLM tokens.

## Fix

Normalize paths with `os.path.abspath()` after `expanduser()` to ensure consistent cache keys:

```python
path = os.path.expanduser(path)
if path:
    path = os.path.abspath(path)
```

## Testing

All 32 editor tests pass.

Fixes #345