### PR TITLE
fix: prevent shell tool hang with pager-based commands in non-interactive mode

### DIFF
--- a/src/strands_tools/shell.py
+++ b/src/strands_tools/shell.py
@@ -126,6 +126,16 @@ class CommandExecutor:
 
             if pid == 0:  # Child process
                 try:
+                    # Ensure TERM is set for proper terminal emulation
+                    os.environ.setdefault("TERM", "xterm-256color")
+
+                    # Disable pagers in non-interactive mode to prevent hangs
+                    # (e.g. git diff spawning 'less' which waits for input)
+                    if non_interactive_mode:
+                        os.environ.setdefault("GIT_PAGER", "cat")
+                        os.environ.setdefault("PAGER", "cat")
+                        os.environ.setdefault("MANPAGER", "cat")
+
                     os.chdir(cwd)
                     os.execvp("/bin/sh", ["/bin/sh", "-c", command])
                 except Exception as e:


### PR DESCRIPTION
## Problem

When the shell tool runs commands like `git diff` or `man` in non-interactive mode, the spawned pager (usually `less`) hangs because:

1. `TERM` environment variable is not set → `less` reports `WARNING: terminal is not fully functional`
2. The pager waits for user input that never comes → command hangs until timeout

## Root Cause

In `execute_with_pty()`, the child process doesn't set `TERM` or disable pagers:

```python
if pid == 0:  # Child process
    os.chdir(cwd)
    os.execvp("/bin/sh", ["/bin/sh", "-c", command])  # TERM not set, pagers enabled
```

## Fix

1. Set `TERM=xterm-256color` if not already set (needed for PTY emulation)
2. In non-interactive mode, disable pagers by setting `GIT_PAGER=cat`, `PAGER=cat`, `MANPAGER=cat`

```python
if pid == 0:
    os.environ.setdefault("TERM", "xterm-256color")
    if non_interactive_mode:
        os.environ.setdefault("GIT_PAGER", "cat")
        os.environ.setdefault("PAGER", "cat")
        os.environ.setdefault("MANPAGER", "cat")
```

## Testing

All 30 shell tests pass.

Fixes #360