### PR TITLE
fix: filter hidden files and directories from glob results in file_read

### DIFF
--- a/src/strands_tools/file_read.py
+++ b/src/strands_tools/file_read.py
@@ -405,6 +405,11 @@ def find_files(console: Console, pattern: str, recursive: bool = True) -> List[s
 
         try:
             matching_files = glob.glob(pattern, recursive=recursive)
+            # Filter out hidden files and files under hidden directories
+            matching_files = [
+                f for f in matching_files
+                if not any(part.startswith(".") for part in f.split(os.sep) if part)
+            ]
             return sorted(matching_files)
         except Exception as e:
             console.print(


### PR DESCRIPTION
## Problem

The `search_file()` function has two code paths:
1. **os.walk path** (for direct directory traversal) — correctly prunes hidden directories and skips hidden files
2. **glob.glob path** (for pattern matching) — **no filtering**, so files under `.git/`, `.venv/`, etc. appear in results

## Fix

Add the same hidden file/directory filtering to glob results:

```python
matching_files = [
    f for f in matching_files
    if not any(part.startswith(".") for part in f.split(os.sep) if part)
]
```

This checks every path component (not just the filename) to catch files nested under hidden directories.

## Testing

All 18 file_read tests pass.

Fixes #289