### PR TITLE
fix(http_request): remove proxies from LLM-controllable tool input schema

### DIFF
--- a/src/strands_tools/http_request.py
+++ b/src/strands_tools/http_request.py
@@ -61,7 +61,7 @@ TOOL_SPEC = {
         "Make HTTP requests to any API with comprehensive authentication including Bearer tokens, Basic auth, "
         "JWT, AWS SigV4, Digest auth, and enterprise authentication patterns. "
         "Includes session management, metrics, "
-        "streaming support, cookie handling, redirect control, proxy support, and optional HTML to markdown conversion."
+        "streaming support, cookie handling, redirect control, and optional HTML to markdown conversion."
     ),
     "inputSchema": {
         "json": {
@@ -193,15 +193,6 @@ TOOL_SPEC = {
                         "secret": {"type": "string"},
                         "algorithm": {"type": "string"},
                         "expiry": {"type": "integer"},
-                    },
-                },
-                "proxies": {
-                    "type": "object",
-                    "description": "Dictionary mapping protocol or protocol and hostname to the URL of the proxy.",
-                    "properties": {
-                        "http": {"type": "string"},
-                        "https": {"type": "string"},
-                        "ftp": {"type": "string"},
                     },
                 },
             },
@@ -673,17 +664,12 @@ def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
         )
         ```
 
-    7. Using proxy:
-        ```python
-        http_request(
-            method="GET",
-            url="https://example.com/api",
-            proxies={"https": "https://proxy.example.com:8080"},
-        )
-        ```
-
     Environment Variables:
     - AWS credentials are automatically loaded from environment variables or credentials file
+    - Proxies are configured by the operator at process level via the standard
+      HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars (honored by `requests`), or by
+      setting `session.proxies` in code. Proxies are intentionally not part of the
+      LLM-controllable tool input.
 
     Token Config:
     - Use HTTP_REQUEST_TOKEN_CONFIG to allow specific env vars as auth tokens for permitted domains
@@ -832,7 +818,11 @@ def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
             "verify": verify,
             "auth": auth,
             "allow_redirects": tool_input.get("allow_redirects", True),
-            "proxies": tool_input.get("proxies", None),
+            # Proxies, if any, are configured by the operator at process level
+            # (HTTP_PROXY / HTTPS_PROXY env vars, or session.proxies set in code).
+            # Proxies are intentionally NOT LLM-controllable: an attacker-influenced
+            # LLM could otherwise route credentialed requests through an actor proxy,
+            # bypassing the HTTP_REQUEST_TOKEN_CONFIG hostname allowlist.
         }
 
         # Set max_redirects if specified
@@ -1029,4 +1019,3 @@ def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
             "status": "error",
             "content": [{"text": error_text}],
         }
-

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -1138,8 +1138,8 @@ def test_markdown_conversion_non_html():
     assert '"message": "hello"' in result_text  # Should still be JSON (no conversion for non-HTML)
 
 
-def test_proxy_support():
-    """Test HTTP proxy support functionality."""
+def test_proxies_input_is_ignored():
+    """An LLM-supplied `proxies` field must NOT be forwarded to requests."""
     tool_use = {
         "toolUseId": "test-proxy-id",
         "input": {
@@ -1172,11 +1172,10 @@ def test_proxy_support():
         # Call the function
         result = http_request.http_request(tool=tool_use)
 
-    # Verify the proxy was actually passed to requests
+    # Verify the LLM-supplied proxy was NOT passed to requests
     assert mock_request.called
     call_kwargs = mock_request.call_args[1]
-    assert "proxies" in call_kwargs
-    assert call_kwargs["proxies"] == {"https": "https://proxy.example.com:8080"}
+    assert "proxies" not in call_kwargs
 
     # Verify the result
     assert result["status"] == "success"


### PR DESCRIPTION
## Description

<!-- Provide a detailed description of the changes in this PR -->

The `proxies` parameter on the `http_request` tool was flagged as a risk space. Specifically, this parameter is included in the LLM-controllable input schema, allowing an LLM influenced by indirect prompt injection to route credentialed requests through actor-controlled proxy infrastructure, bypassing the HTTP_REQUEST_TOKEN_CONFIG hostname allowlist.

Proxies are an operator/deployment concern, not something the model should choose. As such, this PR removes the parameter from the tool schema, making proxy configuration operator-controlled only. Also updates tests/comments as necessary.

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
