### PR TITLE
fix(browser): register event loop on worker thread for stream_async

### DIFF
--- a/src/strands_tools/browser/browser.py
+++ b/src/strands_tools/browser/browser.py
@@ -946,6 +946,10 @@ class Browser(ABC):
             return {"status": "error", "content": [{"text": f"Error: {str(e)}"}]}
 
     def _execute_async(self, action_coro) -> Any:
+        # Ensure the browser's event loop is set on the current thread
+        # (strands dispatches sync methods to a worker thread)
+        asyncio.set_event_loop(self._loop)
+
         # Apply nest_asyncio if not already applied
         if not self._nest_asyncio_applied:
             nest_asyncio.apply()


### PR DESCRIPTION
Fixes #453

When strands dispatches `_execute_async` to a worker thread, the browser's event loop isn't available there, causing `RuntimeError: There is no current event loop in thread`.

**Root cause:**
- `Browser.__init__` creates an event loop on the main thread
- `_execute_async` is a sync method, so strands dispatches it to a worker thread
- The worker thread has no event loop → `self._loop.run_until_complete()` fails

**Fix:** Add `asyncio.set_event_loop(self._loop)` at the start of `_execute_async` so the browser's loop is registered on whatever thread runs the tool.

**Changes:** 1 file, +4 lines (≤10 line fix)