### PR TITLE
fix(python_repl): restrict permissions on persisted state and error logs

### DIFF
--- a/src/strands_tools/python_repl.py
+++ b/src/strands_tools/python_repl.py
@@ -228,8 +228,11 @@ class ReplState:
 
             # Save state with owner-only permissions (0o600) so the persisted
             # namespace, which may contain sensitive values, is not readable by
-            # other users on a shared host.
+            # other users on a shared host. O_CREAT only applies the mode when
+            # the file is newly created, so fchmod the descriptor to also tighten
+            # a pre-existing file; using the fd avoids a TOCTOU race.
             fd = os.open(self.state_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            os.fchmod(fd, 0o600)
             with os.fdopen(fd, "wb") as f:
                 dill.dump(save_dict, f)
             logger.debug("Successfully saved REPL state")
@@ -758,7 +761,10 @@ def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
 
         error_msg = f"\n[{error_time.isoformat()}] Python REPL Error:\nCode:\n{code}\nError:\n{error_tb}\n"
 
+        # O_CREAT only applies the mode on creation, so fchmod the descriptor to
+        # also tighten a pre-existing log file; using the fd avoids a TOCTOU race.
         fd = os.open(error_file, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        os.fchmod(fd, 0o600)
         with os.fdopen(fd, "a") as f:
             f.write(error_msg)
         logger.debug(error_msg)

--- a/src/strands_tools/python_repl.py
+++ b/src/strands_tools/python_repl.py
@@ -232,7 +232,9 @@ class ReplState:
             # the file is newly created, so fchmod the descriptor to also tighten
             # a pre-existing file; using the fd avoids a TOCTOU race.
             fd = os.open(self.state_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-            os.fchmod(fd, 0o600)
+            # fchmod is POSIX-only; on Windows the O_CREAT mode above applies.
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
             with os.fdopen(fd, "wb") as f:
                 dill.dump(save_dict, f)
             logger.debug("Successfully saved REPL state")
@@ -764,7 +766,9 @@ def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
         # O_CREAT only applies the mode on creation, so fchmod the descriptor to
         # also tighten a pre-existing log file; using the fd avoids a TOCTOU race.
         fd = os.open(error_file, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
-        os.fchmod(fd, 0o600)
+        # fchmod is POSIX-only; on Windows the O_CREAT mode above applies.
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
         with os.fdopen(fd, "a") as f:
             f.write(error_msg)
         logger.debug(error_msg)

--- a/src/strands_tools/python_repl.py
+++ b/src/strands_tools/python_repl.py
@@ -181,7 +181,10 @@ class ReplState:
                 self.persistence_dir = os.path.join(Path.cwd(), "repl_state")
         else:
             self.persistence_dir = os.path.join(Path.cwd(), "repl_state")
-        os.makedirs(self.persistence_dir, exist_ok=True)
+        os.makedirs(self.persistence_dir, mode=0o700, exist_ok=True)
+        # makedirs honors the mode only when it creates the directory, so set
+        # restrictive permissions explicitly in case the directory already existed.
+        os.chmod(self.persistence_dir, 0o700)
         self.state_file = os.path.join(self.persistence_dir, "repl_state.pkl")
         self.load_state()
 
@@ -223,8 +226,11 @@ class ReplState:
                     except BaseException:
                         continue
 
-            # Save state
-            with open(self.state_file, "wb") as f:
+            # Save state with owner-only permissions (0o600) so the persisted
+            # namespace, which may contain sensitive values, is not readable by
+            # other users on a shared host.
+            fd = os.open(self.state_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "wb") as f:
                 dill.dump(save_dict, f)
             logger.debug("Successfully saved REPL state")
 
@@ -743,14 +749,17 @@ def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
             )
         )
 
-        # Log error with details
+        # Log error with details. The error log echoes the executed code, so it
+        # is created with owner-only permissions on a private directory.
         errors_dir = os.path.join(Path.cwd(), "errors")
-        os.makedirs(errors_dir, exist_ok=True)
+        os.makedirs(errors_dir, mode=0o700, exist_ok=True)
+        os.chmod(errors_dir, 0o700)
         error_file = os.path.join(errors_dir, "errors.txt")
 
         error_msg = f"\n[{error_time.isoformat()}] Python REPL Error:\nCode:\n{code}\nError:\n{error_tb}\n"
 
-        with open(error_file, "a") as f:
+        fd = os.open(error_file, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        with os.fdopen(fd, "a") as f:
             f.write(error_msg)
         logger.debug(error_msg)
 

--- a/tests/test_python_repl.py
+++ b/tests/test_python_repl.py
@@ -774,3 +774,44 @@ class TestStatePermissions:
                 assert os.path.exists(repl.state_file)
                 mode = stat.S_IMODE(os.stat(repl.state_file).st_mode)
                 assert mode & 0o077 == 0, oct(mode)
+
+    def test_existing_state_file_permissions_are_tightened(self):
+        """A pre-existing, group/other-readable state file is tightened on save.
+
+        os.open with O_CREAT only applies the mode on creation, so a file left
+        behind with looser permissions must still be restricted on the next save.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"PYTHON_REPL_PERSISTENCE_DIR": tmpdir}):
+                repl = python_repl.ReplState()
+                repl.clear_state()
+                # Pre-create the state file world-readable.
+                with open(repl.state_file, "wb") as f:
+                    f.write(b"stale")
+                os.chmod(repl.state_file, 0o644)
+                assert stat.S_IMODE(os.stat(repl.state_file).st_mode) & 0o077 != 0
+
+                repl.save_state("perm_test = 1")
+
+                mode = stat.S_IMODE(os.stat(repl.state_file).st_mode)
+                assert mode & 0o077 == 0, oct(mode)
+
+    def test_error_log_is_owner_only(self):
+        """The error log echoes executed code, so it must be written mode 0o600."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                tool_use = {
+                    "toolUseId": "test-id",
+                    "input": {"code": "this is not valid python", "interactive": False},
+                }
+                with patch("strands_tools.python_repl.get_user_input", return_value="y"):
+                    python_repl.python_repl(tool=tool_use)
+
+                error_file = os.path.join(tmpdir, "errors", "errors.txt")
+                assert os.path.exists(error_file)
+                mode = stat.S_IMODE(os.stat(error_file).st_mode)
+                assert mode & 0o077 == 0, oct(mode)
+            finally:
+                os.chdir(original_cwd)

--- a/tests/test_python_repl.py
+++ b/tests/test_python_repl.py
@@ -1,6 +1,7 @@
 """Tests for the python_repl tool using the Agent interface."""
 
 import os
+import stat
 import sys
 import tempfile
 import threading
@@ -749,3 +750,27 @@ class TestLazyState:
         first = module.get_repl_state()
         assert module._repl_state is first
         assert module.get_repl_state() is first
+
+
+class TestStatePermissions:
+    """Test that persisted state is written with restrictive permissions."""
+
+    def test_persistence_dir_is_owner_only(self):
+        """The persistence directory should be created mode 0o700."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"PYTHON_REPL_PERSISTENCE_DIR": tmpdir}):
+                repl = python_repl.ReplState()
+                mode = stat.S_IMODE(os.stat(repl.persistence_dir).st_mode)
+                # No group or other access bits should be set.
+                assert mode & 0o077 == 0, oct(mode)
+
+    def test_state_file_is_owner_only(self):
+        """The persisted state file should be written mode 0o600."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"PYTHON_REPL_PERSISTENCE_DIR": tmpdir}):
+                repl = python_repl.ReplState()
+                repl.clear_state()
+                repl.save_state("perm_test = 1")
+                assert os.path.exists(repl.state_file)
+                mode = stat.S_IMODE(os.stat(repl.state_file).st_mode)
+                assert mode & 0o077 == 0, oct(mode)


### PR DESCRIPTION
## Description

`python_repl` persists the REPL namespace to `repl_state/repl_state.pkl` and
appends executed code and tracebacks to `errors/errors.txt`. Both the
directories and files were created with default permissions, so on a shared
host they could be readable by other local users even though they may hold
sensitive values from the session.

This change creates those directories with mode `0o700` and writes the files
with mode `0o600` (via `os.open`), so they are owner-only.

## Changes

- Create the persistence directory and errors directory with `mode=0o700` and
  `os.chmod` them to `0o700` (covering the already-exists case).
- Write `repl_state.pkl` and `errors.txt` through `os.open(..., 0o600)`.

## Testing

- Added `TestStatePermissions` asserting no group/other permission bits are set
  on the persistence directory and the state file.
- `pytest tests/test_python_repl.py` passes.
- `ruff format --check` and `ruff check` pass on the changed files.