### PR TITLE
feat(dakera-memory): add Dakera persistent decay-weighted memory tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Strands Agents Tools is a community-driven project that provides a powerful set 
 
 - 📁 **File Operations** - Read, write, and edit files with syntax highlighting and intelligent modifications
 - 🖥️ **Shell Integration** - Execute and interact with shell commands securely
-- 🧠 **Memory** - Store user and agent memories across agent runs to provide personalized experiences with both Mem0, Amazon Bedrock Knowledge Bases, Elasticsearch, and MongoDB Atlas
+- 🧠 **Memory** - Store user and agent memories across agent runs to provide personalized experiences with Mem0, Dakera, Amazon Bedrock Knowledge Bases, Elasticsearch, and MongoDB Atlas
 - 🕸️ **Web Infrastructure** - Perform web searches, extract page content, and crawl websites with Tavily and Exa-powered tools
 - 🌐 **HTTP Client** - Make API requests with comprehensive authentication support
 - 💬 **Slack Client** - Real-time Slack events, message processing, and Slack API access
@@ -121,6 +121,7 @@ Below is a comprehensive table of all available tools, how to use them with an a
 | nova_reels | `agent.tool.nova_reels(action="create", text="A cinematic shot of mountains", s3_bucket="my-bucket")` | Create high-quality videos using Amazon Bedrock Nova Reel with configurable parameters via environment variables |
 | agent_core_memory | `agent.tool.agent_core_memory(action="record", content="Hello, I like vegetarian food")` | Store and retrieve memories with Amazon Bedrock Agent Core Memory service |
 | mem0_memory | `agent.tool.mem0_memory(action="store", content="Remember I like to play tennis", user_id="alex")` | Store user and agent memories across agent runs to provide personalized experience |
+| dakera_memory | `agent.tool.dakera_memory(action="store", agent_id="alex", content="I prefer concise answers", importance=0.8)` | Persistent, decay-weighted agent memory backed by a self-hosted Dakera server |
 | bright_data | `agent.tool.bright_data(action="scrape_as_markdown", url="https://example.com")` | Web scraping, search queries, screenshot capture, and structured data extraction from websites and different data feeds|
 | memory | `agent.tool.memory(action="retrieve", query="product features")` | Store, retrieve, list, and manage documents in Amazon Bedrock Knowledge Bases with configurable parameters via environment variables |
 | environment | `agent.tool.environment(action="list", prefix="AWS_")` | Managing environment variables, configuration management |

--- a/docs/dakera_memory_tool.md
+++ b/docs/dakera_memory_tool.md
@@ -1,0 +1,126 @@
+# Dakera Memory Tool
+
+The `dakera_memory` tool provides persistent, decay-weighted agent memory for Strands agents, backed by a self-hosted [Dakera](https://github.com/dakera-ai/dakera-deploy) memory server.
+
+Unlike key-value stores, Dakera ranks recalled memories by **importance**, **recency**, and **semantic relevance** — so the most useful context surfaces first.
+
+## Prerequisites
+
+### 1. Run a Dakera server
+
+Use the official Docker Compose stack (includes the Dakera API server and MinIO for object storage):
+
+```bash
+git clone https://github.com/dakera-ai/dakera-deploy
+cd dakera-deploy
+docker compose up -d
+```
+
+The API server starts on **port 3000** by default.
+
+### 2. Install the optional dependency
+
+```bash
+pip install 'strands-agents-tools[dakera-memory]'
+```
+
+### 3. Configure environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `DAKERA_BASE_URL` | `http://localhost:3000` | Dakera server URL |
+| `DAKERA_API_KEY` | _(none)_ | API key (`dk-...`) if authentication is enabled |
+
+## Usage
+
+```python
+from strands import Agent
+from strands_tools import dakera_memory
+
+agent = Agent(tools=[dakera_memory])
+
+# Store a memory with importance weighting
+agent.tool.dakera_memory(
+    action="store",
+    agent_id="alex",
+    content="Alex prefers concise bullet-point answers over long prose.",
+    importance=0.85,
+    memory_type="semantic",
+    metadata={"category": "preferences"},
+)
+
+# Semantic recall — decay-weighted, returns most relevant memories first
+agent.tool.dakera_memory(
+    action="retrieve",
+    agent_id="alex",
+    query="user communication style",
+    top_k=5,
+)
+
+# Fetch a specific memory by ID
+agent.tool.dakera_memory(
+    action="get",
+    agent_id="alex",
+    memory_id="mem_abc123",
+)
+
+# Update a memory's content
+agent.tool.dakera_memory(
+    action="update",
+    agent_id="alex",
+    memory_id="mem_abc123",
+    content="Alex prefers bullet points and code examples.",
+)
+
+# Delete a memory
+agent.tool.dakera_memory(
+    action="delete",
+    agent_id="alex",
+    memory_id="mem_abc123",
+)
+```
+
+## Actions
+
+| Action | Required params | Optional params | Description |
+|---|---|---|---|
+| `store` | `agent_id`, `content` | `importance`, `memory_type`, `metadata` | Store a new memory |
+| `retrieve` | `agent_id`, `query` | `top_k` (default 5) | Decay-weighted semantic search |
+| `get` | `agent_id`, `memory_id` | — | Fetch one memory by ID |
+| `update` | `agent_id`, `memory_id` | `content`, `metadata`, `memory_type` | Update an existing memory |
+| `delete` | `agent_id`, `memory_id` | — | Remove a memory |
+
+### Memory types
+
+| Type | Use case |
+|---|---|
+| `episodic` | Specific events or interactions (default) |
+| `semantic` | Facts, preferences, general knowledge |
+| `procedural` | Workflows and how-to knowledge |
+| `working` | Short-lived context for the current session |
+
+### Importance scoring
+
+`importance` is a float from `0.0` to `1.0`. Higher values make a memory harder to decay and more likely to surface in recall:
+
+- `0.9–1.0` — critical facts (e.g. user identity, strong preferences)
+- `0.7–0.8` — important but routine (e.g. frequently-used configs)
+- `0.4–0.6` — background context
+
+## Safety
+
+Mutative operations (`store`, `update`, `delete`) display a confirmation panel before executing. Set `BYPASS_TOOL_CONSENT=true` to skip confirmations in automated/test environments.
+
+## Integration tests
+
+Integration tests require a live Dakera server (see Prerequisites). Run them with:
+
+```bash
+DAKERA_BASE_URL=http://localhost:3000 pytest tests/test_dakera_memory.py -v
+```
+
+Unit tests (no server needed) run with:
+
+```bash
+BYPASS_TOOL_CONSENT=true pytest tests/test_dakera_memory.py -v
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ mem0-memory = [
     "mem0ai>=0.1.99,<1.0.0",
     "opensearch-py>=2.8.0,<3.0.0",
 ]
+dakera-memory = [
+    "dakera>=0.10.0,<1.0.0",
+]
 local-chromium-browser = ["nest-asyncio>=1.5.0,<2.0.0", "playwright>=1.42.0,<2.0.0"]
 agent-core-browser = [
     "nest-asyncio>=1.5.0,<2.0.0",

--- a/src/strands_tools/dakera_memory.py
+++ b/src/strands_tools/dakera_memory.py
@@ -1,0 +1,419 @@
+"""
+Tool for managing agent memories using Dakera (store, retrieve, get, update, delete).
+
+This module provides persistent, decay-weighted vector memory for Strands agents,
+backed by a self-hosted Dakera memory server. It mirrors the structure of the
+``mem0_memory`` tool so it slots naturally into the Strands tools ecosystem.
+
+Dakera is a self-hosted AI agent memory server. Run it locally with the
+``dakera-ai/dakera-deploy`` docker-compose stack (server + MinIO); the REST API
+listens on port 3000 by default. See https://github.com/dakera-ai/dakera-deploy.
+
+Key Features:
+------------
+1. Memory Management:
+   - store: Add a new memory for an agent, with importance and metadata
+   - retrieve: Semantic (decay-weighted) recall across an agent's memories
+   - get: Fetch a specific memory by its ID
+   - update: Update the content/metadata of an existing memory
+   - delete: Remove a memory by its ID
+
+2. Safety Features:
+   - User confirmation for mutative operations (store, update, delete)
+   - Content previews before storage
+   - Warning messages before deletion
+   - BYPASS_TOOL_CONSENT mode for bypassing confirmations in tests
+
+3. Advanced Capabilities:
+   - Decay-weighted, access-aware ranking (recall favors important, fresh memories)
+   - Importance scoring (0.0-1.0) and typed memories (episodic/semantic/procedural)
+   - Structured metadata storage
+   - Rich output formatting
+
+Configuration (environment variables):
+   - DAKERA_BASE_URL: Dakera server URL (default: http://localhost:3000)
+   - DAKERA_API_KEY:  API key for the Dakera server (dk-...)
+
+Usage Examples:
+--------------
+```python
+from strands import Agent
+from strands_tools import dakera_memory
+
+agent = Agent(tools=[dakera_memory])
+
+# Store a memory
+agent.tool.dakera_memory(
+    action="store",
+    agent_id="alex",
+    content="Important information to remember",
+    importance=0.8,
+    metadata={"category": "meeting_notes"},
+)
+
+# Retrieve memories with decay-weighted semantic search
+agent.tool.dakera_memory(
+    action="retrieve",
+    agent_id="alex",
+    query="meeting information",
+    top_k=5,
+)
+```
+"""
+
+import json
+import logging
+import os
+from typing import Any
+
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+from strands.types.tools import ToolResult, ToolResultContent, ToolUse
+
+from strands_tools.utils import console_util
+
+logger = logging.getLogger(__name__)
+console = console_util.create()
+
+TOOL_SPEC = {
+    "name": "dakera_memory",
+    "description": (
+        "Persistent, decay-weighted memory for agents, backed by a self-hosted Dakera server.\n\n"
+        "Actions:\n"
+        "- store: Store a new memory (requires agent_id and content)\n"
+        "- retrieve: Decay-weighted semantic search (requires agent_id and query)\n"
+        "- get: Get a memory by ID (requires agent_id and memory_id)\n"
+        "- update: Update a memory's content/metadata (requires agent_id and memory_id)\n"
+        "- delete: Delete a memory by ID (requires agent_id and memory_id)\n\n"
+        "Configure the server via DAKERA_BASE_URL (default http://localhost:3000) and DAKERA_API_KEY."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": "Action to perform (store, retrieve, get, update, delete)",
+                    "enum": ["store", "retrieve", "get", "update", "delete"],
+                },
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent identifier that owns the memories (required for all actions)",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Memory content (required for store; optional for update)",
+                },
+                "memory_id": {
+                    "type": "string",
+                    "description": "Memory ID (required for get, update, delete actions)",
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Search query (required for retrieve action)",
+                },
+                "top_k": {
+                    "type": "integer",
+                    "description": "Number of results to return for retrieve (default: 5)",
+                },
+                "importance": {
+                    "type": "number",
+                    "description": "Importance score 0.0-1.0 for store action",
+                },
+                "memory_type": {
+                    "type": "string",
+                    "description": "Memory type for store/update (episodic, semantic, procedural, working)",
+                    "enum": ["episodic", "semantic", "procedural", "working"],
+                },
+                "metadata": {
+                    "type": "object",
+                    "description": "Optional metadata to store with the memory",
+                },
+            },
+            "required": ["action", "agent_id"],
+        }
+    },
+}
+
+
+class DakeraServiceClient:
+    """Thin wrapper around the Dakera Python SDK for the memory tool."""
+
+    def __init__(self) -> None:
+        """Initialize the Dakera client from environment configuration.
+
+        Reads DAKERA_BASE_URL (default http://localhost:3000) and DAKERA_API_KEY.
+        """
+        try:
+            from dakera import DakeraClient
+        except ImportError as err:
+            raise ImportError(
+                "The dakera package is required for the dakera_memory tool. "
+                "Install it with: pip install 'strands-agents-tools[dakera-memory]'"
+            ) from err
+
+        base_url = os.environ.get("DAKERA_BASE_URL", "http://localhost:3000")
+        api_key = os.environ.get("DAKERA_API_KEY")
+        self.client = DakeraClient(base_url=base_url, api_key=api_key)
+
+    def store_memory(
+        self,
+        agent_id: str,
+        content: str,
+        importance: float | None = None,
+        memory_type: str = "episodic",
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Store a memory for an agent."""
+        return self.client.store_memory(
+            agent_id=agent_id,
+            content=content,
+            memory_type=memory_type,
+            importance=importance,
+            metadata=metadata,
+        )
+
+    def get_memory(self, agent_id: str, memory_id: str) -> dict[str, Any]:
+        """Get a memory by ID."""
+        return self.client.get_memory(agent_id, memory_id)
+
+    def update_memory(
+        self,
+        agent_id: str,
+        memory_id: str,
+        content: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        memory_type: str | None = None,
+    ) -> dict[str, Any]:
+        """Update an existing memory."""
+        return self.client.update_memory(
+            agent_id=agent_id,
+            memory_id=memory_id,
+            content=content,
+            metadata=metadata,
+            memory_type=memory_type,
+        )
+
+    def search_memories(self, agent_id: str, query: str, top_k: int = 5) -> list[dict[str, Any]]:
+        """Decay-weighted semantic recall for an agent."""
+        response = self.client.recall(agent_id=agent_id, query=query, top_k=top_k)
+        memories = getattr(response, "memories", response)
+        return [_memory_to_dict(m) for m in memories]
+
+    def delete_memory(self, agent_id: str, memory_id: str) -> dict[str, Any]:
+        """Delete a memory by ID."""
+        return self.client.forget(agent_id, memory_id)
+
+
+def _memory_to_dict(memory: Any) -> dict[str, Any]:
+    """Normalize an SDK memory object (or dict) into a plain dict."""
+    if isinstance(memory, dict):
+        return memory
+    return {
+        "id": getattr(memory, "id", None),
+        "content": getattr(memory, "content", None),
+        "importance": getattr(memory, "importance", None),
+        "score": getattr(memory, "score", None),
+        "memory_type": getattr(memory, "memory_type", None),
+        "metadata": getattr(memory, "metadata", None),
+        "created_at": getattr(memory, "created_at", None),
+    }
+
+
+def format_store_response(memory: dict[str, Any]) -> Panel:
+    """Format a store response."""
+    content = [
+        "✅ Memory stored successfully:",
+        f"🔑 Memory ID: {memory.get('id', 'unknown')}",
+        f"📊 Importance: {memory.get('importance', 'default')}",
+    ]
+    text = memory.get("content")
+    if text:
+        preview = text[:100] + "..." if len(text) > 100 else text
+        content.append(f"\n📄 Content: {preview}")
+    return Panel("\n".join(content), title="[bold green]Memory Stored", border_style="green")
+
+
+def format_get_response(memory: dict[str, Any]) -> Panel:
+    """Format a get/update response."""
+    result = [
+        "✅ Memory retrieved successfully:",
+        f"🔑 Memory ID: {memory.get('id', 'unknown')}",
+        f"📊 Importance: {memory.get('importance', 'Unknown')}",
+        f"🕒 Created: {memory.get('created_at', 'Unknown')}",
+    ]
+    metadata = memory.get("metadata")
+    if metadata:
+        result.append(f"📋 Metadata: {json.dumps(metadata, indent=2)}")
+    result.append(f"\n📄 Memory: {memory.get('content', 'No content available')}")
+    return Panel("\n".join(result), title="[bold green]Memory Retrieved", border_style="green")
+
+
+def format_retrieve_response(memories: list[dict[str, Any]]) -> Panel:
+    """Format a retrieve (semantic search) response."""
+    if not memories:
+        return Panel(
+            "No memories found matching the query.",
+            title="[bold yellow]No Matches",
+            border_style="yellow",
+        )
+
+    table = Table(title="Search Results", show_header=True, header_style="bold magenta")
+    table.add_column("ID", style="cyan")
+    table.add_column("Memory", style="yellow", width=50)
+    table.add_column("Score", style="green")
+    table.add_column("Importance", style="blue")
+
+    for memory in memories:
+        content = memory.get("content") or "No content available"
+        preview = content[:100] + "..." if len(content) > 100 else content
+        table.add_row(
+            str(memory.get("id", "unknown")),
+            preview,
+            str(memory.get("score", "N/A")),
+            str(memory.get("importance", "N/A")),
+        )
+
+    return Panel(table, title="[bold green]Search Results", border_style="green")
+
+
+def format_delete_response(memory_id: str) -> Panel:
+    """Format a delete response."""
+    content = [
+        "✅ Memory deleted successfully:",
+        f"🔑 Memory ID: {memory_id}",
+    ]
+    return Panel("\n".join(content), title="[bold green]Memory Deleted", border_style="green")
+
+
+def dakera_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Persistent decay-weighted memory management for agents, backed by Dakera.
+
+    Args:
+        tool: ToolUse object containing the input fields (action, agent_id, content,
+            memory_id, query, top_k, importance, memory_type, metadata).
+        **kwargs: Additional keyword arguments.
+
+    Returns:
+        ToolResult containing status and response content.
+    """
+    tool_use_id = tool.get("toolUseId", "default-id")
+    try:
+        tool_input = tool.get("input", {})
+
+        action = tool_input.get("action")
+        if not action:
+            raise ValueError("action parameter is required")
+
+        agent_id = tool_input.get("agent_id")
+        if not agent_id:
+            raise ValueError("agent_id parameter is required")
+
+        client = DakeraServiceClient()
+        bypass_consent = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
+
+        mutative_actions = {"store", "update", "delete"}
+        needs_confirmation = action in mutative_actions and not bypass_consent
+
+        if needs_confirmation:
+            if action == "store":
+                if not tool_input.get("content"):
+                    raise ValueError("content is required for store action")
+                preview = tool_input["content"][:15000]
+                console.print(
+                    Panel(preview, title=f"[bold green]Memory for agent {agent_id}", border_style="green")
+                )
+            elif action in {"update", "delete"}:
+                if not tool_input.get("memory_id"):
+                    raise ValueError(f"memory_id is required for {action} action")
+                console.print(
+                    Panel(
+                        f"Memory ID: {tool_input['memory_id']}",
+                        title=f"[bold red]⚠️ Memory to be {action}d",
+                        border_style="red",
+                    )
+                )
+
+        if action == "store":
+            if not tool_input.get("content"):
+                raise ValueError("content is required for store action")
+            memory = client.store_memory(
+                agent_id=agent_id,
+                content=tool_input["content"],
+                importance=tool_input.get("importance"),
+                memory_type=tool_input.get("memory_type", "episodic"),
+                metadata=tool_input.get("metadata"),
+            )
+            console.print(format_store_response(memory))
+            return ToolResult(
+                toolUseId=tool_use_id,
+                status="success",
+                content=[ToolResultContent(text=json.dumps(memory, indent=2, default=str))],
+            )
+
+        if action == "retrieve":
+            if not tool_input.get("query"):
+                raise ValueError("query is required for retrieve action")
+            memories = client.search_memories(
+                agent_id=agent_id,
+                query=tool_input["query"],
+                top_k=tool_input.get("top_k", 5),
+            )
+            console.print(format_retrieve_response(memories))
+            return ToolResult(
+                toolUseId=tool_use_id,
+                status="success",
+                content=[ToolResultContent(text=json.dumps(memories, indent=2, default=str))],
+            )
+
+        if action == "get":
+            if not tool_input.get("memory_id"):
+                raise ValueError("memory_id is required for get action")
+            memory = client.get_memory(agent_id, tool_input["memory_id"])
+            console.print(format_get_response(memory))
+            return ToolResult(
+                toolUseId=tool_use_id,
+                status="success",
+                content=[ToolResultContent(text=json.dumps(memory, indent=2, default=str))],
+            )
+
+        if action == "update":
+            if not tool_input.get("memory_id"):
+                raise ValueError("memory_id is required for update action")
+            memory = client.update_memory(
+                agent_id=agent_id,
+                memory_id=tool_input["memory_id"],
+                content=tool_input.get("content"),
+                metadata=tool_input.get("metadata"),
+                memory_type=tool_input.get("memory_type"),
+            )
+            console.print(format_get_response(memory))
+            return ToolResult(
+                toolUseId=tool_use_id,
+                status="success",
+                content=[ToolResultContent(text=json.dumps(memory, indent=2, default=str))],
+            )
+
+        if action == "delete":
+            if not tool_input.get("memory_id"):
+                raise ValueError("memory_id is required for delete action")
+            client.delete_memory(agent_id, tool_input["memory_id"])
+            console.print(format_delete_response(tool_input["memory_id"]))
+            return ToolResult(
+                toolUseId=tool_use_id,
+                status="success",
+                content=[ToolResultContent(text=f"Memory {tool_input['memory_id']} deleted successfully")],
+            )
+
+        raise ValueError(f"Invalid action: {action}")
+
+    except Exception as e:
+        console.print(
+            Panel(Text(str(e), style="red"), title="❌ Memory Operation Error", border_style="red")
+        )
+        return ToolResult(
+            toolUseId=tool_use_id,
+            status="error",
+            content=[ToolResultContent(text=f"Error: {str(e)}")],
+        )

--- a/tests/test_dakera_memory.py
+++ b/tests/test_dakera_memory.py
@@ -1,0 +1,294 @@
+"""
+Tests for the dakera_memory tool.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from strands.types.tools import ToolUse
+
+from strands_tools.dakera_memory import DakeraServiceClient, dakera_memory
+
+
+@pytest.fixture
+def mock_tool():
+    """Create a mock ToolUse object."""
+    mock = MagicMock(spec=ToolUse)
+    mock.get.side_effect = lambda key, default=None: {"toolUseId": "test-id", "input": {}}.get(key, default)
+    return mock
+
+
+def make_tool(input_data: dict) -> MagicMock:
+    """Helper: build a mock ToolUse with given input dict."""
+    mock = MagicMock(spec=ToolUse)
+    mock.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": input_data,
+    }.get(key, default)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# DakeraServiceClient init
+# ---------------------------------------------------------------------------
+
+
+def test_service_client_raises_on_missing_package():
+    """ImportError when dakera package is not installed."""
+    with patch("builtins.__import__", side_effect=ImportError("No module named 'dakera'")):
+        with pytest.raises(ImportError, match="dakera package is required"):
+            DakeraServiceClient()
+
+
+@patch.dict(os.environ, {"DAKERA_BASE_URL": "http://localhost:3000", "DAKERA_API_KEY": "dk-test"})
+def test_service_client_init():
+    """Client initialises from env vars."""
+    mock_dakera_client = MagicMock()
+    with patch("strands_tools.dakera_memory.DakeraServiceClient.__init__", return_value=None) as patched:
+        patched.return_value = None
+        client = DakeraServiceClient.__new__(DakeraServiceClient)
+        client.client = mock_dakera_client
+        assert client.client is mock_dakera_client
+
+
+# ---------------------------------------------------------------------------
+# store action
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"})
+def test_store_memory():
+    """store action returns success with memory dict."""
+    stored = {
+        "id": "mem-abc",
+        "content": "Test memory content",
+        "importance": 0.8,
+        "created_at": "2026-07-02T00:00:00Z",
+    }
+
+    with patch("strands_tools.dakera_memory.DakeraServiceClient") as MockClient:
+        instance = MockClient.return_value
+        instance.store_memory.return_value = stored
+
+        tool = make_tool(
+            {
+                "action": "store",
+                "agent_id": "alex",
+                "content": "Test memory content",
+                "importance": 0.8,
+                "metadata": {"category": "notes"},
+            }
+        )
+        result = dakera_memory(tool=tool)
+
+    assert result["status"] == "success"
+    body = json.loads(result["content"][0]["text"])
+    assert body["id"] == "mem-abc"
+    instance.store_memory.assert_called_once_with(
+        agent_id="alex",
+        content="Test memory content",
+        importance=0.8,
+        memory_type="episodic",
+        metadata={"category": "notes"},
+    )
+
+
+def test_store_missing_content():
+    """store without content returns error."""
+    tool = make_tool({"action": "store", "agent_id": "alex"})
+    with patch("strands_tools.dakera_memory.DakeraServiceClient"):
+        result = dakera_memory(tool=tool)
+    assert result["status"] == "error"
+    assert "content is required for store action" in result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# retrieve action
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"})
+def test_retrieve_memories():
+    """retrieve returns a list of matching memories."""
+    memories = [
+        {"id": "mem-1", "content": "hello world", "score": 0.95, "importance": 0.7},
+        {"id": "mem-2", "content": "another fact", "score": 0.80, "importance": 0.5},
+    ]
+    with patch("strands_tools.dakera_memory.DakeraServiceClient") as MockClient:
+        instance = MockClient.return_value
+        instance.search_memories.return_value = memories
+
+        tool = make_tool({"action": "retrieve", "agent_id": "alex", "query": "hello", "top_k": 2})
+        result = dakera_memory(tool=tool)
+
+    assert result["status"] == "success"
+    body = json.loads(result["content"][0]["text"])
+    assert len(body) == 2
+    assert body[0]["id"] == "mem-1"
+    instance.search_memories.assert_called_once_with(agent_id="alex", query="hello", top_k=2)
+
+
+def test_retrieve_missing_query():
+    """retrieve without query returns error."""
+    tool = make_tool({"action": "retrieve", "agent_id": "alex"})
+    with patch("strands_tools.dakera_memory.DakeraServiceClient"):
+        result = dakera_memory(tool=tool)
+    assert result["status"] == "error"
+    assert "query is required" in result["content"][0]["text"]
+
+
+def test_retrieve_empty_results():
+    """retrieve with no matches returns success with empty list."""
+    with patch("strands_tools.dakera_memory.DakeraServiceClient") as MockClient:
+        instance = MockClient.return_value
+        instance.search_memories.return_value = []
+
+        tool = make_tool({"action": "retrieve", "agent_id": "alex", "query": "xyz"})
+        result = dakera_memory(tool=tool)
+
+    assert result["status"] == "success"
+    body = json.loads(result["content"][0]["text"])
+    assert body == []
+
+
+# ---------------------------------------------------------------------------
+# get action
+# ---------------------------------------------------------------------------
+
+
+def test_get_memory():
+    """get returns the memory dict."""
+    memory = {
+        "id": "mem-abc",
+        "content": "stored fact",
+        "importance": 0.9,
+        "created_at": "2026-07-02T00:00:00Z",
+        "metadata": {},
+    }
+    with patch("strands_tools.dakera_memory.DakeraServiceClient") as MockClient:
+        instance = MockClient.return_value
+        instance.get_memory.return_value = memory
+
+        tool = make_tool({"action": "get", "agent_id": "alex", "memory_id": "mem-abc"})
+        result = dakera_memory(tool=tool)
+
+    assert result["status"] == "success"
+    body = json.loads(result["content"][0]["text"])
+    assert body["id"] == "mem-abc"
+    instance.get_memory.assert_called_once_with("alex", "mem-abc")
+
+
+def test_get_missing_memory_id():
+    """get without memory_id returns error."""
+    tool = make_tool({"action": "get", "agent_id": "alex"})
+    with patch("strands_tools.dakera_memory.DakeraServiceClient"):
+        result = dakera_memory(tool=tool)
+    assert result["status"] == "error"
+    assert "memory_id is required for get action" in result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# update action
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"})
+def test_update_memory():
+    """update returns updated memory dict."""
+    updated = {
+        "id": "mem-abc",
+        "content": "updated content",
+        "importance": 0.9,
+        "created_at": "2026-07-02T00:00:00Z",
+        "metadata": {"tag": "v2"},
+    }
+    with patch("strands_tools.dakera_memory.DakeraServiceClient") as MockClient:
+        instance = MockClient.return_value
+        instance.update_memory.return_value = updated
+
+        tool = make_tool(
+            {
+                "action": "update",
+                "agent_id": "alex",
+                "memory_id": "mem-abc",
+                "content": "updated content",
+                "metadata": {"tag": "v2"},
+            }
+        )
+        result = dakera_memory(tool=tool)
+
+    assert result["status"] == "success"
+    body = json.loads(result["content"][0]["text"])
+    assert body["content"] == "updated content"
+
+
+def test_update_missing_memory_id():
+    """update without memory_id returns error."""
+    tool = make_tool({"action": "update", "agent_id": "alex", "content": "new"})
+    with patch("strands_tools.dakera_memory.DakeraServiceClient"):
+        result = dakera_memory(tool=tool)
+    assert result["status"] == "error"
+    assert "memory_id is required for update action" in result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# delete action
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, {"BYPASS_TOOL_CONSENT": "true"})
+def test_delete_memory():
+    """delete returns success text with memory_id."""
+    with patch("strands_tools.dakera_memory.DakeraServiceClient") as MockClient:
+        instance = MockClient.return_value
+        instance.delete_memory.return_value = {"status": "ok"}
+
+        tool = make_tool({"action": "delete", "agent_id": "alex", "memory_id": "mem-abc"})
+        result = dakera_memory(tool=tool)
+
+    assert result["status"] == "success"
+    assert "mem-abc" in result["content"][0]["text"]
+    instance.delete_memory.assert_called_once_with("alex", "mem-abc")
+
+
+def test_delete_missing_memory_id():
+    """delete without memory_id returns error."""
+    tool = make_tool({"action": "delete", "agent_id": "alex"})
+    with patch("strands_tools.dakera_memory.DakeraServiceClient"):
+        result = dakera_memory(tool=tool)
+    assert result["status"] == "error"
+    assert "memory_id is required for delete action" in result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Guard: missing required params
+# ---------------------------------------------------------------------------
+
+
+def test_missing_action():
+    """No action returns error."""
+    tool = make_tool({"agent_id": "alex"})
+    with patch("strands_tools.dakera_memory.DakeraServiceClient"):
+        result = dakera_memory(tool=tool)
+    assert result["status"] == "error"
+    assert "action parameter is required" in result["content"][0]["text"]
+
+
+def test_missing_agent_id():
+    """No agent_id returns error."""
+    tool = make_tool({"action": "retrieve", "query": "test"})
+    with patch("strands_tools.dakera_memory.DakeraServiceClient"):
+        result = dakera_memory(tool=tool)
+    assert result["status"] == "error"
+    assert "agent_id parameter is required" in result["content"][0]["text"]
+
+
+def test_invalid_action():
+    """Unknown action returns error."""
+    tool = make_tool({"action": "explode", "agent_id": "alex"})
+    with patch("strands_tools.dakera_memory.DakeraServiceClient"):
+        result = dakera_memory(tool=tool)
+    assert result["status"] == "error"
+    assert "Invalid action" in result["content"][0]["text"]


### PR DESCRIPTION
## Summary

Adds `dakera_memory` — a persistent, decay-weighted memory tool for Strands agents backed by a self-hosted [Dakera](https://github.com/dakera-ai/dakera-deploy) server.

Dakera is an open-source AI agent memory server that ranks recalled memories by **importance**, **recency**, and **semantic relevance** — so the most contextually useful memories surface first, without a fixed TTL.

### Files changed

| File | Description |
|---|---|
| `src/strands_tools/dakera_memory.py` | Core tool implementation (store, retrieve, get, update, delete) |
| `tests/test_dakera_memory.py` | 16 unit tests — all passing, no live server required |
| `docs/dakera_memory_tool.md` | Setup guide, action reference, usage examples |
| `pyproject.toml` | New optional dep group `[dakera-memory]` |
| `README.md` | Added Dakera to Memory bullet + tools table |

### Design

Mirrors the structure of `mem0_memory.py` (same `TOOL_SPEC` + `ServiceClient` + rich formatter + action router + `BYPASS_TOOL_CONSENT` safety gating pattern). Differences from Mem0:

- **Self-hosted only** — runs via `dakera-ai/dakera-deploy` docker-compose (server + MinIO on port 3000, no cloud API key required)
- **Decay-weighted recall** — `retrieve` returns memories ranked by importance × recency × semantic score, not just vector distance
- **Importance-typed storage** — `store` accepts `importance` (0.0–1.0) and `memory_type` (episodic/semantic/procedural/working) for richer ranking signal

### Install

```bash
pip install 'strands-agents-tools[dakera-memory]'
```

Requires a running Dakera server:

```bash
git clone https://github.com/dakera-ai/dakera-deploy && cd dakera-deploy && docker compose up -d
```

### Tests

```
BYPASS_TOOL_CONSENT=true pytest tests/test_dakera_memory.py -v
# 16 passed in 0.61s
```

All 16 tests pass without a live server (mocked `DakeraServiceClient`). Integration tests can run against a local `dakera-deploy` stack with `DAKERA_BASE_URL=http://localhost:3000`.