### PR TITLE
feat(code_interpreter): support custom boto3 session for cross-account access

### DIFF
--- a/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
+++ b/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
@@ -3,6 +3,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+import boto3
 from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter as BedrockAgentCoreCodeInterpreterClient
 
 from ..utils.aws_util import resolve_region
@@ -54,6 +55,7 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         auto_create: bool = True,
         persist_sessions: bool = True,
         session_timeout_seconds: int = 900,
+        boto_session: Optional[boto3.Session] = None,
     ) -> None:
         """
         Initialize the Bedrock AgentCore code interpreter with session persistence support.
@@ -104,6 +106,11 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
             session_timeout_seconds (int): Timeout in seconds for sessions created
                 by this instance. Sessions automatically terminate after the timeout period.
                 Default: 900 (15 minutes).
+
+            boto_session (Optional[boto3.Session]): Custom boto3 session for AWS authentication.
+                If provided, this session is passed to the underlying Bedrock AgentCore client,
+                enabling cross-account access or custom credential configurations.
+                If None (default), the client uses the default credential chain.
 
         Session Lifecycle:
             Invocation 1 (Instance #1):
@@ -186,6 +193,7 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         self.auto_create = auto_create
         self.persist_sessions = persist_sessions
         self.session_timeout_seconds = session_timeout_seconds
+        self.boto_session = boto_session
 
         if session_name is None:
             self.default_session = f"session-{uuid.uuid4().hex[:12]}"
@@ -266,7 +274,7 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
 
         try:
             # Create new sandbox client
-            client = BedrockAgentCoreCodeInterpreterClient(region=self.region)
+            client = BedrockAgentCoreCodeInterpreterClient(region=self.region, session=self.boto_session)
 
             client.start(
                 identifier=self.identifier,
@@ -360,7 +368,7 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
             logger.debug(f"Found session in module cache: {target_session} -> {aws_session_id}")
 
             try:
-                client = BedrockAgentCoreCodeInterpreterClient(region=self.region)
+                client = BedrockAgentCoreCodeInterpreterClient(region=self.region, session=self.boto_session)
 
                 # Verify session still exists and is ready
                 session_info = client.get_session(interpreter_id=self.identifier, session_id=aws_session_id)

--- a/tests/code_interpreter/test_agent_core_code_interpreter.py
+++ b/tests/code_interpreter/test_agent_core_code_interpreter.py
@@ -68,6 +68,7 @@ def test_initialization(interpreter):
     assert interpreter.auto_create is True
     assert interpreter.persist_sessions is True
     assert interpreter.session_timeout_seconds == 900
+    assert interpreter.boto_session is None
 
 
 def test_initialization_with_new_parameters():
@@ -412,7 +413,7 @@ def test_init_session_success(mock_client_class, interpreter, mock_client):
     assert result["content"][0]["json"]["description"] == "Test session"
     assert result["content"][0]["json"]["sessionId"] == "test-session-id-123"
 
-    mock_client_class.assert_called_once_with(region="us-west-2")
+    mock_client_class.assert_called_once_with(region="us-west-2", session=None)
     mock_client.start.assert_called_once_with(
         identifier="aws.codeinterpreter.v1", name="my-session", session_timeout_seconds=900
     )
@@ -447,7 +448,7 @@ def test_init_session_with_custom_identifier(mock_client_class, mock_client):
         assert result["content"][0]["json"]["description"] == "Test session"
         assert result["content"][0]["json"]["sessionId"] == "test-session-id-123"
 
-        mock_client_class.assert_called_once_with(region="us-west-2")
+        mock_client_class.assert_called_once_with(region="us-west-2", session=None)
         mock_client.start.assert_called_once_with(
             identifier=custom_id, name="custom-session", session_timeout_seconds=900
         )
@@ -478,7 +479,7 @@ def test_init_session_with_default_identifier(mock_client_class, mock_client):
         assert result["content"][0]["json"]["description"] == "Test session"
         assert result["content"][0]["json"]["sessionId"] == "test-session-id-123"
 
-        mock_client_class.assert_called_once_with(region="us-west-2")
+        mock_client_class.assert_called_once_with(region="us-west-2", session=None)
         mock_client.start.assert_called_once_with(
             identifier="aws.codeinterpreter.v1", name="default-session", session_timeout_seconds=900
         )
@@ -918,3 +919,54 @@ def test_module_level_session_mapping():
             mock_client2.get_session.assert_called_once_with(
                 interpreter_id="aws.codeinterpreter.v1", session_id="aws-session-123"
             )
+
+
+def test_initialization_with_boto_session():
+    """Test initialization with custom boto3 session."""
+    with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
+        mock_resolve.return_value = "us-west-2"
+        mock_session = MagicMock()
+        interpreter = AgentCoreCodeInterpreter(region="us-west-2", boto_session=mock_session)
+        assert interpreter.boto_session is mock_session
+
+
+@patch("strands_tools.code_interpreter.agent_core_code_interpreter.BedrockAgentCoreCodeInterpreterClient")
+def test_init_session_passes_boto_session_to_client(mock_client_class):
+    """Test that init_session passes boto_session to the underlying client."""
+    with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
+        mock_resolve.return_value = "us-west-2"
+        mock_session = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.session_id = "test-session-id"
+        mock_client_class.return_value = mock_client
+
+        interpreter = AgentCoreCodeInterpreter(region="us-west-2", boto_session=mock_session)
+
+        action = InitSessionAction(type="initSession", description="Test", session_name="boto-session-test")
+        result = interpreter.init_session(action)
+
+        assert result["status"] == "success"
+        mock_client_class.assert_called_once_with(region="us-west-2", session=mock_session)
+
+
+@patch("strands_tools.code_interpreter.agent_core_code_interpreter.BedrockAgentCoreCodeInterpreterClient")
+def test_ensure_session_passes_boto_session_on_reconnect(mock_client_class):
+    """Test that _ensure_session passes boto_session when reconnecting via module cache."""
+    with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
+        mock_resolve.return_value = "us-west-2"
+        mock_session = MagicMock()
+
+        _session_mapping["cached-session"] = "cached-session-id"
+
+        reconnect_client = MagicMock()
+        reconnect_client.get_session.return_value = {"status": "READY"}
+        mock_client_class.return_value = reconnect_client
+
+        interpreter = AgentCoreCodeInterpreter(region="us-west-2", boto_session=mock_session)
+
+        session_name, error = interpreter._ensure_session("cached-session")
+
+        assert session_name == "cached-session"
+        assert error is None
+        mock_client_class.assert_called_once_with(region="us-west-2", session=mock_session)


### PR DESCRIPTION
## Description

Closes #495 
Adds a boto_session parameter to AgentCoreCodeInterpreter that gets passed through to the underlying BedrockAgentCoreCodeInterpreterClient, enabling cross-account access.


## Related Issues

#495 

## Type of Change

Other (please describe): New feature — adds an optional parameter to an existing tool

## Testing

Ran unit tests for the code interpreter module. All 54 tests pass including 3 new tests covering:
- Initialization with a custom boto3 session
- init_session passes the boto3 session to the underlying client
- _ensure_session passes the boto3 session when reconnecting via module cache

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
