### PR TITLE
fix(load_tool): prompt for confirmation before loading a tool file

### DIFF
--- a/src/strands_tools/load_tool.py
+++ b/src/strands_tools/load_tool.py
@@ -177,7 +177,8 @@ def load_tool(path: str, name: str, agent=None) -> Dict[str, Any]:
 
     Notes:
         - Because loading a file executes its top-level code, the user is prompted to confirm
-          before the file is loaded; set BYPASS_TOOL_CONSENT=true to skip the prompt
+          before the file is loaded; set BYPASS_TOOL_CONSENT=true or STRANDS_NON_INTERACTIVE=true
+          to skip the prompt
         - The tool loading can be disabled via STRANDS_DISABLE_LOAD_TOOL=true environment variable
         - Python files in the cwd()/tools/ directory are automatically hot reloaded without
           requiring explicit calls to load_tool
@@ -205,7 +206,8 @@ def load_tool(path: str, name: str, agent=None) -> Dict[str, Any]:
         # Loading a tool runs the target file, so ask the user to confirm before doing so,
         # matching the confirmation prompt used by other tools such as shell.
         strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
-        if not strands_dev:
+        non_interactive_mode = os.environ.get("STRANDS_NON_INTERACTIVE", "").lower() == "true"
+        if not strands_dev and not non_interactive_mode:
             confirm = get_user_input(
                 f"<yellow><bold>Load and execute Python file '{path}' as tool '{name}'?</bold> "
                 f"This runs arbitrary code from the file. [y/*]</yellow>"

--- a/src/strands_tools/load_tool.py
+++ b/src/strands_tools/load_tool.py
@@ -56,6 +56,8 @@ from typing import Any, Dict
 
 from strands import tool
 
+from strands_tools.utils.user_input import get_user_input
+
 # Set up logging
 logger = logging.getLogger(__name__)
 
@@ -73,9 +75,10 @@ def load_tool(path: str, name: str, agent=None) -> Dict[str, Any]:
     ------------
     1. The function validates the provided tool file path exists
     2. It checks if dynamic tool loading is allowed via environment configuration
-    3. It uses the agent's tool registry to load and register the tool
-    4. Once loaded, the tool becomes available to use like any built-in tool
-    5. The tool can then be called directly on the agent object as agent.tool.tool_name(...)
+    3. It prompts for user consent before executing the file (unless BYPASS_TOOL_CONSENT is set)
+    4. It uses the agent's tool registry to load and register the tool
+    5. Once loaded, the tool becomes available to use like any built-in tool
+    6. The tool can then be called directly on the agent object as agent.tool.tool_name(...)
 
     Tool Loading Process:
     -------------------
@@ -173,6 +176,8 @@ def load_tool(path: str, name: str, agent=None) -> Dict[str, Any]:
         Various exceptions: Depending on the tool file's content and validity
 
     Notes:
+        - Because loading a file executes its top-level code, the user is prompted to confirm
+          before the file is loaded; set BYPASS_TOOL_CONSENT=true to skip the prompt
         - The tool loading can be disabled via STRANDS_DISABLE_LOAD_TOOL=true environment variable
         - Python files in the cwd()/tools/ directory are automatically hot reloaded without
           requiring explicit calls to load_tool
@@ -196,6 +201,20 @@ def load_tool(path: str, name: str, agent=None) -> Dict[str, Any]:
         # Validate that the file exists
         if not os.path.exists(path):
             raise FileNotFoundError(f"Tool file not found: {path}")
+
+        # Loading a tool runs the target file, so ask the user to confirm before doing so,
+        # matching the confirmation prompt used by other tools such as shell.
+        strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
+        if not strands_dev:
+            confirm = get_user_input(
+                f"<yellow><bold>Load and execute Python file '{path}' as tool '{name}'?</bold> "
+                f"This runs arbitrary code from the file. [y/*]</yellow>"
+            )
+            if confirm.lower() != "y":
+                return {
+                    "status": "error",
+                    "content": [{"text": f"Tool loading cancelled by user. Input: {confirm}"}],
+                }
 
         # Load the tool using the agent's tool registry
         current_agent.tool_registry.load_tool_from_filepath(tool_name=name, tool_path=path)

--- a/tests/test_load_tool.py
+++ b/tests/test_load_tool.py
@@ -57,6 +57,7 @@ def extract_result_text(result):
     return str(result)
 
 
+@patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"})
 def test_load_tool_direct(temp_tool_file):
     """Test direct invocation of the load_tool tool."""
     # Create a mock agent with a mock tool registry
@@ -109,6 +110,7 @@ def test_load_tool_file_not_found():
     mock_agent.tool_registry.load_tool_from_filepath.assert_not_called()
 
 
+@patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"})
 def test_load_tool_exception():
     """Test load_tool when an exception occurs during loading."""
     mock_agent = MagicMock()
@@ -124,6 +126,7 @@ def test_load_tool_exception():
         assert "Test exception" in result["content"][0]["text"]
 
 
+@patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"})
 def test_load_tool_via_agent(agent, temp_tool_file):
     """Test loading a tool via the agent interface."""
     # Just verify that the agent can be instantiated with the load_tool tool
@@ -134,3 +137,50 @@ def test_load_tool_via_agent(agent, temp_tool_file):
         assert True
     except Exception as e:
         pytest.fail(f"Agent load_tool call raised an exception: {e}")
+
+
+@patch.dict(os.environ, {}, clear=False)
+@patch("strands_tools.load_tool.get_user_input")
+def test_load_tool_consent_declined(mock_get_user_input, temp_tool_file):
+    """Test that load_tool aborts and does not execute the file when consent is declined."""
+    os.environ.pop("BYPASS_TOOL_CONSENT", None)
+    mock_get_user_input.return_value = "n"
+
+    mock_agent = MagicMock()
+    result = load_tool.load_tool(path=temp_tool_file, name="sample_tool", agent=mock_agent)
+
+    # Loading is refused and the file is never handed to the registry (so its code never runs).
+    assert result["status"] == "error"
+    assert "cancelled" in result["content"][0]["text"].lower()
+    mock_agent.tool_registry.load_tool_from_filepath.assert_not_called()
+    mock_get_user_input.assert_called_once()
+
+
+@patch.dict(os.environ, {}, clear=False)
+@patch("strands_tools.load_tool.get_user_input")
+def test_load_tool_consent_granted(mock_get_user_input, temp_tool_file):
+    """Test that load_tool proceeds when the user confirms the prompt."""
+    os.environ.pop("BYPASS_TOOL_CONSENT", None)
+    mock_get_user_input.return_value = "y"
+
+    mock_agent = MagicMock()
+    result = load_tool.load_tool(path=temp_tool_file, name="sample_tool", agent=mock_agent)
+
+    assert result["status"] == "success"
+    mock_agent.tool_registry.load_tool_from_filepath.assert_called_once_with(
+        tool_name="sample_tool", tool_path=temp_tool_file
+    )
+    mock_get_user_input.assert_called_once()
+
+
+@patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"})
+@patch("strands_tools.load_tool.get_user_input")
+def test_load_tool_consent_bypassed(mock_get_user_input, temp_tool_file):
+    """Test that BYPASS_TOOL_CONSENT skips the prompt and loads directly."""
+    mock_agent = MagicMock()
+    result = load_tool.load_tool(path=temp_tool_file, name="sample_tool", agent=mock_agent)
+
+    assert result["status"] == "success"
+    mock_agent.tool_registry.load_tool_from_filepath.assert_called_once()
+    # No prompt should be shown when consent is bypassed.
+    mock_get_user_input.assert_not_called()

--- a/tests/test_load_tool.py
+++ b/tests/test_load_tool.py
@@ -184,3 +184,17 @@ def test_load_tool_consent_bypassed(mock_get_user_input, temp_tool_file):
     mock_agent.tool_registry.load_tool_from_filepath.assert_called_once()
     # No prompt should be shown when consent is bypassed.
     mock_get_user_input.assert_not_called()
+
+
+@patch.dict(os.environ, {"STRANDS_NON_INTERACTIVE": "true"})
+@patch("strands_tools.load_tool.get_user_input")
+def test_load_tool_consent_non_interactive(mock_get_user_input, temp_tool_file):
+    """Test that STRANDS_NON_INTERACTIVE skips the prompt and loads directly, matching shell."""
+    os.environ.pop("BYPASS_TOOL_CONSENT", None)
+    mock_agent = MagicMock()
+    result = load_tool.load_tool(path=temp_tool_file, name="sample_tool", agent=mock_agent)
+
+    assert result["status"] == "success"
+    mock_agent.tool_registry.load_tool_from_filepath.assert_called_once()
+    # No prompt should be shown in non-interactive mode.
+    mock_get_user_input.assert_not_called()


### PR DESCRIPTION
`load_tool` loads a Python file and runs it, but it didn't confirm with the user first. Other tools that run user-provided code, like `shell`, prompt for confirmation before proceeding; `load_tool` is now consistent with that.

- Prompts via `get_user_input` before `load_tool_from_filepath`, unless `BYPASS_TOOL_CONSENT=true`.
- Aborts with an error result if the user doesn't confirm.
- `STRANDS_DISABLE_LOAD_TOOL` is unchanged as an operator-level disable.
- Adds tests for declined confirmation, granted confirmation, and the bypass.