### PR TITLE
fix(ci): sha-pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check PR title follows conventional commits
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -76,4 +76,4 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
Pin all third-party actions to their current commit SHA to reduce supply chain risk.

| Action | Tag | SHA |
|--------|-----|-----|
| amannn/action-semantic-pull-request | v6 | 48f25628 |
| pypa/gh-action-pypi-publish | release/v1 | cef22109 |
| amannn/action-semantic-pull-request | v5 | e32d7e60 |