### PR TITLE
feat: add append mode to file_write tool

### DIFF
--- a/src/strands_tools/file_write.py
+++ b/src/strands_tools/file_write.py
@@ -82,6 +82,12 @@ TOOL_SPEC = {
                     "type": "string",
                     "description": "The content to write to the file",
                 },
+                "mode": {
+                    "type": "string",
+                    "description": "Write mode: 'w' (default) to overwrite, 'a' to append to existing content",
+                    "enum": ["w", "a"],
+                    "default": "w",
+                },
             },
             "required": ["path", "content"],
         }
@@ -168,6 +174,7 @@ def file_write(tool: ToolUse, **kwargs: Any) -> ToolResult:
             - path: The path to the file to write. User paths with tilde (~)
                     are automatically expanded.
             - content: The content to write to the file.
+            - mode: Write mode - 'w' (default) to overwrite, 'a' to append.
         **kwargs: Additional keyword arguments (not used currently)
 
     Returns:
@@ -257,10 +264,12 @@ def file_write(tool: ToolUse, **kwargs: Any) -> ToolResult:
             )
 
         # Write the file
-        with open(path, "w") as file:
+        mode = tool.get("input", {}).get("mode", "w")
+        with open(path, mode) as file:
             file.write(content)
 
-        success_message = f"File written successfully to {path}"
+        action = "appended to" if mode == "a" else "written successfully to"
+        success_message = f"Content {action} {path}"
         success_panel = Panel(
             Text(success_message, style="bold green"),
             title="[bold green]Write Successful",


### PR DESCRIPTION
## Problem

The `file_write` tool hardcodes `open(path, 'w')`, always overwriting the file. The documentation at [strandsagents.com](https://strandsagents.com/latest/documentation/docs/examples/python/file_operations/) claims append mode is supported, but the implementation doesn't support it.

## Fix

Add optional `mode` parameter to `file_write`:

- `mode='w'` (default): overwrite file — **existing behavior preserved**
- `mode='a'`: append content to existing file

### Changes

1. **TOOL_SPEC**: Add `mode` parameter with enum `['w', 'a']` and default `'w'`
2. **Function**: Read `mode` from tool input, use it in `open(path, mode)`
3. **Success message**: Reflect whether content was 'written to' or 'appended to'

## Testing

All 9 file_write tests pass with no changes needed.

Fixes #344