### PR TITLE
fix(swarm): extract content from AgentResult.message instead of non-existent .content

### DIFF
--- a/src/strands_tools/swarm.py
+++ b/src/strands_tools/swarm.py
@@ -448,9 +448,9 @@ def swarm(
         if hasattr(result, "results") and result.results:
             response_parts.append("\n**🤖 Individual Agent Contributions:**")
             for agent_name, node_result in result.results.items():
-                if hasattr(node_result, "result") and hasattr(node_result.result, "content"):
+                if hasattr(node_result, "result") and hasattr(node_result.result, "message"):
                     agent_content = []
-                    for content_block in node_result.result.content:
+                    for content_block in (node_result.result.message.get("content", []) if hasattr(node_result.result, "message") else []):
                         if hasattr(content_block, "text") and content_block.text:
                             agent_content.append(content_block.text)
 
@@ -463,9 +463,9 @@ def swarm(
             last_agent = result.node_history[-1].node_id
             if last_agent in result.results:
                 last_result = result.results[last_agent]
-                if hasattr(last_result, "result") and hasattr(last_result.result, "content"):
+                if hasattr(last_result, "result") and hasattr(last_result.result, "message"):
                     response_parts.append("\n**🎯 Final Team Result:**")
-                    for content_block in last_result.result.content:
+                    for content_block in (last_result.result.message.get("content", []) if hasattr(last_result.result, "message") else []):
                         if hasattr(content_block, "text") and content_block.text:
                             response_parts.append(content_block.text)
 


### PR DESCRIPTION
## Problem

The swarm tool silently drops ALL sub-agent output. The 'Individual Agent Contributions' section is always empty despite sub-agents producing output (visible in token counts).

## Root Cause

The code checks `hasattr(node_result.result, "content")` but `AgentResult` has `.message` (a dict with a `"content"` key), not `.content` directly. The `hasattr()` check always returns `False`, so the entire extraction block is silently skipped.

## Fix

- Check for `.message` attribute instead of `.content`
- Extract content blocks from `.message.get("content", [])`
- Applied to both individual contributions and final team result sections

Fixes #437

## Changes

- 1 file changed, 4 insertions(+), 4 deletions(-)