### PR TITLE
fix(editor): normalize paths for consistent cache keys

### DIFF
--- a/src/strands_tools/editor.py
+++ b/src/strands_tools/editor.py
@@ -314,7 +314,7 @@ def editor(
     console = console_util.create()
 
     try:
-        path = os.path.expanduser(path)
+        path = os.path.abspath(os.path.expanduser(path))
 
         if not command:
             raise ValueError("Command is required")


### PR DESCRIPTION
## Summary

Fix editor tool cache using non-normalized paths (fixes #345).

## Problem
The editor tool cache uses raw path strings as keys, so the same file accessed via relative vs absolute paths creates separate cache entries. This causes stale content to be returned after modifications.

## Solution
Normalize paths with  at the start of the editor function, ensuring consistent cache keys regardless of path format.

## Changes
- : Changed line 317 from  to 

## Impact
- Agents no longer retry edits unnecessarily due to stale cache content
- Consistent behavior regardless of how paths are specified (relative vs absolute)
- Single line change, low risk