### PR TITLE
fix(environment): add STRANDS_NON_INTERACTIVE to PROTECTED_VARS

### DIFF
--- a/src/strands_tools/environment.py
+++ b/src/strands_tools/environment.py
@@ -147,7 +147,16 @@ Key Features:
 
 
 # Protected variables that can't be modified
-PROTECTED_VARS = {"PATH", "PYTHONPATH", "STRANDS_HOME", "SHELL", "USER", "HOME", "BYPASS_TOOL_CONSENT"}
+PROTECTED_VARS = {
+    "PATH",
+    "PYTHONPATH",
+    "STRANDS_HOME",
+    "SHELL",
+    "USER",
+    "HOME",
+    "BYPASS_TOOL_CONSENT",
+    "STRANDS_NON_INTERACTIVE",
+}
 
 
 def mask_sensitive_value(name: str, value: str) -> str:


### PR DESCRIPTION
## Description

Adds `STRANDS_NON_INTERACTIVE` to the `PROTECTED_VARS` set in the environment tool, preventing it from being modified at runtime. This is consistent with how `BYPASS_TOOL_CONSENT` is already treated.

## Related Issues

N/A

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`
- All 17 environment tests pass
- Verified that the environment tool rejects attempts to set `STRANDS_NON_INTERACTIVE`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.