### PR TITLE
fix(code_interpreter): partition session cache by caller key instead of AWS identity

### DIFF
--- a/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
+++ b/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
@@ -21,18 +21,19 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 
-# Module-level session cache - persists across object instances within a single process.
+# Module-level session cache - lets a new object instance in the same process reconnect to
+# an AWS code interpreter session a previous instance started, instead of paying to recreate
+# it. Keys are partitioned per caller (see partition_key / _scoped_key) so that a session name
+# supplied in one caller's partition can never address a session created in another's.
 #
-# Keys are scoped per caller identity (see _resolve_isolation_key) so that instances
-# configured with different AWS credentials do not reconnect to each other's sessions
-# when they happen to use the same session_name. Instances that share the same identity
-# (the common case: one process, one set of credentials) still reconnect as before.
-#
-# NOTE: this in-process cache is a performance optimization, not an isolation boundary.
-# It only persists within a single Python process and is keyed on a best-effort identity.
-# Deployments that serve multiple distinct callers must run them in separate processes and
-# use distinct, unguessable session names. Do not rely on this cache to keep callers apart.
-_session_mapping: Dict[str, str] = {}  # "isolation_key\x00user_session_name" -> aws_session_id
+# The real isolation boundary is AWS-side, not this map: a session is reachable only by holding
+# its server-issued, unguessable sessionId, and every operation is authorized against the
+# interpreter's IAM execution role. This cache is a per-process reconnect convenience. The
+# partition_key is what keeps callers apart within one process; it is bound at construction
+# from operator-controlled input and is never taken from a tool action, so a model-supplied
+# session name cannot reach across partitions. Multi-tenant deployments should pass a distinct
+# partition_key per caller (e.g. the authenticated principal or agent session id).
+_session_mapping: Dict[str, str] = {}  # "partition_key\x00session_name" -> aws_session_id
 
 
 @dataclass
@@ -66,6 +67,7 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         persist_sessions: bool = True,
         session_timeout_seconds: int = 900,
         boto_session: Optional[boto3.Session] = None,
+        partition_key: Optional[str] = None,
     ) -> None:
         """
         Initialize the Bedrock AgentCore code interpreter with session persistence support.
@@ -121,6 +123,18 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
                 If provided, this session is passed to the underlying Bedrock AgentCore client,
                 enabling cross-account access or custom credential configurations.
                 If None (default), the client uses the default credential chain.
+
+            partition_key (Optional[str]): Caller partition for the in-process reconnect cache.
+                Session names are namespaced under this key, so a session name used in one
+                partition can never address a session created in another. Bind it at construction
+                from operator-controlled input (it is never read from a tool action), passing a
+                distinct value per caller in multi-tenant deployments:
+                    - The authenticated principal / tenant id, or
+                    - The agent session id (e.g. context.session_id), when one identity may run
+                      several isolated sessions.
+                Defaults to a shared "default" partition when not provided, which preserves the
+                prior single-caller reconnect behavior. The cache key is no longer derived from
+                AWS credentials.
 
         Session Lifecycle:
             Invocation 1 (Instance #1):
@@ -183,19 +197,17 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         Notes:
             - Module-level cache persists in long-running Python processes (AgentCore)
             - Cache does NOT persist across container restarts (cold starts)
-            - Cache keys are scoped per caller identity (derived from STS GetCallerIdentity
-              for the configured credentials), so instances using different identities do not
-              reconnect to each other's sessions through a shared session_name. The key stays
-              stable across credential refreshes for STS/SSO/assumed-role callers
-            - Session names must be unique per user/conversation for isolation
+            - Cache keys are namespaced by partition_key, so a session name used in one
+              partition cannot address a session created in another. partition_key is bound at
+              construction and is never taken from a tool action
             - AWS session IDs are globally unique (ULID format)
             - Sessions can be manually stopped via AWS console/API if needed
 
-            The in-process cache is a performance optimization, NOT a security boundary.
-            It lives only within a single Python process and is keyed on a best-effort
-            identity. Deployments that serve multiple distinct callers must run them in
-            separate processes and use distinct, unguessable session names rather than
-            relying on this cache to keep callers separated.
+            The in-process cache is a reconnect convenience, NOT the isolation boundary. The
+            real boundary is AWS-side: a session is reachable only by holding its server-issued,
+            unguessable sessionId, and every operation is authorized against the interpreter's
+            IAM execution role. Within a single process, partition_key is what keeps callers
+            apart, so multi-tenant deployments must pass a distinct partition_key per caller.
 
         Raises:
             ValueError: If auto_create=False and session doesn't exist, or if
@@ -214,70 +226,30 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         self.persist_sessions = persist_sessions
         self.session_timeout_seconds = session_timeout_seconds
         self.boto_session = boto_session
-        # Computed lazily and memoized on first use (see _resolve_isolation_key).
-        self._isolation_key = self._resolve_isolation_key(boto_session)
 
         if session_name is None:
             self.default_session = f"session-{uuid.uuid4().hex[:12]}"
         else:
             self.default_session = session_name
 
+        # Partition for the in-process reconnect cache. Bound here from operator-controlled
+        # input and never read from a tool action, so a model-supplied session name cannot
+        # reach across partitions. Defaults to a shared "default" partition, preserving the
+        # prior single-caller reconnect behavior; multi-tenant callers must pass a distinct
+        # partition_key per principal to keep their sessions isolated.
+        self.partition_key = partition_key if partition_key is not None else "default"
+
         self._sessions: Dict[str, SessionInfo] = {}
 
         logger.info(
             f"Initialized CodeInterpreter with session='{self.default_session}', "
-            f"identifier='{self.identifier}', auto_create={auto_create}, "
-            f"persist_sessions={persist_sessions}"
+            f"partition='{self.partition_key}', identifier='{self.identifier}', "
+            f"auto_create={auto_create}, persist_sessions={persist_sessions}"
         )
 
-    def _resolve_isolation_key(self, boto_session: Optional[boto3.Session]) -> str:
-        """Derive a rotation-stable cache-scoping key for the configured credentials.
-
-        Instances that resolve to the same key share cached sessions in the module-level
-        cache; instances with different keys do not. The goal is that two instances backed
-        by the same caller identity always reconnect to each other's cached sessions via a
-        shared session_name, while instances backed by a different identity never do.
-
-        The key is derived from the caller identity reported by STS GetCallerIdentity
-        (Account + Arn). For STS/SSO/assumed-role credentials the access key id rotates on
-        refresh, but the account and ARN stay constant, so keying on them keeps the cache
-        key stable across credential refreshes and lets reconnection succeed.
-
-        The result is memoized on the instance (this method is invoked once at init), so STS
-        is contacted at most once per interpreter. If STS is unavailable (offline, no creds,
-        permission denied), this falls back to the access key id and finally to the boto
-        session object identity, so cache scoping never crashes the interpreter.
-        """
-        if boto_session is None:
-            return "default"
-
-        try:
-            sts = boto_session.client("sts", region_name=self.region)
-            identity = sts.get_caller_identity()
-            account = identity.get("Account")
-            arn = identity.get("Arn")
-            if account or arn:
-                return f"caller:{account}/{arn}"
-        except Exception as e:
-            logger.debug(f"Could not resolve caller identity via STS for cache scoping: {e}")
-
-        # STS unavailable: fall back to the access key id of the resolved credentials.
-        # This is not rotation-stable, but it preserves the previous best-effort behavior.
-        try:
-            credentials = boto_session.get_credentials()
-            access_key = getattr(credentials, "access_key", None) if credentials else None
-            if access_key:
-                return f"akid:{access_key}"
-        except Exception as e:
-            logger.debug(f"Could not resolve credentials for cache scoping: {e}")
-
-        # Distinct boto session but no resolvable identity or credentials: scope to this
-        # session object so it cannot reconnect to another caller's cached sessions.
-        return f"session:{id(boto_session)}"
-
     def _scoped_key(self, session_name: str) -> str:
-        """Build the module-level cache key for a session name under this instance's identity."""
-        return f"{self._isolation_key}\x00{session_name}"
+        """Build the module-level cache key for a session name under this instance's partition."""
+        return f"{self.partition_key}\x00{session_name}"
 
     def start_platform(self) -> None:
         """Initialize the Bedrock AgentCoreplatform connection."""
@@ -333,7 +305,7 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         if session_name in self._sessions:
             return {"status": "error", "content": [{"text": f"Session '{session_name}' already exists"}]}
 
-        # Check if session name already in use (module-level cache, scoped to this identity)
+        # Check if session name already in use (module-level cache, scoped to this partition)
         if self._scoped_key(session_name) in _session_mapping:
             error_msg = (
                 f"Session '{session_name}' is already in use by another instance. "
@@ -355,7 +327,7 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
 
             aws_session_id = client.session_id
 
-            # Store mapping in module-level cache (scoped to this identity)
+            # Store mapping in module-level cache (scoped to this partition)
             _session_mapping[self._scoped_key(session_name)] = aws_session_id
 
             # Store session info locally
@@ -431,7 +403,7 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
             logger.debug(f"Using cached session: {target_session}")
             return target_session, None
 
-        # Check module-level cache for AWS session ID (scoped to this identity)
+        # Check module-level cache for AWS session ID (scoped to this partition)
         scoped_key = self._scoped_key(target_session)
         aws_session_id = _session_mapping.get(scoped_key)
 

--- a/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
+++ b/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
@@ -21,8 +21,18 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 
-# Module-level session cache - persists across object instances
-_session_mapping: Dict[str, str] = {}  # user_session_name -> aws_session_id
+# Module-level session cache - persists across object instances within a single process.
+#
+# Keys are scoped per caller identity (see _resolve_isolation_key) so that instances
+# configured with different AWS credentials do not reconnect to each other's sessions
+# when they happen to use the same session_name. Instances that share the same identity
+# (the common case: one process, one set of credentials) still reconnect as before.
+#
+# NOTE: this in-process cache is a performance optimization, not an isolation boundary.
+# It only persists within a single Python process and is keyed on a best-effort identity.
+# Deployments that serve multiple distinct callers must run them in separate processes and
+# use distinct, unguessable session names. Do not rely on this cache to keep callers apart.
+_session_mapping: Dict[str, str] = {}  # "isolation_key\x00user_session_name" -> aws_session_id
 
 
 @dataclass
@@ -173,9 +183,18 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         Notes:
             - Module-level cache persists in long-running Python processes (AgentCore)
             - Cache does NOT persist across container restarts (cold starts)
+            - Cache keys are scoped per caller identity (derived from the configured
+              credentials), so instances using different credentials do not reconnect to
+              each other's sessions through a shared session_name
             - Session names must be unique per user/conversation for isolation
             - AWS session IDs are globally unique (ULID format)
             - Sessions can be manually stopped via AWS console/API if needed
+
+            The in-process cache is a performance optimization, NOT a security boundary.
+            It lives only within a single Python process and is keyed on a best-effort
+            identity. Deployments that serve multiple distinct callers must run them in
+            separate processes and use distinct, unguessable session names rather than
+            relying on this cache to keep callers separated.
 
         Raises:
             ValueError: If auto_create=False and session doesn't exist, or if
@@ -194,6 +213,7 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         self.persist_sessions = persist_sessions
         self.session_timeout_seconds = session_timeout_seconds
         self.boto_session = boto_session
+        self._isolation_key = self._resolve_isolation_key(boto_session)
 
         if session_name is None:
             self.default_session = f"session-{uuid.uuid4().hex[:12]}"
@@ -207,6 +227,39 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
             f"identifier='{self.identifier}', auto_create={auto_create}, "
             f"persist_sessions={persist_sessions}"
         )
+
+    @staticmethod
+    def _resolve_isolation_key(boto_session: Optional[boto3.Session]) -> str:
+        """Derive a stable cache-scoping key from the configured credentials.
+
+        Instances that resolve to the same key share cached sessions in the module-level
+        cache; instances with different keys do not. The goal is that two instances backed
+        by different AWS credentials never reconnect to each other's cached sessions via a
+        shared session_name.
+
+        The key is best-effort and derived from the access key id of the resolved
+        credentials. When no distinguishing identity is available (no explicit boto session
+        and no resolvable credentials), a shared default is used so the common single-process,
+        single-identity reconnection behavior is preserved.
+        """
+        if boto_session is None:
+            return "default"
+
+        try:
+            credentials = boto_session.get_credentials()
+            access_key = getattr(credentials, "access_key", None) if credentials else None
+            if access_key:
+                return f"akid:{access_key}"
+        except Exception as e:
+            logger.debug(f"Could not resolve credentials for cache scoping: {e}")
+
+        # Distinct boto session but no resolvable credentials: scope to this session object
+        # so it cannot reconnect to another caller's cached sessions.
+        return f"session:{id(boto_session)}"
+
+    def _scoped_key(self, session_name: str) -> str:
+        """Build the module-level cache key for a session name under this instance's identity."""
+        return f"{self._isolation_key}\x00{session_name}"
 
     def start_platform(self) -> None:
         """Initialize the Bedrock AgentCoreplatform connection."""
@@ -262,8 +315,8 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         if session_name in self._sessions:
             return {"status": "error", "content": [{"text": f"Session '{session_name}' already exists"}]}
 
-        # Check if session name already in use (module-level cache)
-        if session_name in _session_mapping:
+        # Check if session name already in use (module-level cache, scoped to this identity)
+        if self._scoped_key(session_name) in _session_mapping:
             error_msg = (
                 f"Session '{session_name}' is already in use by another instance. "
                 f"Use a unique session name or reconnect to the existing session "
@@ -284,8 +337,8 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
 
             aws_session_id = client.session_id
 
-            # Store mapping in module-level cache
-            _session_mapping[session_name] = aws_session_id
+            # Store mapping in module-level cache (scoped to this identity)
+            _session_mapping[self._scoped_key(session_name)] = aws_session_id
 
             # Store session info locally
             self._sessions[session_name] = SessionInfo(
@@ -360,8 +413,9 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
             logger.debug(f"Using cached session: {target_session}")
             return target_session, None
 
-        # Check module-level cache for AWS session ID
-        aws_session_id = _session_mapping.get(target_session)
+        # Check module-level cache for AWS session ID (scoped to this identity)
+        scoped_key = self._scoped_key(target_session)
+        aws_session_id = _session_mapping.get(scoped_key)
 
         if aws_session_id:
             # Found in module cache - try to reconnect
@@ -387,13 +441,13 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
                 else:
                     # Session exists but not ready - remove from cache
                     logger.warning(f"Session {target_session} not READY, removing from cache")
-                    del _session_mapping[target_session]
+                    del _session_mapping[scoped_key]
 
             except Exception as e:
                 # Session doesn't exist or error - remove from cache
                 logger.debug(f"Session reconnection failed: {e}")
-                if target_session in _session_mapping:
-                    del _session_mapping[target_session]
+                if scoped_key in _session_mapping:
+                    del _session_mapping[scoped_key]
 
         # Session not found - create new if auto_create enabled
         if self.auto_create:

--- a/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
+++ b/src/strands_tools/code_interpreter/agent_core_code_interpreter.py
@@ -183,9 +183,10 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         Notes:
             - Module-level cache persists in long-running Python processes (AgentCore)
             - Cache does NOT persist across container restarts (cold starts)
-            - Cache keys are scoped per caller identity (derived from the configured
-              credentials), so instances using different credentials do not reconnect to
-              each other's sessions through a shared session_name
+            - Cache keys are scoped per caller identity (derived from STS GetCallerIdentity
+              for the configured credentials), so instances using different identities do not
+              reconnect to each other's sessions through a shared session_name. The key stays
+              stable across credential refreshes for STS/SSO/assumed-role callers
             - Session names must be unique per user/conversation for isolation
             - AWS session IDs are globally unique (ULID format)
             - Sessions can be manually stopped via AWS console/API if needed
@@ -213,6 +214,7 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         self.persist_sessions = persist_sessions
         self.session_timeout_seconds = session_timeout_seconds
         self.boto_session = boto_session
+        # Computed lazily and memoized on first use (see _resolve_isolation_key).
         self._isolation_key = self._resolve_isolation_key(boto_session)
 
         if session_name is None:
@@ -228,23 +230,39 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
             f"persist_sessions={persist_sessions}"
         )
 
-    @staticmethod
-    def _resolve_isolation_key(boto_session: Optional[boto3.Session]) -> str:
-        """Derive a stable cache-scoping key from the configured credentials.
+    def _resolve_isolation_key(self, boto_session: Optional[boto3.Session]) -> str:
+        """Derive a rotation-stable cache-scoping key for the configured credentials.
 
         Instances that resolve to the same key share cached sessions in the module-level
         cache; instances with different keys do not. The goal is that two instances backed
-        by different AWS credentials never reconnect to each other's cached sessions via a
-        shared session_name.
+        by the same caller identity always reconnect to each other's cached sessions via a
+        shared session_name, while instances backed by a different identity never do.
 
-        The key is best-effort and derived from the access key id of the resolved
-        credentials. When no distinguishing identity is available (no explicit boto session
-        and no resolvable credentials), a shared default is used so the common single-process,
-        single-identity reconnection behavior is preserved.
+        The key is derived from the caller identity reported by STS GetCallerIdentity
+        (Account + Arn). For STS/SSO/assumed-role credentials the access key id rotates on
+        refresh, but the account and ARN stay constant, so keying on them keeps the cache
+        key stable across credential refreshes and lets reconnection succeed.
+
+        The result is memoized on the instance (this method is invoked once at init), so STS
+        is contacted at most once per interpreter. If STS is unavailable (offline, no creds,
+        permission denied), this falls back to the access key id and finally to the boto
+        session object identity, so cache scoping never crashes the interpreter.
         """
         if boto_session is None:
             return "default"
 
+        try:
+            sts = boto_session.client("sts", region_name=self.region)
+            identity = sts.get_caller_identity()
+            account = identity.get("Account")
+            arn = identity.get("Arn")
+            if account or arn:
+                return f"caller:{account}/{arn}"
+        except Exception as e:
+            logger.debug(f"Could not resolve caller identity via STS for cache scoping: {e}")
+
+        # STS unavailable: fall back to the access key id of the resolved credentials.
+        # This is not rotation-stable, but it preserves the previous best-effort behavior.
         try:
             credentials = boto_session.get_credentials()
             access_key = getattr(credentials, "access_key", None) if credentials else None
@@ -253,8 +271,8 @@ class AgentCoreCodeInterpreter(CodeInterpreter):
         except Exception as e:
             logger.debug(f"Could not resolve credentials for cache scoping: {e}")
 
-        # Distinct boto session but no resolvable credentials: scope to this session object
-        # so it cannot reconnect to another caller's cached sessions.
+        # Distinct boto session but no resolvable identity or credentials: scope to this
+        # session object so it cannot reconnect to another caller's cached sessions.
         return f"session:{id(boto_session)}"
 
     def _scoped_key(self, session_name: str) -> str:

--- a/tests/code_interpreter/test_agent_core_code_interpreter.py
+++ b/tests/code_interpreter/test_agent_core_code_interpreter.py
@@ -972,101 +972,84 @@ def test_ensure_session_passes_boto_session_on_reconnect(mock_client_class):
         mock_client_class.assert_called_once_with(region="us-west-2", session=mock_session)
 
 
-def _make_boto_session(account, arn, access_key="AKIAAAAAAAAAAAAAAAA"):
-    """Build a mock boto3 session whose STS GetCallerIdentity returns a fixed account/ARN."""
-    session = MagicMock()
-    sts_client = MagicMock()
-    sts_client.get_caller_identity.return_value = {"Account": account, "Arn": arn}
-    session.client.return_value = sts_client
-    session.get_credentials.return_value.access_key = access_key
-    return session
-
-
-def test_session_cache_scoped_per_identity_keys():
-    """Instances with different caller identities produce different module-cache keys for the same name."""
+def test_partition_key_defaults_to_shared_default():
+    """When no partition_key is given, the partition is the shared 'default' (single-caller)."""
     with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
         mock_resolve.return_value = "us-west-2"
 
-        session_a = _make_boto_session("111111111111", "arn:aws:sts::111111111111:assumed-role/RoleA/sessA")
-        session_b = _make_boto_session("222222222222", "arn:aws:sts::222222222222:assumed-role/RoleB/sessB")
+        interpreter = AgentCoreCodeInterpreter(region="us-west-2", session_name="my-session")
 
-        interpreter_a = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_a)
-        interpreter_b = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_b)
+        assert interpreter.partition_key == "default"
+        assert interpreter._scoped_key("my-session") == "default\x00my-session"
+
+
+def test_session_cache_scoped_per_partition_keys():
+    """Instances in different partitions produce different module-cache keys for the same name."""
+    with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
+        mock_resolve.return_value = "us-west-2"
+
+        interpreter_a = AgentCoreCodeInterpreter(region="us-west-2", partition_key="tenant-a")
+        interpreter_b = AgentCoreCodeInterpreter(region="us-west-2", partition_key="tenant-b")
 
         # Same user-facing session name resolves to different module-cache keys.
         assert interpreter_a._scoped_key("shared-name") != interpreter_b._scoped_key("shared-name")
 
 
-def test_isolation_key_stable_across_credential_rotation():
-    """The isolation key stays stable when STS credentials rotate but the caller identity is unchanged.
+def test_partition_key_independent_of_credential_rotation():
+    """The cache key depends only on partition_key, not on AWS credentials.
 
-    Regression test for STS/SSO/assumed-role users: the live access key id rotates on every
-    credential refresh, but GetCallerIdentity reports the same Account + Arn. Keying the cache
-    on the caller identity (not the access key) keeps the scoped key stable across rotation, so
-    a later instance reconnects to the earlier instance's cached session instead of missing it.
+    A service runs under one IAM identity but serves many callers; two instances given the
+    same partition_key must produce the same scoped key (so reconnection works) regardless of
+    which boto session or credentials back them. The cache key is no longer derived from AWS
+    credentials, so rotating credentials cannot cause a reconnect miss.
     """
     with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
         mock_resolve.return_value = "us-west-2"
 
-        account = "111111111111"
-        arn = "arn:aws:sts::111111111111:assumed-role/MyRole/agentcore"
+        interpreter_before = AgentCoreCodeInterpreter(
+            region="us-west-2", partition_key="user-1", boto_session=MagicMock()
+        )
+        interpreter_after = AgentCoreCodeInterpreter(
+            region="us-west-2", partition_key="user-1", boto_session=MagicMock()
+        )
 
-        # First instance: initial (pre-rotation) access key.
-        session_before = MagicMock()
-        sts_before = MagicMock()
-        sts_before.get_caller_identity.return_value = {"Account": account, "Arn": arn}
-        session_before.client.return_value = sts_before
-        session_before.get_credentials.return_value.access_key = "AKIAOLDOLDOLDOLDOLDO"
-
-        # Second instance: credentials have rotated (new access key) but same caller identity.
-        session_after = MagicMock()
-        sts_after = MagicMock()
-        sts_after.get_caller_identity.return_value = {"Account": account, "Arn": arn}
-        session_after.client.return_value = sts_after
-        session_after.get_credentials.return_value.access_key = "AKIANEWNEWNEWNEWNEWN"
-
-        interpreter_before = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_before)
-        interpreter_after = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_after)
-
-        # Despite the rotated access key, the scoped cache key is identical, so reconnection works.
         assert interpreter_before._scoped_key("shared-name") == interpreter_after._scoped_key("shared-name")
 
 
 @patch("strands_tools.code_interpreter.agent_core_code_interpreter.BedrockAgentCoreCodeInterpreterClient")
-def test_session_not_shared_across_instances_with_different_identity(mock_client_class):
-    """A session cached by one instance is not reachable from an instance with a different identity.
+def test_session_not_shared_across_partitions(mock_client_class):
+    """A session cached in one partition is not reachable from an instance in another partition.
 
-    Regression test: instance A initializes a session under a given session_name; instance B,
-    configured with different credentials, must not reconnect to A's session by reusing that name.
+    This is the multi-tenant case the maintainer review called out: one IAM identity serves
+    many callers, so isolation must be keyed on a per-caller partition rather than on AWS
+    credentials. Instance A initializes a session under partition "tenant-a"; instance B in
+    partition "tenant-b" must not reconnect to A's session by reusing the same session name.
     """
     with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
         mock_resolve.return_value = "us-west-2"
 
-        session_a = _make_boto_session("111111111111", "arn:aws:sts::111111111111:assumed-role/RoleA/sessA")
-        session_b = _make_boto_session("222222222222", "arn:aws:sts::222222222222:assumed-role/RoleB/sessB")
-
-        # Instance A creates a session named "shared-name".
+        # Instance A creates a session named "shared-name" in partition tenant-a.
         client_a = MagicMock()
         client_a.session_id = "aws-session-a"
         mock_client_class.return_value = client_a
 
-        interpreter_a = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_a)
+        interpreter_a = AgentCoreCodeInterpreter(region="us-west-2", partition_key="tenant-a")
         result = interpreter_a.init_session(
             InitSessionAction(type="initSession", description="A", session_name="shared-name")
         )
         assert result["status"] == "success"
         assert _session_mapping[interpreter_a._scoped_key("shared-name")] == "aws-session-a"
 
-        # Instance B (different credentials) tries to reach "shared-name".
+        # Instance B in a different partition tries to reach "shared-name".
         # It must NOT reconnect to A's session; with auto_create it creates its own instead.
         client_b = MagicMock()
         client_b.session_id = "aws-session-b"
         client_b.get_session.return_value = {"status": "READY"}
         mock_client_class.return_value = client_b
 
-        interpreter_b = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_b, auto_create=True)
+        interpreter_b = AgentCoreCodeInterpreter(region="us-west-2", partition_key="tenant-b", auto_create=True)
 
-        # B does not see A's cached entry under its own identity scope.
+        # B does not see A's cached entry under its own partition scope.
         assert interpreter_b._scoped_key("shared-name") not in _session_mapping
 
         session_name, error = interpreter_b._ensure_session("shared-name")
@@ -1077,3 +1060,30 @@ def test_session_not_shared_across_instances_with_different_identity(mock_client
         client_b.get_session.assert_not_called()
         # A's cached mapping is unchanged by B's activity.
         assert _session_mapping[interpreter_a._scoped_key("shared-name")] == "aws-session-a"
+
+
+@patch("strands_tools.code_interpreter.agent_core_code_interpreter.BedrockAgentCoreCodeInterpreterClient")
+def test_same_partition_reconnects_across_instances(mock_client_class):
+    """Two instances sharing a partition_key reconnect to the same cached AWS session."""
+    with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
+        mock_resolve.return_value = "us-west-2"
+
+        client_a = MagicMock()
+        client_a.session_id = "aws-session-shared"
+        mock_client_class.return_value = client_a
+
+        interpreter_a = AgentCoreCodeInterpreter(region="us-west-2", partition_key="user-1")
+        interpreter_a.init_session(InitSessionAction(type="initSession", description="A", session_name="shared-name"))
+
+        # A second instance in the same partition reconnects to the existing AWS session.
+        client_b = MagicMock()
+        client_b.get_session.return_value = {"status": "READY"}
+        mock_client_class.return_value = client_b
+
+        interpreter_b = AgentCoreCodeInterpreter(region="us-west-2", partition_key="user-1")
+        session_name, error = interpreter_b._ensure_session("shared-name")
+
+        assert error is None
+        client_b.get_session.assert_called_once_with(
+            interpreter_id=interpreter_b.identifier, session_id="aws-session-shared"
+        )

--- a/tests/code_interpreter/test_agent_core_code_interpreter.py
+++ b/tests/code_interpreter/test_agent_core_code_interpreter.py
@@ -972,21 +972,64 @@ def test_ensure_session_passes_boto_session_on_reconnect(mock_client_class):
         mock_client_class.assert_called_once_with(region="us-west-2", session=mock_session)
 
 
+def _make_boto_session(account, arn, access_key="AKIAAAAAAAAAAAAAAAA"):
+    """Build a mock boto3 session whose STS GetCallerIdentity returns a fixed account/ARN."""
+    session = MagicMock()
+    sts_client = MagicMock()
+    sts_client.get_caller_identity.return_value = {"Account": account, "Arn": arn}
+    session.client.return_value = sts_client
+    session.get_credentials.return_value.access_key = access_key
+    return session
+
+
 def test_session_cache_scoped_per_identity_keys():
-    """Instances with different credentials produce different module-cache keys for the same name."""
+    """Instances with different caller identities produce different module-cache keys for the same name."""
     with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
         mock_resolve.return_value = "us-west-2"
 
-        session_a = MagicMock()
-        session_a.get_credentials.return_value.access_key = "AKIAAAAAAAAAAAAAAAA"
-        session_b = MagicMock()
-        session_b.get_credentials.return_value.access_key = "AKIBBBBBBBBBBBBBBBB"
+        session_a = _make_boto_session("111111111111", "arn:aws:sts::111111111111:assumed-role/RoleA/sessA")
+        session_b = _make_boto_session("222222222222", "arn:aws:sts::222222222222:assumed-role/RoleB/sessB")
 
         interpreter_a = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_a)
         interpreter_b = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_b)
 
         # Same user-facing session name resolves to different module-cache keys.
         assert interpreter_a._scoped_key("shared-name") != interpreter_b._scoped_key("shared-name")
+
+
+def test_isolation_key_stable_across_credential_rotation():
+    """The isolation key stays stable when STS credentials rotate but the caller identity is unchanged.
+
+    Regression test for STS/SSO/assumed-role users: the live access key id rotates on every
+    credential refresh, but GetCallerIdentity reports the same Account + Arn. Keying the cache
+    on the caller identity (not the access key) keeps the scoped key stable across rotation, so
+    a later instance reconnects to the earlier instance's cached session instead of missing it.
+    """
+    with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
+        mock_resolve.return_value = "us-west-2"
+
+        account = "111111111111"
+        arn = "arn:aws:sts::111111111111:assumed-role/MyRole/agentcore"
+
+        # First instance: initial (pre-rotation) access key.
+        session_before = MagicMock()
+        sts_before = MagicMock()
+        sts_before.get_caller_identity.return_value = {"Account": account, "Arn": arn}
+        session_before.client.return_value = sts_before
+        session_before.get_credentials.return_value.access_key = "AKIAOLDOLDOLDOLDOLDO"
+
+        # Second instance: credentials have rotated (new access key) but same caller identity.
+        session_after = MagicMock()
+        sts_after = MagicMock()
+        sts_after.get_caller_identity.return_value = {"Account": account, "Arn": arn}
+        session_after.client.return_value = sts_after
+        session_after.get_credentials.return_value.access_key = "AKIANEWNEWNEWNEWNEWN"
+
+        interpreter_before = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_before)
+        interpreter_after = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_after)
+
+        # Despite the rotated access key, the scoped cache key is identical, so reconnection works.
+        assert interpreter_before._scoped_key("shared-name") == interpreter_after._scoped_key("shared-name")
 
 
 @patch("strands_tools.code_interpreter.agent_core_code_interpreter.BedrockAgentCoreCodeInterpreterClient")
@@ -999,10 +1042,8 @@ def test_session_not_shared_across_instances_with_different_identity(mock_client
     with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
         mock_resolve.return_value = "us-west-2"
 
-        session_a = MagicMock()
-        session_a.get_credentials.return_value.access_key = "AKIAAAAAAAAAAAAAAAA"
-        session_b = MagicMock()
-        session_b.get_credentials.return_value.access_key = "AKIBBBBBBBBBBBBBBBB"
+        session_a = _make_boto_session("111111111111", "arn:aws:sts::111111111111:assumed-role/RoleA/sessA")
+        session_b = _make_boto_session("222222222222", "arn:aws:sts::222222222222:assumed-role/RoleB/sessB")
 
         # Instance A creates a session named "shared-name".
         client_a = MagicMock()

--- a/tests/code_interpreter/test_agent_core_code_interpreter.py
+++ b/tests/code_interpreter/test_agent_core_code_interpreter.py
@@ -133,15 +133,15 @@ def test_ensure_session_reconnection_via_module_cache(mock_client):
         ) as mock_client_class:
             mock_resolve.return_value = "us-west-2"
 
-            # Setup module cache with existing session
-            _session_mapping["target-session"] = "found-session-id"
-
             reconnect_client = MagicMock()
             reconnect_client.session_id = "found-session-id"
             reconnect_client.get_session.return_value = {"status": "READY"}
             mock_client_class.return_value = reconnect_client
 
             interpreter = AgentCoreCodeInterpreter(region="us-west-2", persist_sessions=True)
+
+            # Setup module cache with existing session (keyed per caller identity)
+            _session_mapping[interpreter._scoped_key("target-session")] = "found-session-id"
 
             session_name, error = interpreter._ensure_session("target-session")
 
@@ -164,15 +164,15 @@ def test_ensure_session_module_cache_session_not_ready():
         ) as mock_client_class:
             mock_resolve.return_value = "us-west-2"
 
-            # Setup module cache
-            _session_mapping["stale-session"] = "stale-session-id"
-
             reconnect_client = MagicMock()
             reconnect_client.session_id = "new-session-id"
             reconnect_client.get_session.return_value = {"status": "STOPPED"}
             mock_client_class.return_value = reconnect_client
 
             interpreter = AgentCoreCodeInterpreter(region="us-west-2", persist_sessions=True, auto_create=True)
+
+            # Setup module cache (keyed per caller identity)
+            _session_mapping[interpreter._scoped_key("stale-session")] = "stale-session-id"
 
             with patch.object(interpreter, "init_session") as mock_init:
                 mock_init.return_value = {"status": "success", "content": [{"text": "Created"}]}
@@ -182,7 +182,7 @@ def test_ensure_session_module_cache_session_not_ready():
                 assert session_name == "stale-session"
                 assert error is None
                 # Session should be removed from cache
-                assert "stale-session" not in _session_mapping
+                assert interpreter._scoped_key("stale-session") not in _session_mapping
                 # New session should be created
                 mock_init.assert_called_once()
 
@@ -195,15 +195,15 @@ def test_ensure_session_module_cache_get_session_fails():
         ) as mock_client_class:
             mock_resolve.return_value = "us-west-2"
 
-            # Setup module cache
-            _session_mapping["missing-session"] = "missing-session-id"
-
             reconnect_client = MagicMock()
             reconnect_client.get_session.side_effect = Exception("Session not found")
             reconnect_client.session_id = "new-session-id"
             mock_client_class.return_value = reconnect_client
 
             interpreter = AgentCoreCodeInterpreter(region="us-west-2", persist_sessions=True, auto_create=True)
+
+            # Setup module cache (keyed per caller identity)
+            _session_mapping[interpreter._scoped_key("missing-session")] = "missing-session-id"
 
             with patch.object(interpreter, "init_session") as mock_init:
                 mock_init.return_value = {"status": "success", "content": [{"text": "Created"}]}
@@ -213,7 +213,7 @@ def test_ensure_session_module_cache_get_session_fails():
                 assert session_name == "missing-session"
                 assert error is None
                 # Session should be removed from cache after error
-                assert "missing-session" not in _session_mapping
+                assert interpreter._scoped_key("missing-session") not in _session_mapping
                 mock_init.assert_called_once()
 
 
@@ -425,8 +425,8 @@ def test_init_session_success(mock_client_class, interpreter, mock_client):
     assert session_info.description == "Test session"
     assert session_info.client == mock_client
 
-    # Check module-level cache
-    assert _session_mapping.get("my-session") == "test-session-id-123"
+    # Check module-level cache (keyed per caller identity)
+    assert _session_mapping.get(interpreter._scoped_key("my-session")) == "test-session-id-123"
 
 
 @patch("strands_tools.code_interpreter.agent_core_code_interpreter.BedrockAgentCoreCodeInterpreterClient")
@@ -903,7 +903,7 @@ def test_module_level_session_mapping():
             result = interpreter1.init_session(action)
 
             assert result["status"] == "success"
-            assert _session_mapping["shared-session"] == "aws-session-123"
+            assert _session_mapping[interpreter1._scoped_key("shared-session")] == "aws-session-123"
 
             # Second instance should find session in module cache
             mock_client2 = MagicMock()
@@ -957,16 +957,82 @@ def test_ensure_session_passes_boto_session_on_reconnect(mock_client_class):
         mock_resolve.return_value = "us-west-2"
         mock_session = MagicMock()
 
-        _session_mapping["cached-session"] = "cached-session-id"
-
         reconnect_client = MagicMock()
         reconnect_client.get_session.return_value = {"status": "READY"}
         mock_client_class.return_value = reconnect_client
 
         interpreter = AgentCoreCodeInterpreter(region="us-west-2", boto_session=mock_session)
 
+        _session_mapping[interpreter._scoped_key("cached-session")] = "cached-session-id"
+
         session_name, error = interpreter._ensure_session("cached-session")
 
         assert session_name == "cached-session"
         assert error is None
         mock_client_class.assert_called_once_with(region="us-west-2", session=mock_session)
+
+
+def test_session_cache_scoped_per_identity_keys():
+    """Instances with different credentials produce different module-cache keys for the same name."""
+    with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
+        mock_resolve.return_value = "us-west-2"
+
+        session_a = MagicMock()
+        session_a.get_credentials.return_value.access_key = "AKIAAAAAAAAAAAAAAAA"
+        session_b = MagicMock()
+        session_b.get_credentials.return_value.access_key = "AKIBBBBBBBBBBBBBBBB"
+
+        interpreter_a = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_a)
+        interpreter_b = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_b)
+
+        # Same user-facing session name resolves to different module-cache keys.
+        assert interpreter_a._scoped_key("shared-name") != interpreter_b._scoped_key("shared-name")
+
+
+@patch("strands_tools.code_interpreter.agent_core_code_interpreter.BedrockAgentCoreCodeInterpreterClient")
+def test_session_not_shared_across_instances_with_different_identity(mock_client_class):
+    """A session cached by one instance is not reachable from an instance with a different identity.
+
+    Regression test: instance A initializes a session under a given session_name; instance B,
+    configured with different credentials, must not reconnect to A's session by reusing that name.
+    """
+    with patch("strands_tools.code_interpreter.agent_core_code_interpreter.resolve_region") as mock_resolve:
+        mock_resolve.return_value = "us-west-2"
+
+        session_a = MagicMock()
+        session_a.get_credentials.return_value.access_key = "AKIAAAAAAAAAAAAAAAA"
+        session_b = MagicMock()
+        session_b.get_credentials.return_value.access_key = "AKIBBBBBBBBBBBBBBBB"
+
+        # Instance A creates a session named "shared-name".
+        client_a = MagicMock()
+        client_a.session_id = "aws-session-a"
+        mock_client_class.return_value = client_a
+
+        interpreter_a = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_a)
+        result = interpreter_a.init_session(
+            InitSessionAction(type="initSession", description="A", session_name="shared-name")
+        )
+        assert result["status"] == "success"
+        assert _session_mapping[interpreter_a._scoped_key("shared-name")] == "aws-session-a"
+
+        # Instance B (different credentials) tries to reach "shared-name".
+        # It must NOT reconnect to A's session; with auto_create it creates its own instead.
+        client_b = MagicMock()
+        client_b.session_id = "aws-session-b"
+        client_b.get_session.return_value = {"status": "READY"}
+        mock_client_class.return_value = client_b
+
+        interpreter_b = AgentCoreCodeInterpreter(region="us-west-2", boto_session=session_b, auto_create=True)
+
+        # B does not see A's cached entry under its own identity scope.
+        assert interpreter_b._scoped_key("shared-name") not in _session_mapping
+
+        session_name, error = interpreter_b._ensure_session("shared-name")
+        assert session_name == "shared-name"
+        assert error is None
+
+        # B never reconnected to A's AWS session id.
+        client_b.get_session.assert_not_called()
+        # A's cached mapping is unchanged by B's activity.
+        assert _session_mapping[interpreter_a._scoped_key("shared-name")] == "aws-session-a"


### PR DESCRIPTION
## Description

`AgentCoreCodeInterpreter` keeps a module-level `_session_mapping` cache so that a new instance in a long-running process can reconnect to an existing AWS code interpreter session instead of recreating it. The cache was keyed only on the user-facing `session_name`, which is process-global, so two instances using the same `session_name` would reconnect to the same cached session regardless of who the caller was.

This change partitions the cache by an explicit, caller-supplied `partition_key`. The cache is keyed on `(partition_key, session_name)`, and `partition_key` is bound at construction from operator-controlled input and is never read from a tool action, so a model-supplied `session_name` cannot reach across partitions.

A service typically runs under a single IAM identity while serving many callers, so an AWS-credential-derived key would collapse those callers together. Keying on a caller-supplied partition instead lets one identity host many isolated sessions:

- `partition_key` defaults to a shared `"default"` partition, preserving the prior single-caller reconnect behavior.
- Multi-tenant callers pass a distinct `partition_key` per principal — the authenticated principal/tenant id, or the agent session id (e.g. `context.session_id`) when one identity runs several isolated sessions.

The in-process cache is a reconnect convenience, not the isolation boundary. The real boundary is AWS-side: a session is reachable only by holding its server-issued, unguessable `sessionId`, and every operation is authorized against the interpreter's IAM execution role. Within a single process, `partition_key` is what keeps callers apart.

The public tool contract is unchanged: the `session_name` action field and existing constructor arguments behave as before; `partition_key` is a new optional argument.

## Changes

- Add an optional `partition_key` constructor argument and key `_session_mapping` on `(partition_key, session_name)` via the `_scoped_key` helper.
- Bind `partition_key` at construction (default `"default"`); it is never taken from a tool action.
- Remove the AWS-credential / STS `GetCallerIdentity` derived key (and its eager call at init); the cache key no longer depends on AWS credentials, so credential rotation cannot cause a reconnect miss.
- Reframe the docstring and module comment to state the real boundary (server-issued `sessionId` + IAM execution role) and describe the cache as a per-process reconnect convenience partitioned by `partition_key`.

## Testing

- `pytest tests/code_interpreter/` passes (59 tests).
- `ruff format` / `ruff check` clean.
- Regression tests:
  - default `partition_key` is the shared `"default"` partition,
  - different partitions produce distinct cache keys for the same `session_name`,
  - a session cached in one partition is not reachable from another partition via the same `session_name` (the multi-tenant case),
  - two instances sharing a `partition_key` reconnect to the same cached AWS session,
  - the cache key is independent of the boto session / credentials.