### PR TITLE
docs: fix Stability AI source link

### DIFF
--- a/docs/stability_ai_tool.md
+++ b/docs/stability_ai_tool.md
@@ -59,7 +59,7 @@ agent = Agent(tools=[generate_image_stability])
 agent("Generate an image of a futuristic robot in a cyberpunk city")
 ```
 
-Please see the [Stability AI tool source code](generate_image_stability.py) for details and structure of the object it returns.
+Please see the [Stability AI tool source code](../src/strands_tools/generate_image_stability.py) for details and structure of the object it returns.
 
 For example, you can access the image from the `tool_result`:
 


### PR DESCRIPTION
## Description

Fix the Stability AI docs link to point to the actual `generate_image_stability.py` source file under `src/strands_tools`.

## Related Issues

None.

## Documentation PR

N/A.

## Type of Change

Documentation update

## Testing

- `git diff --check`
- Targeted local Markdown link check for `docs/stability_ai_tool.md`

I did not run `hatch run prepare`; this is a docs-only relative-link fix.

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.