### PR TITLE
fix(generate_image): use requested output_format for saved filename extension

### DIFF
--- a/src/strands_tools/generate_image.py
+++ b/src/strands_tools/generate_image.py
@@ -241,10 +241,10 @@ def generate_image(tool: ToolUse, **kwargs: Any) -> ToolResult:
                 os.makedirs(output_dir)
 
             i = 1
-            base_image_path = os.path.join(output_dir, f"{filename}.png")
+            base_image_path = os.path.join(output_dir, f"{filename}.{output_format}")
             image_path = base_image_path
             while os.path.exists(image_path):
-                image_path = os.path.join(output_dir, f"{filename}_{i}.png")
+                image_path = os.path.join(output_dir, f"{filename}_{i}.{output_format}")
                 i += 1
 
             with open(image_path, "wb") as file:

--- a/tests/test_generate_image.py
+++ b/tests/test_generate_image.py
@@ -145,6 +145,40 @@ def test_generate_image_default_params(mock_boto3_client, mock_os_path_exists, m
     assert result["status"] == "success"
 
 
+def test_generate_image_saved_filename_matches_output_format(
+    mock_boto3_client, mock_os_path_exists, mock_os_makedirs, mock_file_open
+):
+    """Saved file extension should match the requested output_format (png)."""
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {"prompt": "A cute robot", "output_format": "png"},
+    }
+
+    result = generate_image.generate_image(tool=tool_use)
+
+    mock_open, _ = mock_file_open
+    saved_path = mock_open.call_args[0][0]
+    assert saved_path.endswith(".png")
+    assert result["content"][1]["image"]["format"] == "png"
+    # The reported path and the returned format must agree.
+    assert saved_path in result["content"][0]["text"]
+
+
+def test_generate_image_default_output_format_saved_as_jpeg(
+    mock_boto3_client, mock_os_path_exists, mock_os_makedirs, mock_file_open
+):
+    """With the default output_format (jpeg), the saved file must not be a .png."""
+    tool_use = {"toolUseId": "test-tool-use-id", "input": {"prompt": "A cute robot"}}
+
+    result = generate_image.generate_image(tool=tool_use)
+
+    mock_open, _ = mock_file_open
+    saved_path = mock_open.call_args[0][0]
+    assert result["content"][1]["image"]["format"] == "jpeg"
+    assert saved_path.endswith(".jpeg")
+    assert not saved_path.endswith(".png")
+
+
 def test_generate_image_error_handling(mock_boto3_client):
     """Test error handling in generate_image."""
     # Setup boto3 client to raise an exception


### PR DESCRIPTION
Thanks to the maintainers for this tool. Small, low-risk fix.

Fixes #500

## Problem

`generate_image` threads `output_format` (default `"jpeg"`) into the Bedrock request and the returned ToolResult `format`, but the saved filename is hardcoded `.png`. A default run writes JPEG bytes into a `.png` file and reports a `.png` path that disagrees with `"format": "jpeg"`.

## Fix

Derive the saved extension from the existing `output_format` variable — filling the one place an already-established pattern was missing. No new helper, no behavior change beyond the correct extension.

## Before / After

| Item | Before | After |
|------|--------|-------|
| Default run (`output_format="jpeg"`) saved file | ❌ `output/a_cute_robot.png` | ✅ `output/a_cute_robot.jpeg` |
| ToolResult `format` | `jpeg` | `jpeg` (unchanged) |
| On-disk ext vs reported format | ❌ diverge (`.png` vs `jpeg`) | ✅ match |
| `output_format="png"` run | ✅ `.png` | ✅ `.png` (unchanged) |
| Public API / parameters / defaults / request body | — | Unchanged |
| Duplicate-filename increment logic | — | Preserved (correct ext) |

## Tests

Added 2 cases to `tests/test_generate_image.py` (reusing existing mocks). Reverting the source makes the jpeg case fail (file saved as `.png`); restoring makes all 7 pass. `ruff format`/`ruff check` clean on changed files.

---

_This contribution was prepared with the help of an AI agent (Claude Code); I reviewed every line, the rationale, and the test results before submitting._



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.