### PR TITLE
fix(python_repl): create global REPL state lazily

### DIFF
--- a/src/strands_tools/python_repl.py
+++ b/src/strands_tools/python_repl.py
@@ -593,8 +593,6 @@ def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
     tool_use_id = tool["toolUseId"]
     tool_input = tool["input"]
 
-    repl_state = get_repl_state()
-
     code = tool_input["code"]
     interactive = os.environ.get("PYTHON_REPL_INTERACTIVE", str(tool_input.get("interactive", True))).lower() == "true"
     reset_state = os.environ.get("PYTHON_REPL_RESET_STATE", str(tool_input.get("reset_state", False))).lower() == "true"
@@ -606,12 +604,6 @@ def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
     non_interactive_mode = kwargs.get("non_interactive_mode", False)
 
     try:
-        # Handle state reset if requested
-        if reset_state:
-            console.print("[yellow]Resetting REPL state...[/]")
-            repl_state.clear_state()
-            console.print("[green]REPL state reset complete[/]")
-
         # Show code preview
         console.print(
             Panel(
@@ -666,6 +658,17 @@ def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
                     "status": "error",
                     "content": [{"text": error_message}],
                 }
+
+        # Acquire the REPL state only after the consent gate. get_repl_state()
+        # loads the persisted state file on first use, so deferring it to here
+        # keeps that load from happening before the user has approved execution.
+        repl_state = get_repl_state()
+
+        # Handle state reset if requested (also deferred until after consent).
+        if reset_state:
+            console.print("[yellow]Resetting REPL state...[/]")
+            repl_state.clear_state()
+            console.print("[green]REPL state reset complete[/]")
 
         # Track execution time and capture output
         start_time = datetime.now()

--- a/src/strands_tools/python_repl.py
+++ b/src/strands_tools/python_repl.py
@@ -278,13 +278,18 @@ class ReplState:
 # rather than at import time to avoid side effects (directory creation and
 # state file loading) when the module is merely imported.
 _repl_state: Optional[ReplState] = None
+_repl_state_lock = threading.Lock()
 
 
 def get_repl_state() -> ReplState:
     """Return the global ReplState, creating it on first use."""
     global _repl_state
     if _repl_state is None:
-        _repl_state = ReplState()
+        # Guard the check-then-set so concurrent first-use does not create
+        # two instances. Double-checked to avoid locking after initialization.
+        with _repl_state_lock:
+            if _repl_state is None:
+                _repl_state = ReplState()
     return _repl_state
 
 

--- a/src/strands_tools/python_repl.py
+++ b/src/strands_tools/python_repl.py
@@ -274,8 +274,26 @@ class ReplState:
         return objects
 
 
-# Create global state instance
-repl_state = ReplState()
+# Lazily-created global state instance. The instance is created on first use
+# rather than at import time to avoid side effects (directory creation and
+# state file loading) when the module is merely imported.
+_repl_state: Optional[ReplState] = None
+
+
+def get_repl_state() -> ReplState:
+    """Return the global ReplState, creating it on first use."""
+    global _repl_state
+    if _repl_state is None:
+        _repl_state = ReplState()
+    return _repl_state
+
+
+def __getattr__(name: str) -> Any:
+    # Preserve access to ``python_repl.repl_state`` as a module attribute while
+    # keeping initialization lazy.
+    if name == "repl_state":
+        return get_repl_state()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def clean_ansi(text: str) -> str:
@@ -317,7 +335,7 @@ class PtyManager:
                 os.dup2(self.worker_fd, 2)
 
                 # Execute in REPL namespace
-                namespace = repl_state.get_namespace()
+                namespace = get_repl_state().get_namespace()
                 exec(code, namespace)
 
                 os._exit(0)
@@ -569,6 +587,8 @@ def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
 
     tool_use_id = tool["toolUseId"]
     tool_input = tool["input"]
+
+    repl_state = get_repl_state()
 
     code = tool_input["code"]
     interactive = os.environ.get("PYTHON_REPL_INTERACTIVE", str(tool_input.get("interactive", True))).lower() == "true"

--- a/tests/test_python_repl.py
+++ b/tests/test_python_repl.py
@@ -381,6 +381,30 @@ class TestPythonRepl:
             assert "cancelled by the user" in result["content"][0]["text"]
             assert "should_not_execute" not in python_repl.repl_state.get_namespace()
 
+    def test_state_not_loaded_before_consent(self, mock_console):
+        """Declining consent must not load the persisted REPL state.
+
+        get_repl_state() loads the state file on first use, so it must only be
+        called after the user approves execution, never before the prompt.
+        """
+        tool_use = {
+            "toolUseId": "test-id",
+            "input": {"code": "should_not_execute = True", "interactive": False},
+        }
+
+        with (
+            patch("strands_tools.python_repl.get_repl_state") as mock_get_state,
+            patch("strands_tools.python_repl.get_user_input", side_effect=["n", "Testing rejection"]),
+            patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "false"}, clear=False),
+        ):
+            result = python_repl.python_repl(tool=tool_use)
+
+            assert result["status"] == "error"
+            assert "cancelled by the user" in result["content"][0]["text"]
+            # State access is deferred until after consent, so a declined run
+            # never triggers the state load.
+            mock_get_state.assert_not_called()
+
     def test_custom_rejection_message(self, mock_console):
         """Test that custom rejection message is included."""
         # Clear REPL state to ensure clean test environment

--- a/tests/test_python_repl.py
+++ b/tests/test_python_repl.py
@@ -699,3 +699,29 @@ class TestPtyManager:
         # Verify truncation occurred
         assert "[binary content truncated]" in output
         assert len(output) < len(binary_content)
+
+
+class TestLazyState:
+    """Test that the global ReplState is created lazily, not at import time."""
+
+    def test_import_does_not_create_state(self):
+        """Importing the module should not instantiate ReplState."""
+        import importlib
+
+        module = importlib.reload(python_repl)
+        try:
+            # Right after import the global instance must not exist yet.
+            assert module._repl_state is None
+        finally:
+            # Restore a usable state for subsequent tests in this session.
+            module.get_repl_state()
+
+    def test_get_repl_state_is_lazy_singleton(self):
+        """get_repl_state creates the instance on first use and reuses it."""
+        import importlib
+
+        module = importlib.reload(python_repl)
+        assert module._repl_state is None
+        first = module.get_repl_state()
+        assert module._repl_state is first
+        assert module.get_repl_state() is first


### PR DESCRIPTION
## Description

`python_repl` instantiated its global `ReplState` at module import time:

```python
repl_state = ReplState()
```

`ReplState.__init__` creates the persistence directory and loads the persisted
state file (`repl_state.pkl`). Doing this at import means simply importing
`python_repl` has filesystem side effects, before the tool is ever invoked. The
state load also previously ran early inside `python_repl()` — before the user
was prompted to confirm execution.

This change defers state creation to first use through a `get_repl_state()`
accessor, makes that accessor thread-safe, and moves the state acquisition to
after the execution consent prompt so an unapproved run never loads the state.
A module-level `__getattr__` keeps `python_repl.repl_state` working for any
existing callers that reference the attribute directly.

## Changes

- Replace the import-time `repl_state = ReplState()` with a lazily-created
  singleton via `get_repl_state()`.
- Add `__getattr__` so `python_repl.repl_state` still resolves to the singleton.
- Guard the lazy initialization with a module-level `threading.Lock`
  (double-checked) so concurrent first use cannot create two instances.
- Defer `get_repl_state()` (and the `reset_state` handling) in `python_repl()`
  until after the consent prompt, so declining consent does not trigger the
  state-file load or persistence-directory creation. The code preview still
  renders before the prompt without touching state.
- Route internal uses through `get_repl_state()`.

## Testing

- `TestLazyState` asserts the module instantiates no state on import and that
  `get_repl_state()` returns a reused singleton.
- `test_state_not_loaded_before_consent` asserts a declined run never calls
  `get_repl_state()`.
- `pytest tests/test_python_repl.py` passes (38 passed, 1 skipped).
- `ruff format --check` and `ruff check` pass on the changed files.

## Notes

Switching persistence away from `dill` (to a non-executable format) is a
separate, larger effort and is intentionally out of scope here; this PR removes
the import-time and pre-consent load paths.