### PR TITLE
fix(editor): normalize paths in content cache to prevent duplicate entries

### DIFF
--- a/src/strands_tools/editor.py
+++ b/src/strands_tools/editor.py
@@ -314,7 +314,7 @@ def editor(
     console = console_util.create()
 
     try:
-        path = os.path.expanduser(path)
+        path = os.path.normpath(os.path.abspath(os.path.expanduser(path)))
 
         if not command:
             raise ValueError("Command is required")


### PR DESCRIPTION
## Issue
Fixes #345

## Description
The editor tool's CONTENT_HISTORY cache uses raw path strings as dictionary keys. When the same file is referenced via different path formats, separate cache entries are created:

`python
# These all point to the same file but create different cache entries:
editor(command='view', path='./file.py')
editor(command='view', path='/absolute/path/file.py')
editor(command='view', path='~/project/file.py')
``n
This causes:
- Stale cache reads (editing via one path doesn't invalidate the other)
- Unnecessary file I/O (cache misses for already-cached files)
- Potential data inconsistency between cache and disk

## Fix
Apply os.path.normpath(os.path.abspath(...)) after os.path.expanduser() at the entry point of the editor function (line 317). This ensures all path variants resolve to the same canonical absolute path before being used as cache keys.

`python
# Before:
path = os.path.expanduser(path)

# After:
path = os.path.normpath(os.path.abspath(os.path.expanduser(path)))
``n
This is a single-line, minimal-risk fix that normalizes the path once at the top of the function, so all downstream operations (cache reads, cache writes, file operations, backup paths) use the same canonical path.

## Testing
- Verified that os.path.normpath(os.path.abspath('./file.py')) and os.path.normpath(os.path.abspath('/full/path/file.py')) produce identical results
- No behavior change for existing absolute paths (normpath of an already-absolute path is the same path)
- Tilde expansion still works (expanduser runs first)