### PR TITLE
fix(memory): bind tenant namespace out of LLM-controllable tool inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Below is a comprehensive table of all available tools, how to use them with an a
 | retrieve | `agent.tool.retrieve(text="What is STRANDS?")` | Retrieving information from Amazon Bedrock Knowledge Bases with optional metadata |
 | nova_reels | `agent.tool.nova_reels(action="create", text="A cinematic shot of mountains", s3_bucket="my-bucket")` | Create high-quality videos using Amazon Bedrock Nova Reel with configurable parameters via environment variables |
 | agent_core_memory | `agent.tool.agent_core_memory(action="record", content="Hello, I like vegetarian food")` | Store and retrieve memories with Amazon Bedrock Agent Core Memory service |
-| mem0_memory | `agent.tool.mem0_memory(action="store", content="Remember I like to play tennis", user_id="alex")` | Store user and agent memories across agent runs to provide personalized experience |
+| mem0_memory | `agent.tool.mem0_memory(action="store", content="Remember I like to play tennis")` | Store user and agent memories across agent runs to provide personalized experience (tenant identity configured via `Mem0MemoryTool` or environment variables) |
 | bright_data | `agent.tool.bright_data(action="scrape_as_markdown", url="https://example.com")` | Web scraping, search queries, screenshot capture, and structured data extraction from websites and different data feeds|
 | memory | `agent.tool.memory(action="retrieve", query="product features")` | Store, retrieve, list, and manage documents in Amazon Bedrock Knowledge Bases with configurable parameters via environment variables |
 | environment | `agent.tool.environment(action="list", prefix="AWS_")` | Managing environment variables, configuration management |
@@ -151,8 +151,8 @@ Below is a comprehensive table of all available tools, how to use them with an a
 | use_computer | `agent.tool.use_computer(action="click", x=100, y=200, app_name="Chrome") ` | Desktop automation, GUI interaction, screen capture |
 | search_video | `agent.tool.search_video(query="people discussing AI")` | Semantic video search using TwelveLabs' Marengo model |
 | chat_video | `agent.tool.chat_video(prompt="What are the main topics?", video_id="video_123")` | Interactive video analysis using TwelveLabs' Pegasus model |
-| mongodb_memory | `agent.tool.mongodb_memory(action="record", content="User prefers vegetarian pizza", connection_string="mongodb+srv://...", database_name="memories")` | Store and retrieve memories using MongoDB Atlas with semantic search via AWS Bedrock Titan embeddings |
-| elasticsearch_memory | `agent.tool.elasticsearch_memory(action="record", content="User prefers dark mode", cloud_id="...", api_key="...")` | Store and retrieve memories using Elasticsearch with semantic search via AWS Bedrock Titan embeddings |
+| mongodb_memory | `agent.tool.mongodb_memory(action="record", content="User prefers vegetarian pizza")` | Store and retrieve memories using MongoDB Atlas with semantic search via AWS Bedrock Titan embeddings (connection and namespace configured via `MongoDBMemoryTool` or environment variables) |
+| elasticsearch_memory | `agent.tool.elasticsearch_memory(action="record", content="User prefers dark mode")` | Store and retrieve memories using Elasticsearch with semantic search via AWS Bedrock Titan embeddings (connection and namespace configured via `ElasticsearchMemoryTool` or environment variables) |
 
 \* *These tools do not work on windows*
 
@@ -935,20 +935,22 @@ result = agent.tool.graph(action="delete", graph_id="research_pipeline")
 
 ```python
 from strands import Agent
-from strands_tools.elasticsearch_memory import elasticsearch_memory
+from strands_tools.elasticsearch_memory import ElasticsearchMemoryTool, elasticsearch_memory
 
-# Create agent with direct tool usage
-agent = Agent(tools=[elasticsearch_memory])
+# Bind connection, index, and namespace per principal (kept out of the agent-facing tool)
+memory_tool = ElasticsearchMemoryTool(
+    cloud_id="your-elasticsearch-cloud-id",  # or es_url="https://...:443" for Serverless
+    api_key="your-api-key",
+    index_name="memories",
+    namespace="user_123",
+)
+agent = Agent(tools=[memory_tool.elasticsearch_memory])
 
 # Store a memory with semantic embeddings
 result = agent.tool.elasticsearch_memory(
     action="record",
     content="User prefers vegetarian pizza with extra cheese",
     metadata={"category": "food_preferences", "type": "dietary"},
-    cloud_id="your-elasticsearch-cloud-id",
-    api_key="your-api-key",
-    index_name="memories",
-    namespace="user_123"
 )
 
 # Search memories using semantic similarity (vector search)
@@ -956,50 +958,20 @@ result = agent.tool.elasticsearch_memory(
     action="retrieve",
     query="food preferences and dietary restrictions",
     max_results=5,
-    cloud_id="your-elasticsearch-cloud-id",
-    api_key="your-api-key",
-    index_name="memories",
-    namespace="user_123"
 )
-
-# Use configuration dictionary for cleaner code
-config = {
-    "cloud_id": "your-elasticsearch-cloud-id",
-    "api_key": "your-api-key",
-    "index_name": "memories",
-    "namespace": "user_123"
-}
 
 # List all memories with pagination
-result = agent.tool.elasticsearch_memory(
-    action="list",
-    max_results=10,
-    **config
-)
+result = agent.tool.elasticsearch_memory(action="list", max_results=10)
 
 # Get specific memory by ID
-result = agent.tool.elasticsearch_memory(
-    action="get",
-    memory_id="mem_1234567890_abcd1234",
-    **config
-)
+result = agent.tool.elasticsearch_memory(action="get", memory_id="mem_1234567890_abcd1234")
 
 # Delete a memory
-result = agent.tool.elasticsearch_memory(
-    action="delete",
-    memory_id="mem_1234567890_abcd1234",
-    **config
-)
+result = agent.tool.elasticsearch_memory(action="delete", memory_id="mem_1234567890_abcd1234")
 
-# Use Elasticsearch Serverless (URL-based connection)
-result = agent.tool.elasticsearch_memory(
-    action="record",
-    content="User prefers vegetarian pizza",
-    es_url="https://your-serverless-cluster.es.region.aws.elastic.cloud:443",
-    api_key="your-api-key",
-    index_name="memories",
-    namespace="user_123"
-)
+# Single-tenant: use the standalone tool with configuration from environment variables
+agent = Agent(tools=[elasticsearch_memory])
+result = agent.tool.elasticsearch_memory(action="record", content="User prefers vegetarian pizza")
 ```
 
 ### MongoDB Atlas Memory
@@ -1008,20 +980,22 @@ result = agent.tool.elasticsearch_memory(
 
 ```python
 from strands import Agent
-from strands_tools.mongodb_memory import mongodb_memory
+from strands_tools.mongodb_memory import MongoDBMemoryTool, mongodb_memory
 
-# Create agent with direct tool usage
-agent = Agent(tools=[mongodb_memory])
+# Bind connection, collection, and namespace per principal (kept out of the agent-facing tool)
+memory_tool = MongoDBMemoryTool(
+    cluster_uri="mongodb+srv://username:password@cluster0.mongodb.net/?retryWrites=true&w=majority",
+    database_name="memories",
+    collection_name="user_memories",
+    namespace="user_123",
+)
+agent = Agent(tools=[memory_tool.mongodb_memory])
 
 # Store a memory with semantic embeddings
 result = agent.tool.mongodb_memory(
     action="record",
     content="User prefers vegetarian pizza with extra cheese",
     metadata={"category": "food_preferences", "type": "dietary"},
-    connection_string="mongodb+srv://username:password@cluster0.mongodb.net/?retryWrites=true&w=majority",
-    database_name="memories",
-    collection_name="user_memories",
-    namespace="user_123"
 )
 
 # Search memories using semantic similarity (vector search)
@@ -1029,50 +1003,20 @@ result = agent.tool.mongodb_memory(
     action="retrieve",
     query="food preferences and dietary restrictions",
     max_results=5,
-    connection_string="mongodb+srv://username:password@cluster0.mongodb.net/?retryWrites=true&w=majority",
-    database_name="memories",
-    collection_name="user_memories",
-    namespace="user_123"
 )
-
-# Use configuration dictionary for cleaner code
-config = {
-    "connection_string": "mongodb+srv://username:password@cluster0.mongodb.net/?retryWrites=true&w=majority",
-    "database_name": "memories",
-    "collection_name": "user_memories",
-    "namespace": "user_123"
-}
 
 # List all memories with pagination
-result = agent.tool.mongodb_memory(
-    action="list",
-    max_results=10,
-    **config
-)
+result = agent.tool.mongodb_memory(action="list", max_results=10)
 
 # Get specific memory by ID
-result = agent.tool.mongodb_memory(
-    action="get",
-    memory_id="mem_1234567890_abcd1234",
-    **config
-)
+result = agent.tool.mongodb_memory(action="get", memory_id="mem_1234567890_abcd1234")
 
 # Delete a memory
-result = agent.tool.mongodb_memory(
-    action="delete",
-    memory_id="mem_1234567890_abcd1234",
-    **config
-)
+result = agent.tool.mongodb_memory(action="delete", memory_id="mem_1234567890_abcd1234")
 
-# Use environment variables for connection
-# Set MONGODB_ATLAS_CLUSTER_URI in your environment
-result = agent.tool.mongodb_memory(
-    action="record",
-    content="User prefers vegetarian pizza",
-    database_name="memories",
-    collection_name="user_memories",
-    namespace="user_123"
-)
+# Single-tenant: use the standalone tool with configuration from environment variables
+agent = Agent(tools=[mongodb_memory])
+result = agent.tool.mongodb_memory(action="record", content="User prefers vegetarian pizza")
 ```
 
 ## 🌍 Environment Variables Configuration
@@ -1134,6 +1078,24 @@ These variables affect multiple tools:
 
 #### Mem0 Memory Tool
 
+**Security Model:** The tenant-isolation keys (`user_id` / `agent_id`) are never exposed as agent-facing tool parameters. The agent only chooses the `action` and its `content`/`query`/`memory_id`. This prevents a model (or prompt-injected content) from reading, writing, or deleting another tenant's memories.
+
+**Usage patterns:**
+
+```python
+from strands import Agent
+from strands_tools.mem0_memory import Mem0MemoryTool, mem0_memory
+
+# Multi-tenant (recommended): bind identity per authenticated principal
+tool = Mem0MemoryTool(user_id=f"user_{authenticated_user_id}")
+agent = Agent(tools=[tool.mem0_memory])
+agent.tool.mem0_memory(action="store", content="User prefers vegetarian pizza")
+
+# Single-tenant: use the standalone function with env vars (MEM0_USER_ID / MEM0_AGENT_ID)
+agent = Agent(tools=[mem0_memory])
+agent.tool.mem0_memory(action="store", content="User prefers vegetarian pizza")
+```
+
 The Mem0 Memory Tool supports three different backend configurations:
 
 1. **Mem0 Platform**:
@@ -1154,15 +1116,17 @@ The Mem0 Memory Tool supports three different backend configurations:
    ```
    # Configure your Neptune Analytics graph ID in the .env file:
    export NEPTUNE_ANALYTICS_GRAPH_IDENTIFIER=sample-graph-id
-   
+
    # Configure your Neptune Analytics graph ID in Python code:
    import os
    os.environ['NEPTUNE_ANALYTICS_GRAPH_IDENTIFIER'] = "g-sample-graph-id"
-   
+
    ```
 
 | Environment Variable | Description | Default | Required For |
 |----------------------|-------------|---------|--------------|
+| MEM0_USER_ID | User ID for memory operations (standalone function) | None | Standalone |
+| MEM0_AGENT_ID | Agent ID for memory operations (standalone function) | None | Standalone |
 | MEM0_API_KEY | Mem0 Platform API key | None | Mem0 Platform |
 | OPENSEARCH_HOST | OpenSearch Host URL | None | OpenSearch |
 | AWS_REGION | AWS Region for OpenSearch | us-west-2 | OpenSearch |

--- a/docs/elasticsearch_memory_tool.md
+++ b/docs/elasticsearch_memory_tool.md
@@ -32,31 +32,54 @@ This will install:
    - AWS credentials configured
    - Access to `amazon.titan-embed-text-v2:0` model (or custom embedding model)
 
+## Security Model
+
+Connection credentials (`cloud_id`/`es_url`/`api_key`), the target `index_name`, and the tenant `namespace` are **never** exposed as agent-facing tool parameters. The agent only chooses the `action` and its `content`/`query`/`memory_id`. This prevents a model (or prompt-injected content) from redirecting the memory layer at another cluster or index, authenticating with its own `api_key`, or reading, writing, or deleting another tenant's memories by supplying a different `namespace`.
+
+There are two supported patterns:
+
+- **Class-based (recommended, required for multi-tenant):** construct one `ElasticsearchMemoryTool` per authenticated principal, binding the connection, index, and `namespace` at construction time.
+- **Standalone function (single-tenant):** the module-level `elasticsearch_memory` tool reads all connection, index, namespace, and embedding configuration from environment variables only.
+
 ## Quick Start
 
-### Basic Setup
+### Class-Based Usage (Recommended)
+
+Bind the connection, index, and tenant `namespace` per authenticated principal. They are kept out of the agent-facing tool, so the model cannot change them.
+
+```python
+from strands import Agent
+from strands_tools.elasticsearch_memory import ElasticsearchMemoryTool
+
+# Operator code, per authenticated request:
+memory_tool = ElasticsearchMemoryTool(
+    cloud_id="your-elasticsearch-cloud-id",  # or es_url="https://...:443" for Serverless
+    api_key="your-elasticsearch-api-key",
+    index_name="my_memories",
+    namespace=f"user_{authenticated_user_id}",  # bound, not LLM-controllable
+)
+agent = Agent(tools=[memory_tool.elasticsearch_memory])
+
+# The agent only chooses the action and its content/query/memory_id:
+result = agent.tool.elasticsearch_memory(action="record", content="User prefers vegetarian pizza")
+result = agent.tool.elasticsearch_memory(action="retrieve", query="food preferences", max_results=5)
+```
+
+### Standalone Function Usage
+
+Single-tenant convenience. All connection, index, namespace, and embedding configuration comes from environment variables; there are no connection or namespace parameters for the agent to supply.
 
 ```python
 from strands import Agent
 from strands_tools.elasticsearch_memory import elasticsearch_memory
 
-# Create an agent with the direct tool
 agent = Agent(tools=[elasticsearch_memory])
-
-# Use the tool with configuration parameters
-result = agent.tool.elasticsearch_memory(
-    action="record",
-    content="User prefers vegetarian pizza with extra cheese",
-    cloud_id="your-elasticsearch-cloud-id",
-    api_key="your-elasticsearch-api-key",
-    index_name="my_memories",
-    namespace="user_123"
-)
+result = agent.tool.elasticsearch_memory(action="record", content="User prefers vegetarian pizza")
 ```
 
 ### Environment Variables
 
-You can also use environment variables for configuration:
+Configure the standalone function (and the fallbacks for the class) with environment variables:
 
 ```bash
 export ELASTICSEARCH_CLOUD_ID="your-cloud-id"
@@ -67,17 +90,16 @@ export ELASTICSEARCH_EMBEDDING_MODEL="amazon.titan-embed-text-v2:0"
 export AWS_REGION="us-west-2"
 ```
 
-Then use the tool with minimal parameters (environment variables will be used):
+The standalone `elasticsearch_memory` function is single-tenant: it always uses `ELASTICSEARCH_NAMESPACE` (defaulting to `default`). To serve multiple principals, use the class-based approach and construct one `ElasticsearchMemoryTool` per principal with an explicit `namespace`.
 
 ```python
-result = agent.tool.elasticsearch_memory(
-    action="record",
-    content="User prefers vegetarian pizza"
-    # cloud_id, api_key, etc. will be read from environment variables
-)
+agent = Agent(tools=[elasticsearch_memory])
+result = agent.tool.elasticsearch_memory(action="record", content="User prefers vegetarian pizza")
 ```
 
 ## Usage Examples
+
+The examples below use a per-principal `ElasticsearchMemoryTool` (see Quick Start) and assume `agent = Agent(tools=[memory_tool.elasticsearch_memory])`.
 
 ### 1. Store Memories
 
@@ -86,10 +108,6 @@ result = agent.tool.elasticsearch_memory(
 result = agent.tool.elasticsearch_memory(
     action="record",
     content="User prefers vegetarian pizza with extra cheese and no onions",
-    cloud_id="your-cloud-id",
-    api_key="your-api-key",
-    index_name="memories",
-    namespace="user_123"
 )
 
 # Store a memory with metadata
@@ -102,10 +120,6 @@ result = agent.tool.elasticsearch_memory(
         "participants": ["dev_team"],
         "date": "2024-01-16"
     },
-    cloud_id="your-cloud-id",
-    api_key="your-api-key",
-    index_name="memories",
-    namespace="user_123"
 )
 ```
 
@@ -117,10 +131,6 @@ result = agent.tool.elasticsearch_memory(
     action="retrieve",
     query="food preferences and dietary restrictions",
     max_results=5,
-    cloud_id="your-cloud-id",
-    api_key="your-api-key",
-    index_name="memories",
-    namespace="user_123"
 )
 
 # Search for meeting information
@@ -128,10 +138,6 @@ result = agent.tool.elasticsearch_memory(
     action="retrieve",
     query="upcoming meetings and appointments",
     max_results=10,
-    cloud_id="your-cloud-id",
-    api_key="your-api-key",
-    index_name="memories",
-    namespace="user_123"
 )
 ```
 
@@ -142,10 +148,6 @@ result = agent.tool.elasticsearch_memory(
 result = agent.tool.elasticsearch_memory(
     action="list",
     max_results=20,
-    cloud_id="your-cloud-id",
-    api_key="your-api-key",
-    index_name="memories",
-    namespace="user_123"
 )
 
 # List with pagination
@@ -153,10 +155,6 @@ result = agent.tool.elasticsearch_memory(
     action="list",
     max_results=10,
     next_token="10",  # Start from the 11th result
-    cloud_id="your-cloud-id",
-    api_key="your-api-key",
-    index_name="memories",
-    namespace="user_123"
 )
 ```
 
@@ -167,10 +165,6 @@ result = agent.tool.elasticsearch_memory(
 result = agent.tool.elasticsearch_memory(
     action="get",
     memory_id="mem_1704567890123_abc12345",
-    cloud_id="your-cloud-id",
-    api_key="your-api-key",
-    index_name="memories",
-    namespace="user_123"
 )
 ```
 
@@ -181,90 +175,84 @@ result = agent.tool.elasticsearch_memory(
 result = agent.tool.elasticsearch_memory(
     action="delete",
     memory_id="mem_1704567890123_abc12345",
-    cloud_id="your-cloud-id",
-    api_key="your-api-key",
-    index_name="memories",
-    namespace="user_123"
 )
 ```
 
 ## Advanced Configuration
 
-### Using Configuration Dictionary
+### Reusing a Connection Configuration
 
-For cleaner code, you can use a configuration dictionary:
+For cleaner code, collect the connection settings once and bind them to a per-principal tool at construction time:
 
 ```python
 config = {
     "cloud_id": "your-cloud-id",
     "api_key": "your-api-key",
     "index_name": "memories",
-    "namespace": "user_123",
-    "region": "us-east-1"
+    "region": "us-east-1",
 }
 
+# Bind the connection plus the authenticated principal's namespace.
+memory_tool = ElasticsearchMemoryTool(namespace=f"user_{authenticated_user_id}", **config)
+agent = Agent(tools=[memory_tool.elasticsearch_memory])
+
 # Store memory
-result = agent.tool.elasticsearch_memory(
-    action="record",
-    content="User prefers vegetarian pizza",
-    **config
-)
+result = agent.tool.elasticsearch_memory(action="record", content="User prefers vegetarian pizza")
 
 # Search memories
-result = agent.tool.elasticsearch_memory(
-    action="retrieve",
-    query="food preferences",
-    max_results=5,
-    **config
-)
+result = agent.tool.elasticsearch_memory(action="retrieve", query="food preferences", max_results=5)
 ```
 
 ### Custom Embedding Model
 
+The embedding model and region are bound at construction (or via `ELASTICSEARCH_EMBEDDING_MODEL` / `AWS_REGION` for the standalone function):
+
 ```python
-result = agent.tool.elasticsearch_memory(
-    action="record",
-    content="User prefers vegetarian pizza",
+memory_tool = ElasticsearchMemoryTool(
     cloud_id="your-cloud-id",
     api_key="your-api-key",
+    namespace="user_123",
     embedding_model="amazon.titan-embed-text-v1:0",  # Different model
-    region="us-east-1"
+    region="us-east-1",
 )
 ```
 
 ### Elasticsearch Serverless (URL-based connection)
 
+Use `es_url` instead of `cloud_id` for Serverless deployments:
+
 ```python
-result = agent.tool.elasticsearch_memory(
-    action="record",
-    content="User prefers vegetarian pizza",
+memory_tool = ElasticsearchMemoryTool(
     es_url="https://your-serverless-cluster.es.region.aws.elastic.cloud:443",
     api_key="your-api-key",
     index_name="memories",
-    namespace="user_123"
+    namespace="user_123",
 )
+agent = Agent(tools=[memory_tool.elasticsearch_memory])
+result = agent.tool.elasticsearch_memory(action="record", content="User prefers vegetarian pizza")
 ```
 
 ### Multiple Namespaces
 
+The `namespace` is bound per tool instance. To serve multiple principals (or logical groupings), construct one `ElasticsearchMemoryTool` per namespace — never let the agent choose the namespace on a call.
+
 ```python
-# User-specific memories
-result = agent.tool.elasticsearch_memory(
-    action="record",
-    content="Alice likes Italian food",
+# One tool per user, each bound to that user's namespace
+alice_tool = ElasticsearchMemoryTool(
     cloud_id="your-cloud-id",
     api_key="your-api-key",
-    namespace="user_alice"
+    namespace="user_alice",
 )
 
-# System-wide memories
-result = agent.tool.elasticsearch_memory(
-    action="record",
-    content="System maintenance scheduled",
+# A separate tool for system-wide memories
+system_tool = ElasticsearchMemoryTool(
     cloud_id="your-cloud-id",
     api_key="your-api-key",
-    namespace="system_global"
+    namespace="system_global",
 )
+
+# Wire the tool that matches the authenticated principal into that principal's agent.
+alice_agent = Agent(tools=[alice_tool.elasticsearch_memory])
 ```
 
 ## Response Format
@@ -351,13 +339,14 @@ The tool provides comprehensive error handling:
 ### Connection Errors
 
 ```python
-# Invalid credentials
-result = agent.tool.elasticsearch_memory(
-    action="record",
-    content="test",
+# Invalid credentials (configured at construction)
+memory_tool = ElasticsearchMemoryTool(
     cloud_id="invalid-cloud-id",
-    api_key="invalid-api-key"
+    api_key="invalid-api-key",
+    namespace="user_123",
 )
+agent = Agent(tools=[memory_tool.elasticsearch_memory])
+result = agent.tool.elasticsearch_memory(action="record", content="test")
 # Returns: {"status": "error", "content": [{"text": "Unable to connect to Elasticsearch cluster"}]}
 ```
 
@@ -365,29 +354,21 @@ result = agent.tool.elasticsearch_memory(
 
 ```python
 # Missing required content for record action
-result = agent.tool.elasticsearch_memory(
-    action="record",
-    cloud_id="your-cloud-id",
-    api_key="your-api-key"
-)
+result = agent.tool.elasticsearch_memory(action="record")
 # Returns: {"status": "error", "content": [{"text": "The following parameters are required for record action: content"}]}
 
-# Missing connection parameters
-result = agent.tool.elasticsearch_memory(action="record", content="test")
-# Returns: {"status": "error", "content": [{"text": "Either cloud_id or es_url is required"}]}
+# Missing connection configuration (no api_key at construction and no
+# ELASTICSEARCH_API_KEY environment variable) raises at construction time:
+ElasticsearchMemoryTool(cloud_id="your-cloud-id", namespace="user_123")
+# Raises: ElasticsearchValidationError("api_key is required for Elasticsearch Memory Tool initialization")
 ```
 
 ### Memory Not Found
 
 ```python
 # Non-existent memory ID
-result = agent.tool.elasticsearch_memory(
-    action="get",
-    memory_id="nonexistent",
-    cloud_id="your-cloud-id",
-    api_key="your-api-key"
-)
-# Returns: {"status": "error", "content": [{"text": "API error: Memory nonexistent not found"}]}
+result = agent.tool.elasticsearch_memory(action="get", memory_id="nonexistent")
+# Returns: {"status": "error", "content": [{"text": "Memory nonexistent not found in namespace user_123"}]}
 ```
 
 ## Performance Considerations
@@ -414,36 +395,30 @@ result = agent.tool.elasticsearch_memory(
 
 ### 1. Configuration Management
 
-Create reusable configuration objects:
+Build a per-principal tool from reusable connection settings, binding the authenticated user's namespace at construction:
 
 ```python
-# Create a base configuration
+# Create a base connection configuration
 base_config = {
     "cloud_id": "your-cloud-id",
     "api_key": "your-api-key",
-    "region": "us-east-1"
+    "index_name": "user_memories",
+    "region": "us-east-1",
 }
 
-# User-specific configuration
-def get_user_config(user_id):
-    return {
-        **base_config,
-        "index_name": "user_memories",
-        "namespace": f"user_{user_id}"
-    }
+# Build one tool per authenticated principal
+def build_user_agent(user_id):
+    memory_tool = ElasticsearchMemoryTool(namespace=f"user_{user_id}", **base_config)
+    return Agent(tools=[memory_tool.elasticsearch_memory])
 
 # Usage
-user_config = get_user_config("alice")
-result = agent.tool.elasticsearch_memory(
-    action="record",
-    content="Alice likes Italian food",
-    **user_config
-)
+alice_agent = build_user_agent("alice")
+result = alice_agent.tool.elasticsearch_memory(action="record", content="Alice likes Italian food")
 ```
 
 ### 2. Namespace Organization
 
-The namespace parameter is crucial for data isolation and multi-tenant memory management:
+The `namespace` is crucial for data isolation and multi-tenant memory management. It is bound per tool instance and is not agent-controllable:
 
 ```python
 # User-based namespaces
@@ -458,6 +433,13 @@ org_user_namespace = f"org_{org_id}_user_{user_id}"
 # Feature-based namespaces
 chat_namespace = "feature_chat"
 task_namespace = "feature_tasks"
+
+# Bind the chosen namespace when constructing the tool
+memory_tool = ElasticsearchMemoryTool(
+    cloud_id="your-cloud-id",
+    api_key="your-api-key",
+    namespace=user_namespace,
+)
 ```
 
 ### 3. Metadata Usage
@@ -474,7 +456,6 @@ result = agent.tool.elasticsearch_memory(
         "due_date": "2024-02-01",
         "assigned_to": ["alice", "bob"]
     },
-    **config
 )
 ```
 
@@ -496,26 +477,26 @@ def safe_memory_operation(agent, action, **kwargs):
 ### 5. Batch Operations
 
 ```python
-# Store multiple related memories
+# Store multiple related memories with a single per-principal tool
 memories = [
     "User likes Italian food",
     "User is allergic to nuts", 
     "User prefers evening meetings"
 ]
 
-config = {
-    "cloud_id": "your-cloud-id",
-    "api_key": "your-api-key",
-    "index_name": "memories",
-    "namespace": "user_123"
-}
+memory_tool = ElasticsearchMemoryTool(
+    cloud_id="your-cloud-id",
+    api_key="your-api-key",
+    index_name="memories",
+    namespace="user_123",
+)
+agent = Agent(tools=[memory_tool.elasticsearch_memory])
 
 for content in memories:
     agent.tool.elasticsearch_memory(
         action="record",
         content=content,
         metadata={"batch": "user_preferences", "timestamp": datetime.now().isoformat()},
-        **config
     )
 ```
 
@@ -552,12 +533,13 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 # This will show detailed Elasticsearch and Bedrock API calls
-result = agent.tool.elasticsearch_memory(
-    action="record",
-    content="test",
+memory_tool = ElasticsearchMemoryTool(
     cloud_id="your-cloud-id",
-    api_key="your-api-key"
+    api_key="your-api-key",
+    namespace="user_123",
 )
+agent = Agent(tools=[memory_tool.elasticsearch_memory])
+result = agent.tool.elasticsearch_memory(action="record", content="test")
 ```
 
 ## Security Considerations
@@ -571,7 +553,7 @@ result = agent.tool.elasticsearch_memory(
 
 ### Data Privacy
 
-- Use appropriate namespaces for data isolation
+- Bind the `namespace` per authenticated principal at construction; never expose it as an agent-controllable parameter (see Security Model)
 - Consider encryption at rest (Elasticsearch feature)
 - Implement proper access controls
 - Regular security audits

--- a/docs/mongodb_memory_tool.md
+++ b/docs/mongodb_memory_tool.md
@@ -53,66 +53,54 @@ If you're new to MongoDB Atlas:
 
 For detailed instructions, see the [official MongoDB Atlas documentation](https://www.mongodb.com/docs/atlas/connect-to-database-deployment/).
 
+## Security Model
+
+Connection credentials, the target database/collection, and the tenant `namespace` are **never** exposed as agent-facing tool parameters. The agent only chooses the `action` and its `content`/`query`/`memory_id`. This prevents a model (or prompt-injected content) from redirecting the memory layer at another cluster or reading, writing, or deleting another tenant's memories by supplying a different `namespace`.
+
+There are two supported patterns:
+
+- **Class-based (recommended, required for multi-tenant):** construct one `MongoDBMemoryTool` per authenticated principal, binding the connection and `namespace` at construction time.
+- **Standalone function (single-tenant):** the module-level `mongodb_memory` tool reads all connection, collection, namespace, and embedding configuration from environment variables only.
+
 ## Quick Start
 
 ### Class-Based Usage (Recommended)
 
+Bind the connection, collection, and tenant `namespace` per authenticated principal. They are kept out of the agent-facing tool, so the model cannot change them.
+
 ```python
+from strands import Agent
 from strands_tools.mongodb_memory import MongoDBMemoryTool
 
-# Initialize the tool
-memory_tool = MongoDBMemoryTool()
-
-# Store a memory
-result = memory_tool.record_memory(
-    content="User prefers vegetarian pizza with extra cheese",
+# Operator code, per authenticated request:
+memory_tool = MongoDBMemoryTool(
     cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
     database_name="memory_db",
     collection_name="memories",
-    namespace="user_123"
+    namespace=f"user_{authenticated_user_id}",  # bound, not LLM-controllable
 )
+agent = Agent(tools=[memory_tool.mongodb_memory])
 
-# Search memories
-result = memory_tool.retrieve_memories(
-    query="food preferences",
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123",
-    max_results=5
-)
+# The agent only chooses the action and its content/query/memory_id:
+result = agent.tool.mongodb_memory(action="record", content="User prefers vegetarian pizza")
+result = agent.tool.mongodb_memory(action="retrieve", query="food preferences", max_results=5)
 ```
 
 ### Standalone Function Usage
 
+Single-tenant convenience. All connection, collection, namespace, and embedding configuration comes from environment variables; there are no connection or namespace parameters for the agent to supply.
+
 ```python
+from strands import Agent
 from strands_tools.mongodb_memory import mongodb_memory
 
-# Store a memory
-result = mongodb_memory(
-    action="record",
-    content="User prefers vegetarian pizza with extra cheese",
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123"
-)
-
-# Search memories
-result = mongodb_memory(
-    action="retrieve",
-    query="food preferences",
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123",
-    max_results=5
-)
+agent = Agent(tools=[mongodb_memory])
+result = agent.tool.mongodb_memory(action="record", content="User prefers vegetarian pizza")
 ```
 
 ### Environment Variables
 
-You can use environment variables for configuration:
+Configure the standalone function (and the fallbacks for the class) with environment variables:
 
 ```bash
 export MONGODB_ATLAS_CLUSTER_URI="mongodb+srv://user:password@cluster.mongodb.net/"
@@ -123,29 +111,17 @@ export MONGODB_EMBEDDING_MODEL="amazon.titan-embed-text-v2:0"
 export AWS_REGION="us-west-2"
 ```
 
-**Note:** Environment variables take precedence over tool parameters in the standalone function.
-To let the agent control the connection target, use the class-based approach or leave the
-environment variable unset.
-
-Then use the tool with minimal parameters (environment variables will be used):
+The standalone `mongodb_memory` function is single-tenant: it always uses `MONGODB_NAMESPACE` (defaulting to `default`). To serve multiple principals, use the class-based approach and construct one `MongoDBMemoryTool` per principal with an explicit `namespace`.
 
 ```python
-# Class-based usage
-memory_tool = MongoDBMemoryTool()
-result = memory_tool.record_memory(
-    content="User prefers vegetarian pizza"
-    # cluster_uri, database_name, etc. will be read from environment variables
-)
-
-# Standalone function usage
-result = mongodb_memory(
-    action="record",
-    content="User prefers vegetarian pizza"
-    # cluster_uri, database_name, etc. will be read from environment variables
-)
+# Standalone function usage (configuration entirely from environment variables)
+agent = Agent(tools=[mongodb_memory])
+result = agent.tool.mongodb_memory(action="record", content="User prefers vegetarian pizza")
 ```
 
 ## Usage Examples
+
+The examples below use a per-principal `MongoDBMemoryTool` (see Quick Start) and assume `agent = Agent(tools=[memory_tool.mongodb_memory])`.
 
 ### 1. Store Memories
 
@@ -154,10 +130,6 @@ result = mongodb_memory(
 result = agent.tool.mongodb_memory(
     action="record",
     content="User prefers vegetarian pizza with extra cheese and no onions",
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123"
 )
 
 # Store a memory with metadata
@@ -170,10 +142,6 @@ result = agent.tool.mongodb_memory(
         "participants": ["dev_team"],
         "date": "2024-01-16"
     },
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123"
 )
 ```
 
@@ -185,10 +153,6 @@ result = agent.tool.mongodb_memory(
     action="retrieve",
     query="food preferences and dietary restrictions",
     max_results=5,
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123"
 )
 
 # Search for meeting information
@@ -196,10 +160,6 @@ result = agent.tool.mongodb_memory(
     action="retrieve",
     query="upcoming meetings and appointments",
     max_results=10,
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123"
 )
 ```
 
@@ -210,10 +170,6 @@ result = agent.tool.mongodb_memory(
 result = agent.tool.mongodb_memory(
     action="list",
     max_results=20,
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123"
 )
 
 # List with pagination
@@ -221,10 +177,6 @@ result = agent.tool.mongodb_memory(
     action="list",
     max_results=10,
     next_token="10",  # Start from the 11th result
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123"
 )
 ```
 
@@ -235,10 +187,6 @@ result = agent.tool.mongodb_memory(
 result = agent.tool.mongodb_memory(
     action="get",
     memory_id="mem_1704567890123_abc12345",
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123"
 )
 ```
 
@@ -246,80 +194,75 @@ result = agent.tool.mongodb_memory(
 
 ```python
 # Delete a specific memory
-result = memory_tool.delete_memory(
+result = agent.tool.mongodb_memory(
+    action="delete",
     memory_id="mem_1704567890123_abc12345",
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123"
 )
 ```
 
 ## Advanced Configuration
 
-### Using Configuration Dictionary
+### Reusing a Connection Configuration
 
-For cleaner code, you can use a configuration dictionary:
+For cleaner code, collect the connection settings once and bind them to a per-principal tool at construction time:
 
 ```python
 config = {
     "cluster_uri": "mongodb+srv://user:password@cluster.mongodb.net/",
     "database_name": "memory_db",
     "collection_name": "memories",
-    "namespace": "user_123",
-    "region": "us-east-1"
+    "region": "us-east-1",
 }
 
-# Initialize tool
-memory_tool = MongoDBMemoryTool()
+# Bind the connection plus the authenticated principal's namespace.
+memory_tool = MongoDBMemoryTool(namespace=f"user_{authenticated_user_id}", **config)
+agent = Agent(tools=[memory_tool.mongodb_memory])
 
 # Store memory
-result = memory_tool.record_memory(
-    content="User prefers vegetarian pizza",
-    **config
-)
+result = agent.tool.mongodb_memory(action="record", content="User prefers vegetarian pizza")
 
 # Search memories
-result = memory_tool.retrieve_memories(
-    query="food preferences",
-    max_results=5,
-    **config
-)
+result = agent.tool.mongodb_memory(action="retrieve", query="food preferences", max_results=5)
 ```
 
 ### Custom Embedding Model
 
+The embedding model and region are bound at construction (or via `MONGODB_EMBEDDING_MODEL` / `AWS_REGION` for the standalone function):
+
 ```python
-result = memory_tool.record_memory(
-    content="User prefers vegetarian pizza",
+memory_tool = MongoDBMemoryTool(
     cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
     database_name="memory_db",
     collection_name="memories",
+    namespace="user_123",
     embedding_model="amazon.titan-embed-text-v1:0",  # Different model
-    region="us-east-1"
+    region="us-east-1",
 )
 ```
 
 ### Multiple Namespaces
 
+The `namespace` is bound per tool instance. To serve multiple principals (or logical groupings), construct one `MongoDBMemoryTool` per namespace — never let the agent choose the namespace on a call.
+
 ```python
-# Logical grouping by user
-result = memory_tool.record_memory(
-    content="Alice likes Italian food",
+# One tool per user, each bound to that user's namespace
+alice_tool = MongoDBMemoryTool(
     cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
     database_name="memory_db",
     collection_name="memories",
-    namespace="user_alice"
+    namespace="user_alice",
 )
 
-# System-wide memories
-result = memory_tool.record_memory(
-    content="System maintenance scheduled",
+# A separate tool for system-wide memories
+system_tool = MongoDBMemoryTool(
     cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
     database_name="memory_db",
     collection_name="memories",
-    namespace="system_global"
+    namespace="system_global",
 )
+
+# Wire the tool that matches the authenticated principal into that principal's agent.
+alice_agent = Agent(tools=[alice_tool.mongodb_memory])
 ```
 
 ## Response Format
@@ -331,7 +274,10 @@ All operations return a standardized response format:
     "status": "success",  # or "error"
     "content": [
         {
-            "text": "Memory stored successfully: {...}"
+            "text": "Memory stored successfully"
+        },
+        {
+            "json": {...}
         }
     ]
 }
@@ -343,9 +289,8 @@ All operations return a standardized response format:
 {
     "status": "success",
     "content": [
-        {
-            "text": "Memory stored successfully: {\"memory_id\": \"mem_1704567890123_abc12345\", \"content\": \"User prefers vegetarian pizza\", \"namespace\": \"user_123\", \"timestamp\": \"2024-01-06T20:31:30.123456Z\", \"result\": \"created\"}"
-        }
+        {"text": "Memory stored successfully"},
+        {"json": {"memory_id": "mem_1704567890123_abc12345", "content": "User prefers vegetarian pizza", "namespace": "user_123", "timestamp": "2024-01-06T20:31:30.123456Z", "result": "created"}}
     ]
 }
 ```
@@ -356,9 +301,8 @@ All operations return a standardized response format:
 {
     "status": "success",
     "content": [
-        {
-            "text": "Memories retrieved successfully: {\"memories\": [{\"memory_id\": \"mem_123\", \"content\": \"User prefers vegetarian pizza\", \"timestamp\": \"2024-01-06T20:31:30Z\", \"metadata\": {\"category\": \"food\"}, \"score\": 0.95}], \"total\": 1, \"max_score\": 0.95}"
-        }
+        {"text": "Memories retrieved successfully"},
+        {"json": {"memories": [{"memory_id": "mem_123", "content": "User prefers vegetarian pizza", "timestamp": "2024-01-06T20:31:30Z", "metadata": {"category": "food"}, "score": 0.95}], "total": 1, "max_score": 0.95}}
     ]
 }
 ```
@@ -410,39 +354,35 @@ The tool provides comprehensive error handling:
 ### Connection Errors
 
 ```python
-# Invalid connection URI
-memory_tool = MongoDBMemoryTool()
-result = memory_tool.record_memory(
-    content="test",
-    cluster_uri="mongodb+srv://invalid:credentials@invalid.mongodb.net/"
+# Invalid connection URI (configured at construction)
+memory_tool = MongoDBMemoryTool(
+    cluster_uri="mongodb+srv://invalid:credentials@invalid.mongodb.net/",
+    namespace="user_123",
 )
-# Returns: {"status": "error", "content": [{"text": "Unable to connect to MongoDB Atlas cluster"}]}
+agent = Agent(tools=[memory_tool.mongodb_memory])
+result = agent.tool.mongodb_memory(action="record", content="test")
+# Returns: {"status": "error", "content": [{"text": "Unable to connect to MongoDB cluster ..."}]}
 ```
 
 ### Missing Parameters
 
 ```python
 # Missing required content for record action
-memory_tool = MongoDBMemoryTool()
-result = memory_tool.record_memory(
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/"
-)
-# Returns: {"status": "error", "content": [{"text": "content is required"}]}
+result = agent.tool.mongodb_memory(action="record")
+# Returns: {"status": "error", "content": [{"text": "The following parameters are required for record action: content"}]}
 
-# Missing connection parameters
-result = memory_tool.record_memory(content="test")
-# Returns: {"status": "error", "content": [{"text": "cluster_uri is required"}]}
+# Missing connection configuration (no cluster_uri at construction and no
+# MONGODB_ATLAS_CLUSTER_URI environment variable) raises at construction time:
+MongoDBMemoryTool(namespace="user_123")
+# Raises: MongoDBValidationError("cluster_uri is required for MongoDB Memory Tool initialization")
 ```
 
 ### Memory Not Found
 
 ```python
 # Non-existent memory ID
-result = memory_tool.get_memory(
-    memory_id="nonexistent",
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/"
-)
-# Returns: {"status": "error", "content": [{"text": "API error: Memory nonexistent not found"}]}
+result = agent.tool.mongodb_memory(action="get", memory_id="nonexistent")
+# Returns: {"status": "error", "content": [{"text": "API error: Memory nonexistent not found ..."}]}
 ```
 
 ## Performance Considerations
@@ -469,36 +409,30 @@ result = memory_tool.get_memory(
 
 ### 1. Configuration Management
 
-Create reusable configuration objects:
+Build a per-principal tool from reusable connection settings, binding the authenticated user's namespace at construction:
 
 ```python
-# Create a base configuration
+# Create a base connection configuration
 base_config = {
     "cluster_uri": "mongodb+srv://user:password@cluster.mongodb.net/",
     "database_name": "memory_db",
-    "region": "us-east-1"
+    "collection_name": "user_memories",
+    "region": "us-east-1",
 }
 
-# User-specific configuration
-def get_user_config(user_id):
-    return {
-        **base_config,
-        "collection_name": "user_memories",
-        "namespace": f"user_{user_id}"
-    }
+# Build one tool per authenticated principal
+def build_user_agent(user_id):
+    memory_tool = MongoDBMemoryTool(namespace=f"user_{user_id}", **base_config)
+    return Agent(tools=[memory_tool.mongodb_memory])
 
 # Usage
-user_config = get_user_config("alice")
-result = agent.tool.mongodb_memory(
-    action="record",
-    content="Alice likes Italian food",
-    **user_config
-)
+alice_agent = build_user_agent("alice")
+result = alice_agent.tool.mongodb_memory(action="record", content="Alice likes Italian food")
 ```
 
 ### 2. Namespace Organization
 
-The `namespace` parameter is a document field used for logical grouping and query filtering within a collection.
+The `namespace` is a document field used for logical grouping and query filtering within a collection. It is bound per tool instance and is not agent-controllable.
 
 > **Note:** This differs from [MongoDB's glossary definition of "namespace"](https://www.mongodb.com/docs/manual/reference/glossary/#std-term-namespace), which refers to the combination of database and collection names.
 
@@ -515,13 +449,22 @@ org_user_namespace = f"org_{org_id}_user_{user_id}"
 # Feature-based namespaces
 chat_namespace = "feature_chat"
 task_namespace = "feature_tasks"
+
+# Bind the chosen namespace when constructing the tool
+memory_tool = MongoDBMemoryTool(
+    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
+    database_name="memory_db",
+    collection_name="memories",
+    namespace=user_namespace,
+)
 ```
 
 ### 3. Metadata Usage
 
 ```python
 # Use structured metadata for better organization
-result = memory_tool.record_memory(
+result = agent.tool.mongodb_memory(
+    action="record",
     content="Important project deadline",
     metadata={
         "type": "deadline",
@@ -530,16 +473,15 @@ result = memory_tool.record_memory(
         "due_date": "2024-02-01",
         "assigned_to": ["alice", "bob"]
     },
-    **config
 )
 ```
 
 ### 4. Error Handling
 
 ```python
-def safe_memory_operation(memory_tool, operation_method, **kwargs):
+def safe_memory_operation(agent, action, **kwargs):
     try:
-        result = operation_method(**kwargs)
+        result = agent.tool.mongodb_memory(action=action, **kwargs)
         if result["status"] == "error":
             logger.error(f"Memory operation failed: {result['content'][0]['text']}")
             return None
@@ -549,41 +491,32 @@ def safe_memory_operation(memory_tool, operation_method, **kwargs):
         return None
 
 # Usage example:
-memory_tool = MongoDBMemoryTool()
-result = safe_memory_operation(
-    memory_tool, 
-    memory_tool.record_memory,
-    content="Test memory",
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123"
-)
+result = safe_memory_operation(agent, "record", content="Test memory")
 ```
 
 ### 5. Batch Operations
 
 ```python
-# Store multiple related memories
+# Store multiple related memories with a single per-principal tool
 memories = [
     "User likes Italian food",
     "User is allergic to nuts", 
     "User prefers evening meetings"
 ]
 
-config = {
-    "cluster_uri": "mongodb+srv://user:password@cluster.mongodb.net/",
-    "database_name": "memory_db",
-    "collection_name": "memories",
-    "namespace": "user_123"
-}
+memory_tool = MongoDBMemoryTool(
+    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
+    database_name="memory_db",
+    collection_name="memories",
+    namespace="user_123",
+)
+agent = Agent(tools=[memory_tool.mongodb_memory])
 
-memory_tool = MongoDBMemoryTool()
 for content in memories:
-    memory_tool.record_memory(
+    agent.tool.mongodb_memory(
+        action="record",
         content=content,
         metadata={"batch": "user_preferences", "timestamp": datetime.now().isoformat()},
-        **config
     )
 ```
 
@@ -620,11 +553,12 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 # This will show detailed MongoDB and Bedrock API calls
-memory_tool = MongoDBMemoryTool()
-result = memory_tool.record_memory(
-    content="test",
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/"
+memory_tool = MongoDBMemoryTool(
+    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
+    namespace="user_123",
 )
+agent = Agent(tools=[memory_tool.mongodb_memory])
+result = agent.tool.mongodb_memory(action="record", content="test")
 ```
 
 ### Vector Search Index Creation
@@ -647,7 +581,7 @@ If vector search is not working, manually create the index in MongoDB Atlas:
 
 ### Data Privacy
 
-- Use appropriate namespaces for data isolation
+- Bind the `namespace` per authenticated principal at construction; never expose it as an agent-controllable parameter (see Security Model)
 - Consider encryption at rest (MongoDB Atlas feature)
 - Implement proper access controls
 - Regular security audits

--- a/src/strands_tools/elasticsearch_memory.py
+++ b/src/strands_tools/elasticsearch_memory.py
@@ -32,54 +32,37 @@ Key Features:
 
 Usage Examples:
 --------------
+Multi-tenant (recommended): bind credentials, index, and the tenant namespace per authenticated
+principal via ``ElasticsearchMemoryTool``. The agent-facing tool cannot override them.
+
+```python
+from strands import Agent
+from strands_tools.elasticsearch_memory import ElasticsearchMemoryTool
+
+# Operator code, per authenticated request:
+tool = ElasticsearchMemoryTool(
+    cloud_id="your-cloud-id",
+    api_key="your-api-key",
+    index_name="memories",
+    namespace=f"user_{authenticated_user_id}",  # bound, not LLM-controllable
+)
+agent = Agent(tools=[tool.elasticsearch_memory])
+
+# The agent only chooses the action and its content/query/memory_id:
+agent.tool.elasticsearch_memory(action="record", content="User prefers vegetarian pizza")
+agent.tool.elasticsearch_memory(action="retrieve", query="food preferences", max_results=5)
+```
+
+Single-tenant convenience: the module-level ``elasticsearch_memory`` function reads all connection,
+index, namespace, and embedding configuration from environment variables only. It exposes no
+connection or namespace parameter to the agent.
+
 ```python
 from strands import Agent
 from strands_tools.elasticsearch_memory import elasticsearch_memory
 
-# Create agent with elasticsearch_memory tool (credentials via env vars)
 agent = Agent(tools=[elasticsearch_memory])
-
-# Store a memory with semantic embeddings
-elasticsearch_memory(
-    action="record",
-    content="User prefers vegetarian pizza with extra cheese",
-    metadata={"category": "food_preferences", "type": "dietary"},
-    index_name="memories",
-    namespace="user_123"
-)
-
-# Search memories using semantic similarity (vector search)
-elasticsearch_memory(
-    action="retrieve",
-    query="food preferences and dietary restrictions",
-    max_results=5,
-    index_name="memories",
-    namespace="user_123"
-)
-
-# List all memories with pagination
-elasticsearch_memory(
-    action="list",
-    max_results=10,
-    index_name="memories",
-    namespace="user_123"
-)
-
-# Get specific memory by ID
-elasticsearch_memory(
-    action="get",
-    memory_id="mem_1234567890_abcd1234",
-    index_name="memories",
-    namespace="user_123"
-)
-
-# Delete a memory
-elasticsearch_memory(
-    action="delete",
-    memory_id="mem_1234567890_abcd1234",
-    index_name="memories",
-    namespace="user_123"
-)
+agent.tool.elasticsearch_memory(action="record", content="User prefers vegetarian pizza")
 ```
 
 Environment Variables:
@@ -580,6 +563,180 @@ def _delete_memory(es_client: Elasticsearch, index_name: str, namespace: str, me
         raise ElasticsearchMemoryError(f"Failed to delete memory {memory_id}: {str(e)}") from e
 
 
+def _run_memory_operation(
+    *,
+    cloud_id: Optional[str],
+    es_url: Optional[str],
+    api_key: Optional[str],
+    index_name: str,
+    safe_namespace: str,
+    embedding_model: str,
+    region: str,
+    action: str,
+    content: Optional[str],
+    query: Optional[str],
+    memory_id: Optional[str],
+    max_results: Optional[int],
+    next_token: Optional[str],
+    metadata: Optional[Dict],
+) -> Dict:
+    """Execute a memory operation against Elasticsearch.
+
+    Shared runtime path for both entry points (the standalone ``elasticsearch_memory`` function
+    and ``ElasticsearchMemoryTool``). It receives an already-validated ``safe_namespace`` and fully
+    resolved connection/embedding configuration, so tenant isolation is enforced with the same
+    namespace value regardless of which entry point is used. Callers are responsible for resolving
+    that configuration from a trusted source (environment variables or constructor arguments), never
+    from LLM-supplied parameters.
+
+    Args:
+        cloud_id: Elasticsearch Cloud ID (used when es_url is not set).
+        es_url: Elasticsearch URL for serverless/URL-based connections.
+        api_key: Elasticsearch API key for authentication.
+        index_name: Elasticsearch index to operate on.
+        safe_namespace: Validated tenant namespace used to filter every operation.
+        embedding_model: Amazon Bedrock embedding model ID.
+        region: AWS region for the Bedrock client.
+        action: The memory operation to perform.
+        content: Text content to store (record action).
+        query: Search query (retrieve action).
+        memory_id: Memory ID (get and delete actions).
+        max_results: Maximum number of results to return.
+        next_token: Pagination token.
+        metadata: Optional metadata to store with the memory.
+
+    Returns:
+        Dict: Response containing the requested memory information or operation status.
+    """
+    max_results = max_results or DEFAULT_MAX_RESULTS
+
+    # Initialize Elasticsearch client
+    try:
+        if es_url:
+            # Use URL-based connection (for serverless)
+            es_client = Elasticsearch(
+                hosts=[es_url],
+                api_key=api_key,
+                request_timeout=30,
+                retry_on_timeout=True,
+                max_retries=3,
+            )
+        else:
+            # Use cloud_id connection
+            es_client = Elasticsearch(
+                cloud_id=cloud_id,
+                api_key=api_key,
+                request_timeout=30,
+                retry_on_timeout=True,
+                max_retries=3,
+            )
+
+        # Test connection
+        if not es_client.ping():
+            return {"status": "error", "content": [{"text": "Unable to connect to Elasticsearch cluster"}]}
+
+    except Exception as e:
+        return {"status": "error", "content": [{"text": f"Failed to initialize Elasticsearch client: {str(e)}"}]}
+
+    # Initialize Amazon Bedrock client for embeddings
+    try:
+        bedrock_runtime = boto3.client("bedrock-runtime", region_name=region)
+    except Exception as e:
+        return {"status": "error", "content": [{"text": f"Failed to initialize Bedrock client: {str(e)}"}]}
+
+    # Ensure index exists with proper mappings
+    _ensure_index_exists(es_client, index_name, es_url)
+
+    # Validate action
+    try:
+        action_enum = MemoryAction(action)
+    except ValueError:
+        return {
+            "status": "error",
+            "content": [
+                {
+                    "text": f"Action '{action}' is not supported. "
+                    f"Supported actions: {', '.join([a.value for a in MemoryAction])}"
+                }
+            ],
+        }
+
+    # Validate required parameters
+    param_values = {
+        "content": content,
+        "query": query,
+        "memory_id": memory_id,
+    }
+
+    missing_params = [param for param in REQUIRED_PARAMS[action_enum] if param_values.get(param) is None]
+
+    if missing_params:
+        return {
+            "status": "error",
+            "content": [
+                {
+                    "text": (
+                        f"The following parameters are required for {action_enum.value} action: "
+                        f"{', '.join(missing_params)}"
+                    )
+                }
+            ],
+        }
+
+    # Execute the appropriate action
+    try:
+        if action_enum == MemoryAction.RECORD:
+            response = _record_memory(
+                es_client, bedrock_runtime, index_name, safe_namespace, embedding_model, content, metadata
+            )
+            return {
+                "status": "success",
+                "content": [{"text": f"Memory stored successfully: {json.dumps(response, default=str)}"}],
+            }
+
+        elif action_enum == MemoryAction.RETRIEVE:
+            response = _retrieve_memories(
+                es_client,
+                bedrock_runtime,
+                index_name,
+                safe_namespace,
+                embedding_model,
+                query,
+                max_results,
+                next_token,
+            )
+            return {
+                "status": "success",
+                "content": [{"text": f"Memories retrieved successfully: {json.dumps(response, default=str)}"}],
+            }
+
+        elif action_enum == MemoryAction.LIST:
+            response = _list_memories(es_client, index_name, safe_namespace, max_results, next_token)
+            return {
+                "status": "success",
+                "content": [{"text": f"Memories listed successfully: {json.dumps(response, default=str)}"}],
+            }
+
+        elif action_enum == MemoryAction.GET:
+            response = _get_memory(es_client, index_name, safe_namespace, memory_id)
+            return {
+                "status": "success",
+                "content": [{"text": f"Memory retrieved successfully: {json.dumps(response, default=str)}"}],
+            }
+
+        elif action_enum == MemoryAction.DELETE:
+            response = _delete_memory(es_client, index_name, safe_namespace, memory_id)
+            return {
+                "status": "success",
+                "content": [{"text": f"Memory deleted successfully: {memory_id}"}],
+            }
+
+    except Exception as e:
+        error_msg = f"API error: {str(e)}"
+        logger.error(error_msg)
+        return {"status": "error", "content": [{"text": error_msg}]}
+
+
 @tool
 def elasticsearch_memory(
     action: str,
@@ -589,16 +746,18 @@ def elasticsearch_memory(
     max_results: Optional[int] = None,
     next_token: Optional[str] = None,
     metadata: Optional[Dict] = None,
-    index_name: Optional[str] = None,
-    namespace: Optional[str] = None,
-    embedding_model: Optional[str] = None,
-    region: Optional[str] = None,
 ) -> Dict:
     """
     Work with Elasticsearch memories - create, search, retrieve, list, and manage memory records.
 
     This tool helps agents store and access memories using Elasticsearch with semantic search
     capabilities, allowing them to remember important information across conversations.
+
+    Connection, index, tenant namespace, and embedding configuration are read exclusively from
+    environment variables and are never exposed as tool parameters, so an agent cannot redirect the
+    memory layer at another cluster/index or read/write another tenant's namespace. For multi-tenant
+    deployments, construct one ElasticsearchMemoryTool per authenticated principal with an explicit
+    namespace instead of using this single-tenant, environment-driven function.
 
     Key Capabilities:
     - Store new memories with automatic embedding generation
@@ -626,9 +785,13 @@ def elasticsearch_memory(
     - delete: Remove a specific memory
       Use this to delete memories that are no longer needed.
 
-    Connection credentials are read from environment variables:
+    Configuration (read from environment variables only):
     - ELASTICSEARCH_CLOUD_ID or ELASTICSEARCH_URL for connection
     - ELASTICSEARCH_API_KEY for authentication
+    - ELASTICSEARCH_INDEX_NAME: Index name (defaults to 'strands_memory')
+    - ELASTICSEARCH_NAMESPACE: Tenant namespace (defaults to 'default')
+    - ELASTICSEARCH_EMBEDDING_MODEL: Amazon Bedrock embedding model (defaults to Titan)
+    - AWS_REGION: AWS region for Bedrock service (defaults to 'us-west-2')
 
     Args:
         action: The memory operation to perform (one of: "record", "retrieve", "list", "get", "delete")
@@ -638,17 +801,20 @@ def elasticsearch_memory(
         max_results: Maximum number of results to return (optional, default: 10)
         next_token: Pagination token for list action (optional)
         metadata: Additional metadata to store with the memory (optional)
-        index_name: Name of the Elasticsearch index (defaults to 'strands_memory')
-        namespace: Namespace for memory operations (defaults to 'default')
-        embedding_model: Amazon Bedrock model for embeddings (defaults to Titan)
-        region: AWS region for Bedrock service (defaults to 'us-west-2')
 
     Returns:
         Dict: Response containing the requested memory information or operation status
     """
+    # All connection, index, namespace, and embedding configuration is sourced from the environment
+    # only. These are deliberately not tool parameters: exposing them would let the LLM point the
+    # tool at an arbitrary cluster/index, supply its own api_key, or forge another tenant's namespace.
     cloud_id = os.getenv("ELASTICSEARCH_CLOUD_ID")
     es_url = os.getenv("ELASTICSEARCH_URL")
     api_key = os.getenv("ELASTICSEARCH_API_KEY")
+    index_name = os.getenv("ELASTICSEARCH_INDEX_NAME", DEFAULT_INDEX_NAME)
+    namespace = os.getenv("ELASTICSEARCH_NAMESPACE", DEFAULT_NAMESPACE)
+    embedding_model = os.getenv("ELASTICSEARCH_EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL)
+    region = os.getenv("AWS_REGION", "us-west-2")
 
     try:
         # Validate required parameters
@@ -656,14 +822,6 @@ def elasticsearch_memory(
             return {"status": "error", "content": [{"text": "api_key is required"}]}
         if not cloud_id and not es_url:
             return {"status": "error", "content": [{"text": "Either cloud_id or es_url is required"}]}
-
-        # Set defaults
-        index_name = index_name or os.getenv("ELASTICSEARCH_INDEX_NAME", DEFAULT_INDEX_NAME)
-        if namespace is None:
-            namespace = os.getenv("ELASTICSEARCH_NAMESPACE", DEFAULT_NAMESPACE)
-        embedding_model = embedding_model or os.getenv("ELASTICSEARCH_EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL)
-        region = region or os.getenv("AWS_REGION", "us-west-2")
-        max_results = max_results or DEFAULT_MAX_RESULTS
 
         # Validate namespace to prevent injection attacks
         try:
@@ -674,132 +832,162 @@ def elasticsearch_memory(
                 "content": [{"text": f"Invalid namespace: {str(e)}"}],
             }
 
-        # Initialize Elasticsearch client
-        try:
-            if es_url:
-                # Use URL-based connection (for serverless)
-                es_client = Elasticsearch(
-                    hosts=[es_url],
-                    api_key=api_key,
-                    request_timeout=30,
-                    retry_on_timeout=True,
-                    max_retries=3,
-                )
-            else:
-                # Use cloud_id connection
-                es_client = Elasticsearch(
-                    cloud_id=cloud_id,
-                    api_key=api_key,
-                    request_timeout=30,
-                    retry_on_timeout=True,
-                    max_retries=3,
-                )
-
-            # Test connection
-            if not es_client.ping():
-                return {"status": "error", "content": [{"text": "Unable to connect to Elasticsearch cluster"}]}
-
-        except Exception as e:
-            return {"status": "error", "content": [{"text": f"Failed to initialize Elasticsearch client: {str(e)}"}]}
-
-        # Initialize Amazon Bedrock client for embeddings
-        try:
-            bedrock_runtime = boto3.client("bedrock-runtime", region_name=region)
-        except Exception as e:
-            return {"status": "error", "content": [{"text": f"Failed to initialize Bedrock client: {str(e)}"}]}
-
-        # Ensure index exists with proper mappings
-        _ensure_index_exists(es_client, index_name, es_url)
-
-        # Validate action
-        try:
-            action_enum = MemoryAction(action)
-        except ValueError:
-            return {
-                "status": "error",
-                "content": [
-                    {
-                        "text": f"Action '{action}' is not supported. "
-                        f"Supported actions: {', '.join([a.value for a in MemoryAction])}"
-                    }
-                ],
-            }
-
-        # Validate required parameters
-        param_values = {
-            "content": content,
-            "query": query,
-            "memory_id": memory_id,
-        }
-
-        missing_params = [param for param in REQUIRED_PARAMS[action_enum] if param_values.get(param) is None]
-
-        if missing_params:
-            return {
-                "status": "error",
-                "content": [
-                    {
-                        "text": (
-                            f"The following parameters are required for {action_enum.value} action: "
-                            f"{', '.join(missing_params)}"
-                        )
-                    }
-                ],
-            }
-
-        # Execute the appropriate action
-        try:
-            if action_enum == MemoryAction.RECORD:
-                response = _record_memory(
-                    es_client, bedrock_runtime, index_name, safe_namespace, embedding_model, content, metadata
-                )
-                return {
-                    "status": "success",
-                    "content": [{"text": f"Memory stored successfully: {json.dumps(response, default=str)}"}],
-                }
-
-            elif action_enum == MemoryAction.RETRIEVE:
-                response = _retrieve_memories(
-                    es_client,
-                    bedrock_runtime,
-                    index_name,
-                    safe_namespace,
-                    embedding_model,
-                    query,
-                    max_results,
-                    next_token,
-                )
-                return {
-                    "status": "success",
-                    "content": [{"text": f"Memories retrieved successfully: {json.dumps(response, default=str)}"}],
-                }
-
-            elif action_enum == MemoryAction.LIST:
-                response = _list_memories(es_client, index_name, safe_namespace, max_results, next_token)
-                return {
-                    "status": "success",
-                    "content": [{"text": f"Memories listed successfully: {json.dumps(response, default=str)}"}],
-                }
-
-            elif action_enum == MemoryAction.GET:
-                response = _get_memory(es_client, index_name, safe_namespace, memory_id)
-                return {
-                    "status": "success",
-                    "content": [{"text": f"Memory retrieved successfully: {json.dumps(response, default=str)}"}],
-                }
-
-            elif action_enum == MemoryAction.DELETE:
-                response = _delete_memory(es_client, index_name, safe_namespace, memory_id)
-                return {
-                    "status": "success",
-                    "content": [{"text": f"Memory deleted successfully: {memory_id}"}],
-                }
-
-        except Exception as e:
-            error_msg = f"API error: {str(e)}"
-            logger.error(error_msg)
-            return {"status": "error", "content": [{"text": error_msg}]}
+        return _run_memory_operation(
+            cloud_id=cloud_id,
+            es_url=es_url,
+            api_key=api_key,
+            index_name=index_name,
+            safe_namespace=safe_namespace,
+            embedding_model=embedding_model,
+            region=region,
+            action=action,
+            content=content,
+            query=query,
+            memory_id=memory_id,
+            max_results=max_results,
+            next_token=next_token,
+            metadata=metadata,
+        )
 
     except Exception as e:
         logger.error(f"Unexpected error in elasticsearch_memory tool: {str(e)}")
         return {"status": "error", "content": [{"text": str(e)}]}
+
+
+class ElasticsearchMemoryTool:
+    """
+    Elasticsearch Memory Tool with secure credential and tenant management.
+
+    This class encapsulates the Elasticsearch connection credentials, target index, and tenant
+    namespace, preventing agents from accessing sensitive information (API keys, connection targets)
+    or choosing which tenant's memories to read or write. Bind one instance per authenticated
+    principal and pass its ``elasticsearch_memory`` method to the agent.
+    """
+
+    def __init__(
+        self,
+        cloud_id: Optional[str] = None,
+        es_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        index_name: Optional[str] = None,
+        namespace: Optional[str] = None,
+        embedding_model: Optional[str] = None,
+        region: Optional[str] = None,
+    ):
+        """
+        Initialize Elasticsearch Memory Tool with secure credential and namespace storage.
+
+        Args:
+            cloud_id: Elasticsearch Cloud ID (kept private from agents). Falls back to the
+                ELASTICSEARCH_CLOUD_ID environment variable.
+            es_url: Elasticsearch URL for serverless/URL-based connections (kept private from
+                agents). Falls back to the ELASTICSEARCH_URL environment variable.
+            api_key: Elasticsearch API key (kept private from agents). Falls back to the
+                ELASTICSEARCH_API_KEY environment variable.
+            index_name: Name of the Elasticsearch index. Falls back to ELASTICSEARCH_INDEX_NAME,
+                then 'strands_memory'.
+            namespace: Tenant-isolation key bound at construction (kept private from agents).
+                Falls back to the ELASTICSEARCH_NAMESPACE environment variable, then 'default'.
+                Serve multiple principals by constructing one tool per principal, e.g.
+                namespace=f"user_{authenticated_user_id}".
+            embedding_model: Amazon Bedrock model for embeddings. Falls back to
+                ELASTICSEARCH_EMBEDDING_MODEL, then the Titan default.
+            region: AWS region for Bedrock service. Falls back to AWS_REGION, then 'us-west-2'.
+
+        Raises:
+            ElasticsearchValidationError: If credentials are missing or the namespace is invalid.
+        """
+        # Private attributes - not accessible to agents
+        self._cloud_id = cloud_id or os.getenv("ELASTICSEARCH_CLOUD_ID")
+        self._es_url = es_url or os.getenv("ELASTICSEARCH_URL")
+        self._api_key = api_key or os.getenv("ELASTICSEARCH_API_KEY")
+        self._index_name = index_name or os.getenv("ELASTICSEARCH_INDEX_NAME", DEFAULT_INDEX_NAME)
+        self._embedding_model = embedding_model or os.getenv("ELASTICSEARCH_EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL)
+        self._region = region or os.getenv("AWS_REGION", "us-west-2")
+
+        # Validate credentials during initialization so misconfiguration fails fast for the operator.
+        if not self._api_key:
+            raise ElasticsearchValidationError("api_key is required for Elasticsearch Memory Tool initialization")
+        if not self._cloud_id and not self._es_url:
+            raise ElasticsearchValidationError(
+                "Either cloud_id or es_url is required for Elasticsearch Memory Tool initialization"
+            )
+
+        # Namespace is the sole tenant-isolation key, so it is bound here and never taken from the
+        # LLM-controlled @tool signature. An agent cannot read or write another tenant's memories
+        # by choosing a namespace. Validate once at construction.
+        if namespace is None:
+            namespace = os.getenv("ELASTICSEARCH_NAMESPACE", DEFAULT_NAMESPACE)
+        self._namespace = _validate_namespace(namespace)
+
+    @tool
+    def elasticsearch_memory(
+        self,
+        action: str,
+        content: Optional[str] = None,
+        query: Optional[str] = None,
+        memory_id: Optional[str] = None,
+        max_results: Optional[int] = None,
+        next_token: Optional[str] = None,
+        metadata: Optional[Dict] = None,
+    ) -> Dict:
+        """
+        Work with Elasticsearch memories - create, search, retrieve, list, and manage memory records.
+
+        This tool helps agents store and access memories using Elasticsearch with semantic search
+        capabilities, allowing them to remember important information across conversations.
+
+        Note: Credentials and the tenant namespace are securely managed by the class and not
+        exposed to agents.
+
+        Key Capabilities:
+        - Store new memories with automatic embedding generation
+        - Search for memories using semantic similarity
+        - Browse and list all stored memories
+        - Retrieve specific memories by ID
+        - Delete unwanted memories
+
+        Supported Actions:
+        -----------------
+        Memory Management:
+        - record: Store a new memory with semantic embeddings
+        - retrieve: Find relevant memories using semantic search
+        - list: Browse all stored memories with pagination
+        - get: Fetch a specific memory by ID
+        - delete: Remove a specific memory
+
+        Args:
+            action: The memory operation to perform (one of: "record", "retrieve", "list", "get", "delete")
+            content: For record action: Text content to store as a memory
+            query: Search terms for semantic search (required for retrieve action)
+            memory_id: ID of a specific memory (required for get and delete actions)
+            max_results: Maximum number of results to return (optional, default: 10)
+            next_token: Pagination token for list action (optional)
+            metadata: Additional metadata to store with the memory (optional)
+
+        Returns:
+            Dict: Response containing the requested memory information or operation status
+        """
+        try:
+            # Namespace and connection config are bound at construction; the agent cannot supply a
+            # different tenant key, index, or cluster. Namespace was already validated in __init__.
+            return _run_memory_operation(
+                cloud_id=self._cloud_id,
+                es_url=self._es_url,
+                api_key=self._api_key,
+                index_name=self._index_name,
+                safe_namespace=self._namespace,
+                embedding_model=self._embedding_model,
+                region=self._region,
+                action=action,
+                content=content,
+                query=query,
+                memory_id=memory_id,
+                max_results=max_results,
+                next_token=next_token,
+                metadata=metadata,
+            )
+
+        except Exception as e:
+            logger.error(f"Unexpected error in elasticsearch_memory tool: {str(e)}")
+            return {"status": "error", "content": [{"text": str(e)}]}

--- a/src/strands_tools/mem0_memory.py
+++ b/src/strands_tools/mem0_memory.py
@@ -8,66 +8,92 @@ a user-friendly interface and proper error handling.
 Key Features:
 ------------
 1. Memory Management:
-   • store: Add new memories with automatic ID generation and metadata
-   • delete: Remove existing memories using memory IDs
-   • list: Retrieve all memories for a user or agent
-   • get: Retrieve specific memories by memory ID
-   • retrieve: Perform semantic search across all memories
+   - store: Add new memories with automatic ID generation and metadata
+   - delete: Remove existing memories using memory IDs
+   - list: Retrieve all memories for a user or agent
+   - get: Retrieve specific memories by memory ID
+   - retrieve: Perform semantic search across all memories
 
 2. Safety Features:
-   • User confirmation for mutative operations
-   • Content previews before storage
-   • Warning messages before deletion
-   • BYPASS_TOOL_CONSENT mode for bypassing confirmations in tests
+   - User confirmation for mutative operations
+   - Content previews before storage
+   - Warning messages before deletion
+   - BYPASS_TOOL_CONSENT mode for bypassing confirmations in tests
 
 3. Advanced Capabilities:
-   • Automatic memory ID generation
-   • Structured memory storage with metadata
-   • Semantic search with relevance filtering
-   • Rich output formatting
-   • Support for both user and agent memories
-   • Multiple vector database backends (OpenSearch, Mem0 Platform, FAISS)
+   - Automatic memory ID generation
+   - Structured memory storage with metadata
+   - Semantic search with relevance filtering
+   - Rich output formatting
+   - Support for both user and agent memories
+   - Multiple vector database backends (OpenSearch, Mem0 Platform, FAISS)
 
 4. Error Handling:
-   • Memory ID validation
-   • Parameter validation
-   • Graceful API error handling
-   • Clear error messages
+   - Memory ID validation
+   - Parameter validation
+   - Graceful API error handling
+   - Clear error messages
+
+Security Model:
+--------------
+The tenant-isolation keys (``user_id`` / ``agent_id``) are **never** exposed as
+agent-facing tool parameters. The agent only chooses the ``action`` and its
+``content``/``query``/``memory_id``. This prevents a model (or prompt-injected
+content) from reading, writing, or deleting another tenant's memories by supplying
+a different user_id or agent_id value.
+
+There are two supported patterns:
+
+- **Class-based (recommended, required for multi-tenant):** construct one
+  ``Mem0MemoryTool`` per authenticated principal, binding ``user_id`` (or
+  ``agent_id``) at construction time.
+- **Standalone function (single-tenant):** the module-level ``mem0_memory`` tool
+  reads ``user_id`` / ``agent_id`` from environment variables only.
 
 Usage Examples:
 --------------
+Multi-tenant (recommended):
+
 ```python
 from strands import Agent
-from strands_tools import mem0_memory
+from strands_tools.mem0_memory import Mem0MemoryTool
+
+# Operator code, per authenticated request:
+tool = Mem0MemoryTool(user_id=f"user_{authenticated_user_id}")
+agent = Agent(tools=[tool.mem0_memory])
+
+# The agent only chooses the action and its content/query/memory_id:
+agent.tool.mem0_memory(action="store", content="User prefers vegetarian pizza")
+agent.tool.mem0_memory(action="retrieve", query="food preferences")
+```
+
+Single-tenant convenience:
+
+```python
+from strands import Agent
+from strands_tools.mem0_memory import mem0_memory
 
 agent = Agent(tools=[mem0_memory])
+agent.tool.mem0_memory(action="store", content="User prefers vegetarian pizza")
+```
 
-# Store memory in Memory
-agent.tool.mem0_memory(
-    action="store",
-    content="Important information to remember",
-    user_id="alex",  # or agent_id="agent1"
-    metadata={"category": "meeting_notes"}
-)
+Environment Variables:
+---------------------
+```bash
+# Tenant identity (standalone function only)
+export MEM0_USER_ID="my_user"          # or MEM0_AGENT_ID="my_agent"
 
-# Retrieve content using semantic search
-agent.tool.mem0_memory(
-    action="retrieve",
-    query="meeting information",
-    user_id="alex"  # or agent_id="agent1"
-)
-
-# List all memories
-agent.tool.mem0_memory(
-    action="list",
-    user_id="alex"  # or agent_id="agent1"
-)
+# Backend selection (all modes)
+export MEM0_API_KEY="..."              # Use Mem0 Platform
+export OPENSEARCH_HOST="..."           # Use OpenSearch
+# (neither set = FAISS default)
 ```
 """
 
 import json
 import logging
 import os
+import re
 from typing import Any, Dict, List, Optional
 
 import boto3
@@ -92,20 +118,19 @@ TOOL_SPEC = {
     "description": (
         "Memory management tool for storing, retrieving, and managing memories in Mem0.\n\n"
         "Features:\n"
-        "1. Store memories with metadata (requires user_id or agent_id)\n"
-        "2. Retrieve memories by ID or semantic search (requires user_id or agent_id)\n"
-        "3. List all memories for a user/agent (requires user_id or agent_id)\n"
+        "1. Store memories with metadata\n"
+        "2. Retrieve memories by ID or semantic search\n"
+        "3. List all memories\n"
         "4. Delete memories\n"
         "5. Get memory history\n\n"
         "Actions:\n"
-        "- store: Store new memory (requires user_id or agent_id)\n"
+        "- store: Store new memory\n"
         "- get: Get memory by ID\n"
-        "- list: List all memories (requires user_id or agent_id)\n"
-        "- retrieve: Semantic search (requires user_id or agent_id)\n"
+        "- list: List all memories\n"
+        "- retrieve: Semantic search\n"
         "- delete: Delete memory\n"
         "- history: Get memory history\n\n"
-        "Note: Most operations require either user_id or agent_id to be specified. The tool will automatically "
-        "attempt to retrieve relevant memories when user_id or agent_id is available."
+        "Note: Tenant identity (user/agent) is configured by the operator and cannot be changed."
     ),
     "inputSchema": {
         "json": {
@@ -128,14 +153,6 @@ TOOL_SPEC = {
                     "type": "string",
                     "description": "Search query (required for retrieve action)",
                 },
-                "user_id": {
-                    "type": "string",
-                    "description": "User ID for the memory operations (required for store, list, retrieve actions)",
-                },
-                "agent_id": {
-                    "type": "string",
-                    "description": "Agent ID for the memory operations (required for store, list, retrieve actions)",
-                },
                 "metadata": {
                     "type": "object",
                     "description": "Optional metadata to store with the memory",
@@ -145,6 +162,46 @@ TOOL_SPEC = {
         }
     },
 }
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+_IDENTITY_PATTERN = re.compile(r"^[A-Za-z0-9_\-\.]{1,128}$")
+
+
+def _validate_identity(value: Any, name: str) -> str:
+    """Validate a user_id or agent_id value.
+
+    Args:
+        value: The identity value to validate.
+        name: Human-readable name for error messages (e.g. "user_id").
+
+    Returns:
+        The validated string.
+
+    Raises:
+        ValueError: If value is not a valid identity string.
+    """
+    if value is None:
+        raise ValueError(f"{name} must be provided")
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string, got {type(value).__name__}")
+    value = value.strip()
+    if not value:
+        raise ValueError(f"{name} cannot be empty")
+    if not _IDENTITY_PATTERN.match(value):
+        raise ValueError(
+            f"Invalid {name}: '{value}' contains invalid characters. "
+            "Only alphanumeric, underscore, hyphen, and dot are allowed (max 128 chars)."
+        )
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Mem0ServiceClient (unchanged - internal, not agent-facing)
+# ---------------------------------------------------------------------------
 
 
 class Mem0ServiceClient:
@@ -416,6 +473,11 @@ class Mem0ServiceClient:
         return self.mem0.history(memory_id)
 
 
+# ---------------------------------------------------------------------------
+# Formatting helpers (unchanged)
+# ---------------------------------------------------------------------------
+
+
 def format_get_response(memory: Dict) -> Panel:
     """Format get memory response."""
     memory_id = memory.get("id", "unknown")
@@ -425,16 +487,16 @@ def format_get_response(memory: Dict) -> Panel:
     user_id = memory.get("user_id", "Unknown")
 
     result = [
-        "✅ Memory retrieved successfully:",
-        f"🔑 Memory ID: {memory_id}",
-        f"👤 User ID: {user_id}",
-        f"🕒 Created: {created_at}",
+        "Memory retrieved successfully:",
+        f"Memory ID: {memory_id}",
+        f"User ID: {user_id}",
+        f"Created: {created_at}",
     ]
 
     if metadata:
-        result.append(f"📋 Metadata: {json.dumps(metadata, indent=2)}")
+        result.append(f"Metadata: {json.dumps(metadata, indent=2)}")
 
-    result.append(f"\n📄 Memory: {content}")
+    result.append(f"\nMemory: {content}")
 
     return Panel("\n".join(result), title="[bold green]Memory Retrieved", border_style="green")
 
@@ -472,8 +534,8 @@ def format_list_response(memories: List[Dict]) -> Panel:
 def format_delete_response(memory_id: str) -> Panel:
     """Format delete memory response."""
     content = [
-        "✅ Memory deleted successfully:",
-        f"🔑 Memory ID: {memory_id}",
+        "Memory deleted successfully:",
+        f"Memory ID: {memory_id}",
     ]
     return Panel("\n".join(content), title="[bold green]Memory Deleted", border_style="green")
 
@@ -631,27 +693,146 @@ def format_store_graph_response(memories: List[Dict]) -> Panel:
     return Panel(table, title="[bold green]Memories Stored (Graph)", border_style="green")
 
 
-def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
-    """
-    Memory management tool for storing, retrieving, and managing memories in Mem0.
+# ---------------------------------------------------------------------------
+# Mem0MemoryTool - class-based, multi-tenant safe
+# ---------------------------------------------------------------------------
 
-    This tool provides a comprehensive interface for managing memories with Mem0,
-    including storing new memories, retrieving existing ones, listing all memories,
-    performing semantic searches, and managing memory history.
+
+class Mem0MemoryTool:
+    """Multi-tenant memory tool that binds user_id/agent_id at construction time.
+
+    The bound identity is used for all operations and is never exposed to the
+    agent-facing tool signature, preventing prompt-injection or model-driven
+    tenant-boundary crossing.
 
     Args:
-        tool: ToolUse object containing the following input fields:
-            - action: The action to perform (store, get, list, retrieve, delete, history)
-            - content: Content to store (for store action)
-            - memory_id: Memory ID (for get, delete, history actions)
-            - query: Search query (for retrieve action)
-            - user_id: User ID for the memory operations
-            - agent_id: Agent ID for the memory operations
-            - metadata: Optional metadata to store with the memory
-        **kwargs: Additional keyword arguments
+        user_id: User ID to bind for all memory operations. Mutually exclusive
+                 with ``agent_id``. At least one must be provided.
+        agent_id: Agent ID to bind for all memory operations. Mutually exclusive
+                  with ``user_id``. At least one must be provided.
+        config: Optional Mem0 backend configuration dictionary.
 
-    Returns:
-        ToolResult containing status and response content
+    Raises:
+        ValueError: If neither ``user_id`` nor ``agent_id`` is provided, or if
+                    the provided value fails validation.
+
+    Example::
+
+        from strands import Agent
+        from strands_tools.mem0_memory import Mem0MemoryTool
+
+        tool = Mem0MemoryTool(user_id=f"user_{authenticated_user_id}")
+        agent = Agent(tools=[tool.mem0_memory])
+        agent.tool.mem0_memory(action="store", content="User prefers dark mode")
+    """
+
+    def __init__(
+        self,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        config: Optional[Dict] = None,
+    ):
+        if not user_id and not agent_id:
+            raise ValueError("Either user_id or agent_id must be provided to Mem0MemoryTool")
+
+        if user_id:
+            self._user_id = _validate_identity(user_id, "user_id")
+            self._agent_id = None
+        else:
+            self._user_id = None
+            self._agent_id = _validate_identity(agent_id, "agent_id")
+
+        self._config = config
+
+    def mem0_memory(self, tool: ToolUse, **kwargs: Any) -> ToolResult:
+        """Agent-facing tool entry point with bound tenant identity.
+
+        The tool spec is identical to the module-level ``TOOL_SPEC`` (no user_id
+        or agent_id parameters). The bound identity is injected into every backend
+        call automatically.
+        """
+        return _execute_mem0_memory(
+            tool=tool,
+            user_id=self._user_id,
+            agent_id=self._agent_id,
+            config=self._config,
+        )
+
+    # Expose TOOL_SPEC on the bound method so the framework can discover it.
+    mem0_memory.TOOL_SPEC = TOOL_SPEC  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Standalone function - single-tenant, env-configured
+# ---------------------------------------------------------------------------
+
+
+def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Standalone agent-facing tool (single-tenant).
+
+    Reads tenant identity from environment variables:
+    - ``MEM0_USER_ID`` - user ID for memory operations
+    - ``MEM0_AGENT_ID`` - agent ID for memory operations
+
+    At least one must be set. These are never exposed to the LLM.
+    """
+    user_id = os.environ.get("MEM0_USER_ID")
+    agent_id = os.environ.get("MEM0_AGENT_ID")
+
+    if not user_id and not agent_id:
+        tool_use_id = tool.get("toolUseId", "default-id")
+        return ToolResult(
+            toolUseId=tool_use_id,
+            status="error",
+            content=[
+                ToolResultContent(text="Error: Either MEM0_USER_ID or MEM0_AGENT_ID environment variable must be set.")
+            ],
+        )
+
+    # Validate whichever is set
+    try:
+        if user_id:
+            user_id = _validate_identity(user_id, "MEM0_USER_ID")
+        if agent_id:
+            agent_id = _validate_identity(agent_id, "MEM0_AGENT_ID")
+    except ValueError as e:
+        tool_use_id = tool.get("toolUseId", "default-id")
+        return ToolResult(
+            toolUseId=tool_use_id,
+            status="error",
+            content=[ToolResultContent(text=f"Error: {str(e)}")],
+        )
+
+    return _execute_mem0_memory(
+        tool=tool,
+        user_id=user_id,
+        agent_id=agent_id,
+        config=None,
+    )
+
+
+# Attach TOOL_SPEC to the standalone function for framework discovery.
+mem0_memory.TOOL_SPEC = TOOL_SPEC  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Shared implementation
+# ---------------------------------------------------------------------------
+
+
+def _execute_mem0_memory(
+    tool: ToolUse,
+    user_id: Optional[str],
+    agent_id: Optional[str],
+    config: Optional[Dict],
+) -> ToolResult:
+    """Core implementation shared by both class-based and standalone entry points.
+
+    Args:
+        tool: The ToolUse object from the framework.
+        user_id: Bound user ID (may be None if agent_id is set).
+        agent_id: Bound agent ID (may be None if user_id is set).
+        config: Optional Mem0 backend configuration.
     """
     try:
         # Extract input from tool use object
@@ -663,7 +844,7 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
             raise ValueError("action parameter is required")
 
         # Initialize client
-        client = Mem0ServiceClient()
+        client = Mem0ServiceClient(config=config)
 
         # Check if we're in development mode
         strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
@@ -687,11 +868,7 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
                     if len(tool_input["content"]) > 15000
                     else tool_input["content"]
                 )
-                preview_title = (
-                    f"Memory for {'user ' + tool_input.get('user_id', '')}"
-                    if tool_input.get("user_id")
-                    else f"agent {tool_input.get('agent_id', '')}"
-                )
+                preview_title = f"Memory for {'user ' + user_id}" if user_id else f"agent {agent_id}"
 
                 console.print(Panel(content_preview, title=f"[bold green]{preview_title}", border_style="green"))
 
@@ -711,7 +888,7 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
                                 f"Memory ID: {tool_input['memory_id']}\n"
                                 f"Metadata: {json.dumps(metadata) if metadata else 'None'}"
                             ),
-                            title="[bold red]⚠️ Memory to be permanently deleted",
+                            title="[bold red]Memory to be permanently deleted",
                             border_style="red",
                         )
                     )
@@ -720,7 +897,7 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
                     console.print(
                         Panel(
                             f"Memory ID: {tool_input['memory_id']}",
-                            title="[bold red]⚠️ Memory to be permanently deleted",
+                            title="[bold red]Memory to be permanently deleted",
                             border_style="red",
                         )
                     )
@@ -732,8 +909,8 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
 
             results = client.store_memory(
                 tool_input["content"],
-                tool_input.get("user_id"),
-                tool_input.get("agent_id"),
+                user_id,
+                agent_id,
                 tool_input.get("metadata"),
             )
 
@@ -761,6 +938,10 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
                 raise ValueError("memory_id is required for get action")
 
             memory = client.get_memory(tool_input["memory_id"])
+
+            # Verify the retrieved memory belongs to the bound principal
+            _verify_memory_ownership(memory, user_id, agent_id)
+
             panel = format_get_response(memory)
             console.print(panel)
             return ToolResult(
@@ -768,7 +949,7 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
             )
 
         elif action == "list":
-            memories = client.list_memories(tool_input.get("user_id"), tool_input.get("agent_id"))
+            memories = client.list_memories(user_id, agent_id)
             # Normalize to list
             results_list = memories if isinstance(memories, list) else memories.get("results", [])
             panel = format_list_response(results_list)
@@ -793,8 +974,8 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
 
             memories = client.search_memories(
                 tool_input["query"],
-                tool_input.get("user_id"),
-                tool_input.get("agent_id"),
+                user_id,
+                agent_id,
             )
             # Normalize to list
             results_list = memories if isinstance(memories, list) else memories.get("results", [])
@@ -818,6 +999,15 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
             if not tool_input.get("memory_id"):
                 raise ValueError("memory_id is required for delete action")
 
+            # Verify ownership before deleting
+            try:
+                memory = client.get_memory(tool_input["memory_id"])
+                _verify_memory_ownership(memory, user_id, agent_id)
+            except ValueError:
+                raise  # Re-raise ownership errors
+            except Exception:
+                pass  # If we can't fetch for verification, allow the delete (backend may enforce)
+
             client.delete_memory(tool_input["memory_id"])
             panel = format_delete_response(tool_input["memory_id"])
             console.print(panel)
@@ -830,6 +1020,15 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
         elif action == "history":
             if not tool_input.get("memory_id"):
                 raise ValueError("memory_id is required for history action")
+
+            # Verify ownership before returning history
+            try:
+                memory = client.get_memory(tool_input["memory_id"])
+                _verify_memory_ownership(memory, user_id, agent_id)
+            except ValueError:
+                raise  # Re-raise ownership errors
+            except Exception:
+                pass  # If we can't fetch for verification, allow (backend may enforce)
 
             history = client.get_memory_history(tool_input["memory_id"])
             panel = format_history_response(history)
@@ -844,8 +1043,40 @@ def mem0_memory(tool: ToolUse, **kwargs: Any) -> ToolResult:
     except Exception as e:
         error_panel = Panel(
             Text(str(e), style="red"),
-            title="❌ Memory Operation Error",
+            title="Memory Operation Error",
             border_style="red",
         )
         console.print(error_panel)
         return ToolResult(toolUseId=tool_use_id, status="error", content=[ToolResultContent(text=f"Error: {str(e)}")])
+
+
+def _verify_memory_ownership(memory: Dict, user_id: Optional[str], agent_id: Optional[str]) -> None:
+    """Verify that a retrieved memory belongs to the bound principal.
+
+    This is a defense-in-depth check for ``get``, ``delete``, and ``history``
+    operations which take a raw ``memory_id``. If the backend returns ownership
+    metadata, we validate it matches the bound principal.
+
+    Args:
+        memory: The memory record returned by the backend.
+        user_id: The bound user_id (or None).
+        agent_id: The bound agent_id (or None).
+
+    Raises:
+        ValueError: If the memory belongs to a different principal.
+    """
+    if not memory or not isinstance(memory, dict):
+        return
+
+    mem_user = memory.get("user_id")
+    mem_agent = memory.get("agent_id")
+
+    # If backend doesn't return ownership info, we can't verify (rely on backend ACLs)
+    if not mem_user and not mem_agent:
+        return
+
+    # Check ownership
+    if user_id and mem_user and mem_user != user_id:
+        raise ValueError("Access denied: memory belongs to a different user")
+    if agent_id and mem_agent and mem_agent != agent_id:
+        raise ValueError("Access denied: memory belongs to a different agent")

--- a/src/strands_tools/mongodb_memory.py
+++ b/src/strands_tools/mongodb_memory.py
@@ -32,30 +32,37 @@ Key Features:
 
 Usage Examples:
 --------------
+Multi-tenant (recommended): bind credentials and the tenant namespace per authenticated
+principal via ``MongoDBMemoryTool``. The agent-facing tool cannot override them.
+
+```python
+from strands import Agent
+from strands_tools.mongodb_memory import MongoDBMemoryTool
+
+# Operator code, per authenticated request:
+tool = MongoDBMemoryTool(
+    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
+    database_name="memory_db",
+    collection_name="memories",
+    namespace=f"user_{authenticated_user_id}",  # bound, not LLM-controllable
+)
+agent = Agent(tools=[tool.mongodb_memory])
+
+# The agent only chooses the action and its content/query/memory_id:
+agent.tool.mongodb_memory(action="record", content="User prefers vegetarian pizza")
+agent.tool.mongodb_memory(action="retrieve", query="food preferences", max_results=5)
+```
+
+Single-tenant convenience: the module-level ``mongodb_memory`` function reads all connection,
+location, namespace, and embedding configuration from environment variables only. It exposes no
+connection or namespace parameter to the agent.
+
 ```python
 from strands import Agent
 from strands_tools.mongodb_memory import mongodb_memory
 
-# Store a memory
-result = mongodb_memory(
-    action="record",
-    content="User prefers vegetarian pizza with extra cheese",
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123"
-)
-
-# Search memories
-result = mongodb_memory(
-    action="retrieve",
-    query="food preferences",
-    cluster_uri="mongodb+srv://user:password@cluster.mongodb.net/",
-    database_name="memory_db",
-    collection_name="memories",
-    namespace="user_123",
-    max_results=5
-)
+agent = Agent(tools=[mongodb_memory])
+agent.tool.mongodb_memory(action="record", content="User prefers vegetarian pizza")
 ```
 
 Environment Variables:
@@ -732,6 +739,7 @@ class MongoDBMemoryTool:
         cluster_uri: Optional[str] = None,
         database_name: Optional[str] = None,
         collection_name: Optional[str] = None,
+        namespace: Optional[str] = None,
         embedding_model: Optional[str] = None,
         region: Optional[str] = None,
         vector_index_name: Optional[str] = None,
@@ -743,6 +751,10 @@ class MongoDBMemoryTool:
             cluster_uri: MongoDB Atlas cluster URI (kept private from agents)
             database_name: Name of the MongoDB database
             collection_name: Name of the MongoDB collection
+            namespace: Tenant-isolation key bound at construction (kept private from agents).
+                Falls back to the MONGODB_NAMESPACE environment variable, then 'default'.
+                Serve multiple principals by constructing one tool per principal, e.g.
+                namespace=f"user_{authenticated_user_id}".
             embedding_model: Amazon Bedrock model for embeddings
             region: AWS region for Bedrock service
             vector_index_name: Name of the vector search index
@@ -754,6 +766,14 @@ class MongoDBMemoryTool:
         self._embedding_model = embedding_model or os.getenv("MONGODB_EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL)
         self._region = region or os.getenv("AWS_REGION", DEFAULT_AWS_REGION)
         self._vector_index_name = vector_index_name or DEFAULT_VECTOR_INDEX_NAME
+
+        # Namespace is the sole tenant-isolation key, so it is bound here and never taken from
+        # the LLM-controlled @tool signature. An agent cannot read or write another tenant's
+        # memories by choosing a namespace. Validate once at construction so a bad value fails
+        # fast for the operator instead of on every tool call.
+        if namespace is None:
+            namespace = os.getenv("MONGODB_NAMESPACE", DEFAULT_NAMESPACE)
+        self._namespace = _validate_namespace(namespace)
 
         # Validate credentials during initialization
         if not self._cluster_uri:
@@ -772,7 +792,6 @@ class MongoDBMemoryTool:
         max_results: Optional[int] = None,
         next_token: Optional[str] = None,
         metadata: Optional[Dict] = None,
-        namespace: Optional[str] = None,
     ) -> Dict:
         """
         Work with MongoDB Atlas memories - create, search, retrieve, list, and manage memory records.
@@ -780,7 +799,8 @@ class MongoDBMemoryTool:
         This tool helps agents store and access memories using MongoDB Atlas with semantic search
         capabilities, allowing them to remember important information across conversations.
 
-        Note: Credentials are securely managed by the class and not exposed to agents.
+        Note: Credentials and the tenant namespace are securely managed by the class and not
+        exposed to agents.
 
         Key Capabilities:
         - Store new memories with automatic embedding generation
@@ -806,24 +826,15 @@ class MongoDBMemoryTool:
             max_results: Maximum number of results to return (optional, default: 10)
             next_token: Pagination token for list action (optional)
             metadata: Additional metadata to store with the memory (optional)
-            namespace: Namespace for memory operations (defaults to 'default')
 
         Returns:
             Dict: Response containing the requested memory information or operation status
         """
         try:
-            # Use private configuration (credentials not exposed to agents)
-            if namespace is None:
-                namespace = os.getenv("MONGODB_NAMESPACE", DEFAULT_NAMESPACE)
+            # Namespace is bound at construction (self._namespace); the agent cannot supply a
+            # different tenant key. It was already validated in __init__.
+            safe_namespace = self._namespace
             max_results = max_results or DEFAULT_MAX_RESULTS
-
-            try:
-                safe_namespace = _validate_namespace(namespace)
-            except MongoDBValidationError as e:
-                return {
-                    "status": "error",
-                    "content": [{"text": f"Invalid namespace: {str(e)}"}],
-                }
 
             # Initialize MongoDB client with secure error handling
             try:
@@ -968,19 +979,18 @@ def mongodb_memory(
     max_results: Optional[int] = None,
     next_token: Optional[str] = None,
     metadata: Optional[Dict] = None,
-    cluster_uri: Optional[str] = None,
-    database_name: Optional[str] = None,
-    collection_name: Optional[str] = None,
-    namespace: Optional[str] = None,
-    embedding_model: Optional[str] = None,
-    region: Optional[str] = None,
-    vector_index_name: Optional[str] = None,
 ) -> Dict:
     """
     Work with MongoDB Atlas memories - create, search, retrieve, list, and manage memory records.
 
     This tool helps agents store and access memories using MongoDB Atlas with semantic search
     capabilities, allowing them to remember important information across conversations.
+
+    Connection, database/collection, tenant namespace, and embedding configuration are read
+    exclusively from environment variables and are never exposed as tool parameters, so an agent
+    cannot redirect the memory layer at another cluster or read/write another tenant's namespace.
+    For multi-tenant deployments, construct one MongoDBMemoryTool per authenticated principal with
+    an explicit namespace instead of using this single-tenant, environment-driven function.
 
     Key Capabilities:
     - Store new memories with automatic embedding generation
@@ -998,6 +1008,14 @@ def mongodb_memory(
     - get: Retrieve specific memories by memory ID
     - delete: Remove specific memories by memory ID
 
+    Configuration (read from environment variables only):
+    - MONGODB_ATLAS_CLUSTER_URI: MongoDB Atlas cluster URI (required)
+    - MONGODB_DATABASE_NAME: Database name (defaults to 'strands_memory')
+    - MONGODB_COLLECTION_NAME: Collection name (defaults to 'memories')
+    - MONGODB_NAMESPACE: Tenant namespace (defaults to 'default')
+    - MONGODB_EMBEDDING_MODEL: Amazon Bedrock embedding model (defaults to Titan)
+    - AWS_REGION: AWS region for Bedrock service (defaults to 'us-west-2')
+
     Args:
         action: The memory operation to perform (one of: "record", "retrieve", "list", "get", "delete")
         content: For record action: Text content to store as a memory
@@ -1006,31 +1024,21 @@ def mongodb_memory(
         max_results: Maximum number of results to return (optional, default: 10)
         next_token: Pagination token for list action (optional)
         metadata: Additional metadata to store with the memory (optional)
-        cluster_uri: MongoDB Atlas cluster URI. If the MONGODB_ATLAS_CLUSTER_URI environment variable
-            is set, it takes precedence and this parameter is ignored.
-        database_name: Name of the MongoDB database. If the MONGODB_DATABASE_NAME environment variable
-            is set, it takes precedence. Defaults to 'strands_memory'.
-        collection_name: Name of the MongoDB collection. If the MONGODB_COLLECTION_NAME environment
-            variable is set, it takes precedence. Defaults to 'memories'.
-        namespace: Namespace for memory operations (defaults to 'default')
-        embedding_model: Amazon Bedrock model for embeddings (defaults to Titan)
-        region: AWS region for Bedrock service (defaults to 'us-west-2')
-        vector_index_name: Name of the vector search index (defaults to 'vector_index')
 
     Returns:
         Dict: Response containing the requested memory information or operation status
     """
     try:
-        # Environment variables take precedence over agent-provided parameters to prevent
-        # the agent from redirecting connections to untrusted servers.
-        cluster_uri = os.getenv("MONGODB_ATLAS_CLUSTER_URI") or cluster_uri
-        database_name = os.getenv("MONGODB_DATABASE_NAME", database_name or DEFAULT_DATABASE_NAME)
-        collection_name = os.getenv("MONGODB_COLLECTION_NAME", collection_name or DEFAULT_COLLECTION_NAME)
-        embedding_model = os.getenv("MONGODB_EMBEDDING_MODEL", embedding_model or DEFAULT_EMBEDDING_MODEL)
-        region = os.getenv("AWS_REGION", region or DEFAULT_AWS_REGION)
-        vector_index_name = vector_index_name or DEFAULT_VECTOR_INDEX_NAME
-        if namespace is None:
-            namespace = os.getenv("MONGODB_NAMESPACE", DEFAULT_NAMESPACE)
+        # All connection, location, namespace, and embedding configuration is sourced from the
+        # environment only. These are deliberately not tool parameters: exposing them would let
+        # the LLM point the tool at an arbitrary cluster or forge another tenant's namespace.
+        cluster_uri = os.getenv("MONGODB_ATLAS_CLUSTER_URI")
+        database_name = os.getenv("MONGODB_DATABASE_NAME", DEFAULT_DATABASE_NAME)
+        collection_name = os.getenv("MONGODB_COLLECTION_NAME", DEFAULT_COLLECTION_NAME)
+        embedding_model = os.getenv("MONGODB_EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL)
+        region = os.getenv("AWS_REGION", DEFAULT_AWS_REGION)
+        vector_index_name = DEFAULT_VECTOR_INDEX_NAME
+        namespace = os.getenv("MONGODB_NAMESPACE", DEFAULT_NAMESPACE)
         max_results = max_results or DEFAULT_MAX_RESULTS
 
         try:
@@ -1049,7 +1057,7 @@ def mongodb_memory(
                     {
                         "text": (
                             "cluster_uri is required for MongoDB Memory Tool. "
-                            "Set MONGODB_ATLAS_CLUSTER_URI environment variable or provide cluster_uri parameter."
+                            "Set the MONGODB_ATLAS_CLUSTER_URI environment variable."
                         )
                     }
                 ],

--- a/tests/test_elasticsearch_memory.py
+++ b/tests/test_elasticsearch_memory.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 from strands import Agent
 
-from src.strands_tools.elasticsearch_memory import elasticsearch_memory
+from src.strands_tools.elasticsearch_memory import ElasticsearchMemoryTool, elasticsearch_memory
 
 ES_ENV_VARS = {
     "ELASTICSEARCH_CLOUD_ID": "test-cloud-id",
@@ -97,24 +97,37 @@ def agent(mock_elasticsearch_client, mock_bedrock_client):
 
 
 @pytest.fixture
-def config():
-    """Configuration parameters for testing (non-credential params only)."""
+def tool_config():
+    """Configuration for constructing an ElasticsearchMemoryTool in tests."""
     return {
+        "cloud_id": "test-cloud-id",
+        "api_key": "test-api-key",
         "index_name": "test_index",
         "namespace": "test_namespace",
+        "region": "us-east-1",
     }
 
 
 # --- Security Tests ---
 
 
-def test_credential_params_not_in_tool_signature():
-    """Verify that credential/connection parameters cannot be passed to the tool."""
-    sig = inspect.signature(elasticsearch_memory)
-    param_names = set(sig.parameters.keys())
-    assert "es_url" not in param_names
-    assert "cloud_id" not in param_names
-    assert "api_key" not in param_names
+def test_credential_and_namespace_params_not_in_standalone_signature():
+    """IDOR guard: the standalone tool must not expose connection, credential, or namespace params.
+
+    Regression test for the IDOR where an LLM-supplied namespace/api_key/cloud_id could redirect the
+    memory layer at another tenant or cluster (or authenticate as a different principal). These must
+    be environment-only.
+    """
+    param_names = set(inspect.signature(elasticsearch_memory).parameters.keys())
+    for forbidden in ["es_url", "cloud_id", "api_key", "index_name", "namespace", "embedding_model", "region"]:
+        assert forbidden not in param_names, f"'{forbidden}' must not be an LLM-controllable tool parameter"
+
+
+def test_namespace_params_not_in_class_tool_signature():
+    """IDOR guard: ElasticsearchMemoryTool.elasticsearch_memory must not expose namespace/creds."""
+    param_names = set(inspect.signature(ElasticsearchMemoryTool.elasticsearch_memory).parameters.keys())
+    for forbidden in ["es_url", "cloud_id", "api_key", "index_name", "namespace"]:
+        assert forbidden not in param_names
 
 
 def test_missing_required_params(mock_elasticsearch_client, mock_bedrock_client):
@@ -148,7 +161,7 @@ def test_connection_failure(mock_elasticsearch_client, mock_bedrock_client):
     assert "Unable to connect to Elasticsearch cluster" in result["content"][0]["text"]
 
 
-def test_index_creation(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_index_creation(mock_elasticsearch_client, mock_bedrock_client):
     """Test that index is created with proper mappings."""
     agent = Agent(tools=[elasticsearch_memory])
 
@@ -156,7 +169,7 @@ def test_index_creation(mock_elasticsearch_client, mock_bedrock_client, config):
     mock_elasticsearch_client["client"].index.return_value = {"result": "created", "_id": "test_memory_id"}
 
     with mock.patch.dict(os.environ, ES_ENV_VARS):
-        agent.tool.elasticsearch_memory(action="record", content="Test content", **config)
+        agent.tool.elasticsearch_memory(action="record", content="Test content")
 
     # Verify index creation was called
     mock_elasticsearch_client["client"].indices.create.assert_called_once()
@@ -185,7 +198,7 @@ def test_index_creation(mock_elasticsearch_client, mock_bedrock_client, config):
     assert embedding_config["similarity"] == "cosine"
 
 
-def test_record_memory(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_record_memory(mock_elasticsearch_client, mock_bedrock_client):
     """Test recording a memory."""
     agent = Agent(tools=[elasticsearch_memory])
 
@@ -195,7 +208,7 @@ def test_record_memory(mock_elasticsearch_client, mock_bedrock_client, config):
     # Call the tool
     with mock.patch.dict(os.environ, ES_ENV_VARS):
         result = agent.tool.elasticsearch_memory(
-            action="record", content="Test memory content", metadata={"category": "test"}, **config
+            action="record", content="Test memory content", metadata={"category": "test"}
         )
 
     # Verify success response
@@ -209,7 +222,7 @@ def test_record_memory(mock_elasticsearch_client, mock_bedrock_client, config):
     mock_bedrock_client["bedrock"].invoke_model.assert_called_once()
 
 
-def test_retrieve_memories(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_retrieve_memories(mock_elasticsearch_client, mock_bedrock_client):
     """Test retrieving memories with semantic search."""
     agent = Agent(tools=[elasticsearch_memory])
 
@@ -233,7 +246,7 @@ def test_retrieve_memories(mock_elasticsearch_client, mock_bedrock_client, confi
     }
 
     # Call the tool
-    result = agent.tool.elasticsearch_memory(action="retrieve", query="test query", max_results=5, **config)
+    result = agent.tool.elasticsearch_memory(action="retrieve", query="test query", max_results=5)
 
     # Verify success response
     assert result["status"] == "success"
@@ -249,7 +262,7 @@ def test_retrieve_memories(mock_elasticsearch_client, mock_bedrock_client, confi
     mock_bedrock_client["bedrock"].invoke_model.assert_called_once()
 
 
-def test_list_memories(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_list_memories(mock_elasticsearch_client, mock_bedrock_client):
     """Test listing all memories."""
     agent = Agent(tools=[elasticsearch_memory])
 
@@ -279,7 +292,7 @@ def test_list_memories(mock_elasticsearch_client, mock_bedrock_client, config):
     }
 
     # Call the tool
-    result = agent.tool.elasticsearch_memory(action="list", max_results=10, **config)
+    result = agent.tool.elasticsearch_memory(action="list", max_results=10)
 
     # Verify success response
     assert result["status"] == "success"
@@ -292,11 +305,11 @@ def test_list_memories(mock_elasticsearch_client, mock_bedrock_client, config):
     assert search_call["body"]["sort"] == [{"timestamp": {"order": "desc"}}]
 
 
-def test_get_memory(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_get_memory(mock_elasticsearch_client, mock_bedrock_client):
     """Test getting a specific memory by ID."""
     agent = Agent(tools=[elasticsearch_memory])
 
-    # Configure mock search response (now uses search instead of get for namespace enforcement)
+    # Configure mock search response (uses search for namespace enforcement)
     mock_elasticsearch_client["client"].search.return_value = {
         "hits": {
             "hits": [
@@ -315,7 +328,7 @@ def test_get_memory(mock_elasticsearch_client, mock_bedrock_client, config):
     }
 
     # Call the tool
-    result = agent.tool.elasticsearch_memory(action="get", memory_id="mem_123", **config)
+    result = agent.tool.elasticsearch_memory(action="get", memory_id="mem_123")
 
     # Verify success response
     assert result["status"] == "success"
@@ -329,7 +342,7 @@ def test_get_memory(mock_elasticsearch_client, mock_bedrock_client, config):
     assert {"term": {"namespace": "test_namespace"}} in query
 
 
-def test_delete_memory(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_delete_memory(mock_elasticsearch_client, mock_bedrock_client):
     """Test deleting a memory."""
     agent = Agent(tools=[elasticsearch_memory])
 
@@ -337,7 +350,7 @@ def test_delete_memory(mock_elasticsearch_client, mock_bedrock_client, config):
     mock_elasticsearch_client["client"].delete_by_query.return_value = {"deleted": 1}
 
     # Call the tool
-    result = agent.tool.elasticsearch_memory(action="delete", memory_id="mem_123", **config)
+    result = agent.tool.elasticsearch_memory(action="delete", memory_id="mem_123")
 
     # Verify success response
     assert result["status"] == "success"
@@ -351,11 +364,11 @@ def test_delete_memory(mock_elasticsearch_client, mock_bedrock_client, config):
     assert {"term": {"namespace": "test_namespace"}} in query
 
 
-def test_unsupported_action(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_unsupported_action(mock_elasticsearch_client, mock_bedrock_client):
     """Test tool with an unsupported action."""
     agent = Agent(tools=[elasticsearch_memory])
 
-    result = agent.tool.elasticsearch_memory(action="unsupported_action", **config)
+    result = agent.tool.elasticsearch_memory(action="unsupported_action")
 
     # Verify error response
     assert result["status"] == "error"
@@ -364,12 +377,12 @@ def test_unsupported_action(mock_elasticsearch_client, mock_bedrock_client, conf
     assert "retrieve" in result["content"][0]["text"]
 
 
-def test_missing_required_parameters(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_missing_required_parameters(mock_elasticsearch_client, mock_bedrock_client):
     """Test tool with missing required parameters."""
     agent = Agent(tools=[elasticsearch_memory])
 
     # Test record action without content
-    result = agent.tool.elasticsearch_memory(action="record", **config)
+    result = agent.tool.elasticsearch_memory(action="record")
 
     # Verify error response
     assert result["status"] == "error"
@@ -377,7 +390,7 @@ def test_missing_required_parameters(mock_elasticsearch_client, mock_bedrock_cli
     assert "content" in result["content"][0]["text"]
 
     # Test retrieve action without query
-    result = agent.tool.elasticsearch_memory(action="retrieve", **config)
+    result = agent.tool.elasticsearch_memory(action="retrieve")
 
     # Verify error response
     assert result["status"] == "error"
@@ -385,7 +398,7 @@ def test_missing_required_parameters(mock_elasticsearch_client, mock_bedrock_cli
     assert "query" in result["content"][0]["text"]
 
     # Test get action without memory_id
-    result = agent.tool.elasticsearch_memory(action="get", **config)
+    result = agent.tool.elasticsearch_memory(action="get")
 
     # Verify error response
     assert result["status"] == "error"
@@ -393,7 +406,7 @@ def test_missing_required_parameters(mock_elasticsearch_client, mock_bedrock_cli
     assert "memory_id" in result["content"][0]["text"]
 
 
-def test_elasticsearch_api_error_handling(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_elasticsearch_api_error_handling(mock_elasticsearch_client, mock_bedrock_client):
     """Test handling of Elasticsearch API errors."""
     agent = Agent(tools=[elasticsearch_memory])
 
@@ -401,7 +414,7 @@ def test_elasticsearch_api_error_handling(mock_elasticsearch_client, mock_bedroc
     mock_elasticsearch_client["client"].index.side_effect = Exception("Elasticsearch error")
 
     # Call the tool
-    result = agent.tool.elasticsearch_memory(action="record", content="Test content", **config)
+    result = agent.tool.elasticsearch_memory(action="record", content="Test content")
 
     # Verify error response
     assert result["status"] == "error"
@@ -409,7 +422,7 @@ def test_elasticsearch_api_error_handling(mock_elasticsearch_client, mock_bedroc
     assert "Elasticsearch error" in result["content"][0]["text"]
 
 
-def test_bedrock_api_error_handling(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_bedrock_api_error_handling(mock_elasticsearch_client, mock_bedrock_client):
     """Test handling of Bedrock API errors."""
     agent = Agent(tools=[elasticsearch_memory])
 
@@ -417,7 +430,7 @@ def test_bedrock_api_error_handling(mock_elasticsearch_client, mock_bedrock_clie
     mock_bedrock_client["bedrock"].invoke_model.side_effect = Exception("Bedrock error")
 
     # Call the tool
-    result = agent.tool.elasticsearch_memory(action="record", content="Test content", **config)
+    result = agent.tool.elasticsearch_memory(action="record", content="Test content")
 
     # Verify error response
     assert result["status"] == "error"
@@ -425,7 +438,7 @@ def test_bedrock_api_error_handling(mock_elasticsearch_client, mock_bedrock_clie
     assert "Embedding generation failed" in result["content"][0]["text"]
 
 
-def test_memory_not_found(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_memory_not_found(mock_elasticsearch_client, mock_bedrock_client):
     """Test handling when memory is not found."""
     agent = Agent(tools=[elasticsearch_memory])
 
@@ -438,15 +451,15 @@ def test_memory_not_found(mock_elasticsearch_client, mock_bedrock_client, config
     }
 
     # Call the tool
-    result = agent.tool.elasticsearch_memory(action="get", memory_id="nonexistent", **config)
+    result = agent.tool.elasticsearch_memory(action="get", memory_id="nonexistent")
 
     # Verify error response
     assert result["status"] == "error"
     assert "Memory nonexistent not found in namespace test_namespace" in result["content"][0]["text"]
 
 
-def test_namespace_validation(mock_elasticsearch_client, mock_bedrock_client, config):
-    """Test that memories are properly filtered by namespace."""
+def test_namespace_filtering(mock_elasticsearch_client, mock_bedrock_client):
+    """Test that memories are properly filtered by the environment-configured namespace."""
     agent = Agent(tools=[elasticsearch_memory])
 
     # Configure mock search to return empty results (memory not in this namespace)
@@ -458,7 +471,7 @@ def test_namespace_validation(mock_elasticsearch_client, mock_bedrock_client, co
     }
 
     # Call the tool
-    result = agent.tool.elasticsearch_memory(action="get", memory_id="mem_123", **config)
+    result = agent.tool.elasticsearch_memory(action="get", memory_id="mem_123")
 
     # Verify error response
     assert result["status"] == "error"
@@ -472,7 +485,7 @@ def test_namespace_validation(mock_elasticsearch_client, mock_bedrock_client, co
     assert {"term": {"namespace": "test_namespace"}} in query
 
 
-def test_pagination_support(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_pagination_support(mock_elasticsearch_client, mock_bedrock_client):
     """Test pagination support in list and retrieve operations."""
     agent = Agent(tools=[elasticsearch_memory])
 
@@ -494,7 +507,7 @@ def test_pagination_support(mock_elasticsearch_client, mock_bedrock_client, conf
     }
 
     # Test list with pagination
-    agent.tool.elasticsearch_memory(action="list", max_results=5, next_token="10", **config)
+    agent.tool.elasticsearch_memory(action="list", max_results=5, next_token="10")
 
     # Verify search was called with correct offset
     search_call = mock_elasticsearch_client["client"].search.call_args[1]
@@ -503,7 +516,7 @@ def test_pagination_support(mock_elasticsearch_client, mock_bedrock_client, conf
 
 
 def test_environment_variable_defaults(mock_elasticsearch_client, mock_bedrock_client):
-    """Test that environment variables are used for defaults."""
+    """Test that environment variables are used for configuration."""
     agent = Agent(tools=[elasticsearch_memory])
 
     with mock.patch.dict(
@@ -527,32 +540,10 @@ def test_environment_variable_defaults(mock_elasticsearch_client, mock_bedrock_c
         assert result["status"] == "success"
         assert "Memory stored successfully" in result["content"][0]["text"]
 
-
-def test_agent_tool_usage(mock_elasticsearch_client, mock_bedrock_client):
-    """Test using the elasticsearch_memory tool through agent.tool pattern."""
-    # Configure mock responses
-    mock_elasticsearch_client["client"].index.return_value = {"result": "created", "_id": "test_memory_id"}
-
-    # Create agent with direct tool usage - this demonstrates the standard pattern
-    agent = Agent(tools=[elasticsearch_memory])
-
-    # Test calling the tool through agent.tool with configuration parameters
-    result = agent.tool.elasticsearch_memory(
-        action="record",
-        content="Test memory content",
-        index_name="test_index",
-        namespace="test_namespace",
-    )
-
-    # Verify success response
-    assert result["status"] == "success"
-    assert "Memory stored successfully" in result["content"][0]["text"]
-
-    # Verify Elasticsearch index was called
-    mock_elasticsearch_client["client"].index.assert_called_once()
-
-    # Verify embedding generation was called
-    mock_bedrock_client["bedrock"].invoke_model.assert_called_once()
+        # Verify the stored document used the environment-configured namespace and index
+        index_call = mock_elasticsearch_client["client"].index.call_args[1]
+        assert index_call["index"] == "env_index"
+        assert index_call["body"]["namespace"] == "env_namespace"
 
 
 def test_es_url_connection(mock_elasticsearch_client, mock_bedrock_client):
@@ -563,13 +554,8 @@ def test_es_url_connection(mock_elasticsearch_client, mock_bedrock_client):
     mock_elasticsearch_client["client"].index.return_value = {"result": "created", "_id": "test_memory_id"}
 
     # Override env vars to use URL instead of cloud_id
-    with mock.patch.dict(os.environ, ES_URL_ENV_VARS, clear=False):
-        result = agent.tool.elasticsearch_memory(
-            action="record",
-            content="Test memory content",
-            index_name="test_index",
-            namespace="test_namespace",
-        )
+    with mock.patch.dict(os.environ, ES_URL_ENV_VARS, clear=True):
+        result = agent.tool.elasticsearch_memory(action="record", content="Test memory content")
 
     # Verify success response
     assert result["status"] == "success"
@@ -582,18 +568,16 @@ def test_es_url_connection(mock_elasticsearch_client, mock_bedrock_client):
     assert call_args["api_key"] == "test-api-key"
 
 
-def test_custom_embedding_model(mock_elasticsearch_client, mock_bedrock_client, config):
-    """Test using custom embedding model."""
+def test_custom_embedding_model(mock_elasticsearch_client, mock_bedrock_client):
+    """Test using custom embedding model from the environment."""
     agent = Agent(tools=[elasticsearch_memory])
 
     # Configure mock responses
     mock_elasticsearch_client["client"].index.return_value = {"result": "created", "_id": "test_memory_id"}
 
-    # Call tool with custom embedding model
-    result = agent.tool.elasticsearch_memory(
-        action="record", content="Test memory content", embedding_model="amazon.titan-embed-text-v1:0",
-        index_name="test_index", namespace="test_namespace",
-    )
+    # Call tool with custom embedding model via env var
+    with mock.patch.dict(os.environ, {"ELASTICSEARCH_EMBEDDING_MODEL": "amazon.titan-embed-text-v1:0"}):
+        result = agent.tool.elasticsearch_memory(action="record", content="Test memory content")
 
     # Verify success response
     assert result["status"] == "success"
@@ -605,81 +589,7 @@ def test_custom_embedding_model(mock_elasticsearch_client, mock_bedrock_client, 
     assert call_args[1]["modelId"] == "amazon.titan-embed-text-v1:0"
 
 
-def test_multiple_namespaces(mock_elasticsearch_client, mock_bedrock_client, config):
-    """Test using different namespaces for data isolation."""
-    agent = Agent(tools=[elasticsearch_memory])
-
-    # Configure mock responses
-    mock_elasticsearch_client["client"].index.return_value = {"result": "created", "_id": "test_memory_id"}
-
-    # Store memory in user namespace
-    result1 = agent.tool.elasticsearch_memory(
-        action="record",
-        content="Alice likes Italian food",
-        namespace="user_alice",
-        index_name="test_index",
-    )
-
-    # Store memory in system namespace
-    result2 = agent.tool.elasticsearch_memory(
-        action="record",
-        content="System maintenance scheduled",
-        namespace="system_global",
-        index_name="test_index",
-    )
-
-    # Verify both operations succeeded
-    assert result1["status"] == "success"
-    assert result2["status"] == "success"
-
-    # Verify both calls were made
-    assert mock_elasticsearch_client["client"].index.call_count == 2
-
-
-def test_configuration_dictionary_pattern(mock_elasticsearch_client, mock_bedrock_client):
-    """Test using configuration dictionary for cleaner code."""
-    agent = Agent(tools=[elasticsearch_memory])
-
-    # Configure mock responses
-    mock_elasticsearch_client["client"].index.return_value = {"result": "created", "_id": "test_memory_id"}
-    mock_elasticsearch_client["client"].search.return_value = {
-        "hits": {
-            "hits": [
-                {
-                    "_source": {
-                        "memory_id": "mem_123",
-                        "content": "Test content",
-                        "timestamp": "2023-01-01T00:00:00Z",
-                        "metadata": {},
-                    },
-                    "_score": 0.95,
-                }
-            ],
-            "total": {"value": 1},
-            "max_score": 0.95,
-        }
-    }
-
-    # Create configuration dictionary (non-credential params only)
-    config = {
-        "index_name": "memories",
-        "namespace": "user_123",
-    }
-
-    # Store memory using config dictionary
-    result1 = agent.tool.elasticsearch_memory(action="record", content="User prefers vegetarian pizza", **config)
-
-    # Search memories using config dictionary
-    result2 = agent.tool.elasticsearch_memory(action="retrieve", query="food preferences", max_results=5, **config)
-
-    # Verify both operations succeeded
-    assert result1["status"] == "success"
-    assert result2["status"] == "success"
-    assert "Memory stored successfully" in result1["content"][0]["text"]
-    assert "Memories retrieved successfully" in result2["content"][0]["text"]
-
-
-def test_batch_operations(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_batch_operations(mock_elasticsearch_client, mock_bedrock_client):
     """Test storing multiple related memories in batch."""
     agent = Agent(tools=[elasticsearch_memory])
 
@@ -695,7 +605,6 @@ def test_batch_operations(mock_elasticsearch_client, mock_bedrock_client, config
             action="record",
             content=content,
             metadata={"batch": "user_preferences", "category": "preferences"},
-            **config,
         )
         results.append(result)
 
@@ -708,13 +617,13 @@ def test_batch_operations(mock_elasticsearch_client, mock_bedrock_client, config
     assert mock_elasticsearch_client["client"].index.call_count == len(memories)
 
 
-def test_error_handling_scenarios(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_error_handling_scenarios(mock_elasticsearch_client, mock_bedrock_client):
     """Test comprehensive error handling scenarios."""
     agent = Agent(tools=[elasticsearch_memory])
 
     # Test connection errors
     mock_elasticsearch_client["client"].ping.return_value = False
-    result = agent.tool.elasticsearch_memory(action="record", content="test", **config)
+    result = agent.tool.elasticsearch_memory(action="record", content="test")
     assert result["status"] == "error"
     assert "Unable to connect to Elasticsearch cluster" in result["content"][0]["text"]
 
@@ -723,7 +632,7 @@ def test_error_handling_scenarios(mock_elasticsearch_client, mock_bedrock_client
 
     # Test Elasticsearch API errors
     mock_elasticsearch_client["client"].index.side_effect = Exception("Elasticsearch connection failed")
-    result = agent.tool.elasticsearch_memory(action="record", content="test", **config)
+    result = agent.tool.elasticsearch_memory(action="record", content="test")
     assert result["status"] == "error"
     assert "API error" in result["content"][0]["text"]
 
@@ -732,12 +641,12 @@ def test_error_handling_scenarios(mock_elasticsearch_client, mock_bedrock_client
 
     # Test Bedrock API errors
     mock_bedrock_client["bedrock"].invoke_model.side_effect = Exception("Bedrock access denied")
-    result = agent.tool.elasticsearch_memory(action="record", content="test", **config)
+    result = agent.tool.elasticsearch_memory(action="record", content="test")
     assert result["status"] == "error"
     assert "Embedding generation failed" in result["content"][0]["text"]
 
 
-def test_metadata_usage_scenarios(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_metadata_usage_scenarios(mock_elasticsearch_client, mock_bedrock_client):
     """Test various metadata usage patterns."""
     agent = Agent(tools=[elasticsearch_memory])
 
@@ -754,7 +663,7 @@ def test_metadata_usage_scenarios(mock_elasticsearch_client, mock_bedrock_client
     }
 
     result = agent.tool.elasticsearch_memory(
-        action="record", content="Important project deadline", metadata=structured_metadata, **config
+        action="record", content="Important project deadline", metadata=structured_metadata
     )
 
     assert result["status"] == "success"
@@ -766,7 +675,7 @@ def test_metadata_usage_scenarios(mock_elasticsearch_client, mock_bedrock_client
     assert call_args["body"]["metadata"] == structured_metadata
 
 
-def test_performance_scenarios(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_performance_scenarios(mock_elasticsearch_client, mock_bedrock_client):
     """Test performance-related scenarios like pagination."""
     agent = Agent(tools=[elasticsearch_memory])
 
@@ -789,7 +698,7 @@ def test_performance_scenarios(mock_elasticsearch_client, mock_bedrock_client, c
     }
 
     # Test pagination with next_token
-    result = agent.tool.elasticsearch_memory(action="list", max_results=5, next_token="10", **config)
+    result = agent.tool.elasticsearch_memory(action="list", max_results=5, next_token="10")
 
     assert result["status"] == "success"
     assert "Memories listed successfully" in result["content"][0]["text"]
@@ -800,38 +709,13 @@ def test_performance_scenarios(mock_elasticsearch_client, mock_bedrock_client, c
     assert search_call["body"]["size"] == 5
 
 
-def test_security_scenarios(mock_elasticsearch_client, mock_bedrock_client):
-    """Test security-related scenarios like namespace isolation."""
-    agent = Agent(tools=[elasticsearch_memory])
-
-    # Configure mock search to return empty results (memory not in this namespace)
-    mock_elasticsearch_client["client"].search.return_value = {
-        "hits": {
-            "hits": [],
-            "total": {"value": 0},
-        }
-    }
-
-    # Test namespace validation - memory exists but not in requested namespace
-    with mock.patch.dict(os.environ, ES_ENV_VARS):
-        result = agent.tool.elasticsearch_memory(
-            action="get",
-            memory_id="mem_123",
-            index_name="test_index",
-            namespace="correct_namespace",
-        )
-
-    assert result["status"] == "error"
-    assert "not found in namespace correct_namespace" in result["content"][0]["text"]
-
-
-def test_troubleshooting_scenarios(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_troubleshooting_scenarios(mock_elasticsearch_client, mock_bedrock_client):
     """Test troubleshooting scenarios mentioned in documentation."""
     agent = Agent(tools=[elasticsearch_memory])
 
     # Test index creation failure
     mock_elasticsearch_client["client"].indices.create.side_effect = Exception("Index creation failed")
-    result = agent.tool.elasticsearch_memory(action="record", content="test", **config)
+    result = agent.tool.elasticsearch_memory(action="record", content="test")
     assert result["status"] == "error"
     assert "Failed to create index" in result["content"][0]["text"]
 
@@ -840,48 +724,19 @@ def test_troubleshooting_scenarios(mock_elasticsearch_client, mock_bedrock_clien
 
     # Test authentication errors (simulated by connection failure)
     mock_elasticsearch_client["client"].ping.return_value = False
-    result = agent.tool.elasticsearch_memory(action="record", content="test", **config)
+    result = agent.tool.elasticsearch_memory(action="record", content="test")
     assert result["status"] == "error"
     assert "Unable to connect to Elasticsearch cluster" in result["content"][0]["text"]
 
 
-def test_injection_prevention(mock_elasticsearch_client, mock_bedrock_client, config):
-    """Test that injection attempts via namespace are blocked."""
+def test_invalid_namespace_env_var(mock_elasticsearch_client, mock_bedrock_client):
+    """Test that an invalid ELASTICSEARCH_NAMESPACE env var is rejected.
+
+    The agent cannot supply a namespace, so injection cannot reach it via the tool signature. An
+    operator can still misconfigure the environment variable, so validation runs on that value.
+    """
     agent = Agent(tools=[elasticsearch_memory])
 
-    # Config without namespace
-    test_config = {"index_name": "test_index"}
-
-    # Test dict-based injection (analogous to MongoDB {"$ne": ""} attack)
-    malicious_namespace = {"$ne": ""}
-    result = agent.tool.elasticsearch_memory(action="list", namespace=malicious_namespace, **test_config)
-    assert result["status"] == "error"
-    error_text = result["content"][0]["text"]
-    assert "Invalid namespace" in error_text or "Input should be a valid string" in error_text
-
-    # Test other injection payloads
-    injection_attempts = [
-        {"$gt": ""},
-        {"$regex": ".*"},
-        {"$exists": True},
-        {"$in": ["tenant1", "tenant2"]},
-    ]
-
-    for injection_payload in injection_attempts:
-        result = agent.tool.elasticsearch_memory(action="list", namespace=injection_payload, **test_config)
-        assert result["status"] == "error", f"Injection {injection_payload} should be blocked"
-        error_text = result["content"][0]["text"]
-        assert "Invalid namespace" in error_text or "Input should be a valid string" in error_text
-
-
-def test_namespace_validation_strict_rules(mock_elasticsearch_client, mock_bedrock_client, config):
-    """Test strict namespace validation rules."""
-    agent = Agent(tools=[elasticsearch_memory])
-
-    # Config without namespace
-    test_config = {"index_name": "test_index"}
-
-    # Test invalid characters (should be rejected)
     invalid_namespaces = [
         "user.name",  # Dots not allowed
         "user@domain",  # @ symbol
@@ -895,14 +750,14 @@ def test_namespace_validation_strict_rules(mock_elasticsearch_client, mock_bedro
     ]
 
     for invalid_namespace in invalid_namespaces:
-        result = agent.tool.elasticsearch_memory(action="list", namespace=invalid_namespace, **test_config)
-        assert result["status"] == "error", f"Invalid namespace '{invalid_namespace}' should be rejected"
-        error_text = result["content"][0]["text"]
-        assert "Invalid namespace" in error_text
+        with mock.patch.dict(os.environ, {"ELASTICSEARCH_NAMESPACE": invalid_namespace}):
+            result = agent.tool.elasticsearch_memory(action="list")
+            assert result["status"] == "error", f"Invalid namespace '{invalid_namespace}' should be rejected"
+            assert "Invalid namespace" in result["content"][0]["text"]
 
 
-def test_valid_namespaces_accepted(mock_elasticsearch_client, mock_bedrock_client, config):
-    """Test that valid namespaces are accepted."""
+def test_valid_namespaces_accepted(mock_elasticsearch_client, mock_bedrock_client):
+    """Test that valid namespaces (via env var) are accepted."""
     agent = Agent(tools=[elasticsearch_memory])
 
     # Configure mock responses
@@ -912,9 +767,6 @@ def test_valid_namespaces_accepted(mock_elasticsearch_client, mock_bedrock_clien
             "total": {"value": 0},
         }
     }
-
-    # Config without namespace
-    test_config = {"index_name": "test_index"}
 
     valid_namespaces = [
         "default",
@@ -926,18 +778,19 @@ def test_valid_namespaces_accepted(mock_elasticsearch_client, mock_bedrock_clien
     ]
 
     for valid_namespace in valid_namespaces:
-        result = agent.tool.elasticsearch_memory(action="list", namespace=valid_namespace, **test_config)
-        assert result["status"] == "success", f"Valid namespace '{valid_namespace}' should be accepted"
+        with mock.patch.dict(os.environ, {"ELASTICSEARCH_NAMESPACE": valid_namespace}):
+            result = agent.tool.elasticsearch_memory(action="list")
+            assert result["status"] == "success", f"Valid namespace '{valid_namespace}' should be accepted"
 
 
-def test_delete_memory_namespace_enforcement(mock_elasticsearch_client, mock_bedrock_client, config):
+def test_delete_memory_namespace_enforcement(mock_elasticsearch_client, mock_bedrock_client):
     """Test that delete enforces namespace atomically (no TOCTOU)."""
     agent = Agent(tools=[elasticsearch_memory])
 
     # Configure delete_by_query to return 0 deleted (memory not in namespace)
     mock_elasticsearch_client["client"].delete_by_query.return_value = {"deleted": 0}
 
-    result = agent.tool.elasticsearch_memory(action="delete", memory_id="mem_123", **config)
+    result = agent.tool.elasticsearch_memory(action="delete", memory_id="mem_123")
 
     # Should fail because memory not found in the requested namespace
     assert result["status"] == "error"
@@ -949,3 +802,82 @@ def test_delete_memory_namespace_enforcement(mock_elasticsearch_client, mock_bed
     query = call_args["body"]["query"]["bool"]["must"]
     assert {"term": {"memory_id": "mem_123"}} in query
     assert {"term": {"namespace": "test_namespace"}} in query
+
+
+# --- ElasticsearchMemoryTool class (per-principal binding) ---
+
+
+def test_class_requires_api_key(mock_elasticsearch_client, mock_bedrock_client):
+    """Constructing the class without an api_key raises."""
+    from src.strands_tools.elasticsearch_memory import ElasticsearchValidationError
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ElasticsearchValidationError, match="api_key is required"):
+            ElasticsearchMemoryTool(cloud_id="test-cloud-id")
+
+
+def test_class_requires_connection(mock_elasticsearch_client, mock_bedrock_client):
+    """Constructing the class without cloud_id or es_url raises."""
+    from src.strands_tools.elasticsearch_memory import ElasticsearchValidationError
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ElasticsearchValidationError, match="Either cloud_id or es_url is required"):
+            ElasticsearchMemoryTool(api_key="test-api-key")
+
+
+def test_class_rejects_invalid_namespace(mock_elasticsearch_client, mock_bedrock_client, tool_config):
+    """The class validates the bound namespace at construction."""
+    from src.strands_tools.elasticsearch_memory import ElasticsearchValidationError
+
+    bad_config = {**tool_config, "namespace": "user$name"}
+    with pytest.raises(ElasticsearchValidationError, match="Invalid namespace"):
+        ElasticsearchMemoryTool(**bad_config)
+
+
+def test_class_binds_namespace(mock_elasticsearch_client, mock_bedrock_client, tool_config):
+    """The class uses its constructor namespace, not any agent-supplied value."""
+    mock_elasticsearch_client["client"].search.return_value = {"hits": {"hits": [], "total": {"value": 0}}}
+
+    tool = ElasticsearchMemoryTool(**{**tool_config, "namespace": "user_alice"})
+    agent = Agent(tools=[tool.elasticsearch_memory])
+
+    result = agent.tool.elasticsearch_memory(action="get", memory_id="mem_123")
+
+    assert result["status"] == "error"
+    assert "not found in namespace user_alice" in result["content"][0]["text"]
+
+    # Query used the bound namespace
+    search_call = mock_elasticsearch_client["client"].search.call_args[1]
+    query = search_call["body"]["query"]["bool"]["must"]
+    assert {"term": {"namespace": "user_alice"}} in query
+
+
+def test_class_record_uses_bound_namespace(mock_elasticsearch_client, mock_bedrock_client, tool_config):
+    """A record stored through the class lands in the bound namespace and index."""
+    mock_elasticsearch_client["client"].index.return_value = {"result": "created", "_id": "test_memory_id"}
+
+    tool = ElasticsearchMemoryTool(**{**tool_config, "namespace": "user_bob", "index_name": "bob_index"})
+    agent = Agent(tools=[tool.elasticsearch_memory])
+
+    result = agent.tool.elasticsearch_memory(action="record", content="Bob's secret")
+
+    assert result["status"] == "success"
+
+    # The stored document carries the bound namespace and index
+    index_call = mock_elasticsearch_client["client"].index.call_args[1]
+    assert index_call["index"] == "bob_index"
+    assert index_call["body"]["namespace"] == "user_bob"
+
+
+def test_class_namespace_falls_back_to_env(mock_elasticsearch_client, mock_bedrock_client):
+    """When namespace is not passed to the constructor, it falls back to ELASTICSEARCH_NAMESPACE."""
+    mock_elasticsearch_client["client"].search.return_value = {"hits": {"hits": [], "total": {"value": 0}}}
+
+    with mock.patch.dict(os.environ, {**ES_ENV_VARS, "ELASTICSEARCH_NAMESPACE": "env_tenant"}):
+        tool = ElasticsearchMemoryTool(cloud_id="test-cloud-id", api_key="test-api-key")
+        agent = Agent(tools=[tool.elasticsearch_memory])
+        agent.tool.elasticsearch_memory(action="get", memory_id="mem_123")
+
+    search_call = mock_elasticsearch_client["client"].search.call_args[1]
+    query = search_call["body"]["query"]["bool"]["must"]
+    assert {"term": {"namespace": "env_tenant"}} in query

--- a/tests/test_mem0.py
+++ b/tests/test_mem0.py
@@ -1,5 +1,10 @@
 """
-Tests for the memory tool using the Agent interface.
+Tests for the mem0_memory tool.
+
+Covers the standalone module-level function (single-tenant, identity from the
+environment) and the Mem0MemoryTool class (multi-tenant, identity bound at
+construction). Also includes IDOR regression guards ensuring the tenant
+identity is never an LLM-controllable tool parameter.
 """
 
 import builtins
@@ -9,24 +14,10 @@ import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
-from strands import Agent
 from strands.types.tools import ToolUse
 
 from strands_tools import mem0_memory
-from strands_tools.mem0_memory import Mem0ServiceClient
-
-
-@pytest.fixture
-def agent():
-    """Create an agent with the memory tool loaded."""
-    return Agent(tools=[mem0_memory])
-
-
-@pytest.fixture
-def mock_mem0_service_client():
-    """Create a mock mem0 service client."""
-    client = MagicMock(spec=Mem0ServiceClient)
-    return client
+from strands_tools.mem0_memory import Mem0MemoryTool, Mem0ServiceClient
 
 
 @pytest.fixture
@@ -41,23 +32,45 @@ def mock_tool():
     return mock
 
 
-def extract_result_text(result):
-    """Extract the result text from the agent response."""
-    if isinstance(result, dict) and "content" in result and isinstance(result["content"], list):
-        content = result["content"][0]
-        # Handle different response formats
-        if isinstance(content, dict):
-            if "text" in content:
-                return content["text"]
-            # Return the first key-value pair if it's a memory object
-            elif "id" in content and "memory" in content:
-                return content["memory"]
-    return str(result)
+@pytest.fixture
+def mock_mem0_service_client():
+    """Create a mock mem0 service client."""
+    client = MagicMock(spec=Mem0ServiceClient)
+    return client
+
+
+# --- Security Tests (IDOR guards) ---
+
+
+def test_identity_params_not_in_standalone_tool_spec():
+    """IDOR guard: the standalone tool spec must not expose tenant identity params.
+
+    Regression test for the IDOR where an LLM-supplied user_id/agent_id could read, write, or delete
+    another tenant's memories. Identity must come from the environment, never the LLM.
+    """
+    properties = mem0_memory.TOOL_SPEC["inputSchema"]["json"]["properties"]
+    for forbidden in ["user_id", "agent_id"]:
+        assert forbidden not in properties, f"'{forbidden}' must not be an LLM-controllable tool parameter"
+
+
+def test_identity_params_not_in_class_tool_spec():
+    """IDOR guard: Mem0MemoryTool.mem0_memory must not expose tenant identity to the agent.
+
+    Identity is bound at construction; the LLM cannot select a different tenant key.
+    """
+    tool = Mem0MemoryTool(user_id="test_user")
+    properties = tool.mem0_memory.TOOL_SPEC["inputSchema"]["json"]["properties"]
+    for forbidden in ["user_id", "agent_id"]:
+        assert forbidden not in properties
+
+
+# --- Standalone function (identity from environment) ---
 
 
 @patch.dict(
     os.environ,
     {
+        "MEM0_USER_ID": "test_user",
         "MEM0_LLM_PROVIDER": "openai",
         "MEM0_LLM_MODEL": "gpt-4o",
         "MEM0_LLM_TEMPERATURE": "0.2",
@@ -70,7 +83,7 @@ def extract_result_text(result):
 @patch("strands_tools.mem0_memory.Mem0Memory")
 @patch("strands_tools.mem0_memory.boto3.Session")
 def test_store_memory(mock_boto3_session, mock_mem0_memory, mock_tool):
-    """Test store memory functionality."""
+    """Test store uses the environment-configured user_id, not one from tool input."""
     # Setup mock AWS credentials
     mock_credentials = MagicMock()
     mock_credentials.access_key = "test_access_key"
@@ -92,13 +105,12 @@ def test_store_memory(mock_boto3_session, mock_mem0_memory, mock_tool):
     ]
     mock_mem0_memory.from_config.return_value = mock_client
 
-    # Configure the mock_tool
+    # Configure the mock_tool (no user_id/agent_id - those come from the environment)
     mock_tool.get.side_effect = lambda key, default=None: {
         "toolUseId": "test-id",
         "input": {
             "action": "store",
             "content": "Test memory content",
-            "user_id": "test_user",
             "metadata": {"category": "test"},
         },
     }.get(key, default)
@@ -119,9 +131,12 @@ def test_store_memory(mock_boto3_session, mock_mem0_memory, mock_tool):
         ],
         indent=2,
     )
+    # The environment-configured identity was used, not anything from tool input
+    mock_client.add.assert_called_once()
+    assert mock_client.add.call_args[1]["user_id"] == "test_user"
 
 
-@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch.dict(os.environ, {"MEM0_USER_ID": "test_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
 @patch("strands_tools.mem0_memory.Mem0ServiceClient")
 @patch("opensearchpy.OpenSearch")
 def test_get_memory(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
@@ -135,7 +150,7 @@ def test_get_memory(mock_opensearch, mock_mem0_client, mock_mem0_service_client,
         "input": {"action": "get", "memory_id": "mem123"},
     }.get(key, default)
 
-    # Mock data
+    # Mock data - owned by the environment-configured user
     get_response = {
         "id": "mem123",
         "memory": "Test memory content",
@@ -143,8 +158,6 @@ def test_get_memory(mock_opensearch, mock_mem0_client, mock_mem0_service_client,
         "user_id": "test_user",
         "metadata": {"category": "test"},
     }
-
-    # Configure mocks
     mock_mem0_service_client.get_memory.return_value = get_response
 
     # Call the memory function
@@ -152,31 +165,27 @@ def test_get_memory(mock_opensearch, mock_mem0_client, mock_mem0_service_client,
 
     # Assertions
     assert result["status"] == "success"
-    assert isinstance(result["content"], list)
-    assert len(result["content"]) > 0
-    assert "text" in result["content"][0]
     memory = json.loads(result["content"][0]["text"])
     assert memory["id"] == "mem123"
     assert memory["memory"] == "Test memory content"
     assert memory["user_id"] == "test_user"
-    assert memory["metadata"] == {"category": "test"}
 
 
-@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch.dict(os.environ, {"MEM0_USER_ID": "test_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
 @patch("strands_tools.mem0_memory.Mem0ServiceClient")
 @patch("opensearchpy.OpenSearch")
 def test_list_memories(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
-    """Test list memories functionality."""
+    """Test list memories functionality uses the bound identity."""
     # Setup mocks
     mock_mem0_client.return_value = mock_mem0_service_client
 
     # Configure the mock_tool
     mock_tool.get.side_effect = lambda key, default=None: {
         "toolUseId": "test-id",
-        "input": {"action": "list", "user_id": "test_user"},
+        "input": {"action": "list"},
     }.get(key, default)
 
-    # Mock data for list_memories response - the memory.py expects this format
+    # Mock data for list_memories response
     list_response = {
         "results": [
             {
@@ -188,8 +197,6 @@ def test_list_memories(mock_opensearch, mock_mem0_client, mock_mem0_service_clie
             }
         ]
     }
-
-    # Configure mocks
     mock_mem0_service_client.list_memories.return_value = list_response
 
     # Call the memory function
@@ -197,32 +204,27 @@ def test_list_memories(mock_opensearch, mock_mem0_client, mock_mem0_service_clie
 
     # Assertions
     assert result["status"] == "success"
-    assert isinstance(result["content"], list)
-    assert len(result["content"]) > 0
-    assert "text" in result["content"][0]
-    # Parse the JSON string in text
     memories = json.loads(result["content"][0]["text"])
-    assert isinstance(memories, list)
-    assert len(memories) > 0
-    assert "id" in memories[0]
     assert memories[0]["id"] == "mem123"
+    # The environment-configured identity was used
+    mock_mem0_service_client.list_memories.assert_called_once_with("test_user", None)
 
 
-@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch.dict(os.environ, {"MEM0_USER_ID": "test_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
 @patch("strands_tools.mem0_memory.Mem0ServiceClient")
 @patch("opensearchpy.OpenSearch")
 def test_retrieve_memories(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
-    """Test retrieve memories functionality."""
+    """Test retrieve memories functionality uses the bound identity."""
     # Setup mocks
     mock_mem0_client.return_value = mock_mem0_service_client
 
     # Configure the mock_tool
     mock_tool.get.side_effect = lambda key, default=None: {
         "toolUseId": "test-id",
-        "input": {"action": "retrieve", "query": "test query", "user_id": "test_user"},
+        "input": {"action": "retrieve", "query": "test query"},
     }.get(key, default)
 
-    # Mock data for search_memories response - the memory.py expects this format
+    # Mock data for search_memories response
     retrieve_response = {
         "results": [
             {
@@ -235,8 +237,6 @@ def test_retrieve_memories(mock_opensearch, mock_mem0_client, mock_mem0_service_
             }
         ]
     }
-
-    # Configure mocks
     mock_mem0_service_client.search_memories.return_value = retrieve_response
 
     # Call the memory function
@@ -244,18 +244,16 @@ def test_retrieve_memories(mock_opensearch, mock_mem0_client, mock_mem0_service_
 
     # Assertions
     assert result["status"] == "success"
-    assert isinstance(result["content"], list)
-    assert len(result["content"]) > 0
-    assert "text" in result["content"][0]
-    # Parse the JSON string in text
     memories = json.loads(result["content"][0]["text"])
-    assert isinstance(memories, list)
-    assert len(memories) > 0
-    assert "id" in memories[0]
     assert memories[0]["id"] == "mem123"
+    # The environment-configured identity was used
+    mock_mem0_service_client.search_memories.assert_called_once_with("test query", "test_user", None)
 
 
-@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com", "BYPASS_TOOL_CONSENT": "true"})
+@patch.dict(
+    os.environ,
+    {"MEM0_USER_ID": "test_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com", "BYPASS_TOOL_CONSENT": "true"},
+)
 @patch("strands_tools.mem0_memory.Mem0ServiceClient")
 @patch("opensearchpy.OpenSearch")
 def test_delete_memory(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
@@ -269,7 +267,8 @@ def test_delete_memory(mock_opensearch, mock_mem0_client, mock_mem0_service_clie
         "input": {"action": "delete", "memory_id": "mem123"},
     }.get(key, default)
 
-    # Configure mocks
+    # Configure mocks - memory owned by the bound user
+    mock_mem0_service_client.get_memory.return_value = {"id": "mem123", "user_id": "test_user"}
     mock_mem0_service_client.delete_memory.return_value = {"status": "success"}
 
     # Call the memory function
@@ -280,12 +279,10 @@ def test_delete_memory(mock_opensearch, mock_mem0_client, mock_mem0_service_clie
     assert "Memory mem123 deleted successfully" in str(result["content"][0]["text"])
 
     # Verify correct functions were called
-    mock_mem0_service_client.delete_memory.assert_called_once()
-    call_args = mock_mem0_service_client.delete_memory.call_args[0]
-    assert call_args[0] == "mem123"
+    mock_mem0_service_client.delete_memory.assert_called_once_with("mem123")
 
 
-@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch.dict(os.environ, {"MEM0_USER_ID": "test_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
 @patch("strands_tools.mem0_memory.Mem0ServiceClient")
 @patch("opensearchpy.OpenSearch")
 def test_get_memory_history(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
@@ -300,6 +297,7 @@ def test_get_memory_history(mock_opensearch, mock_mem0_client, mock_mem0_service
     }.get(key, default)
 
     # Mock data
+    mock_mem0_service_client.get_memory.return_value = {"id": "mem123", "user_id": "test_user"}
     history_response = [
         {
             "id": "hist123",
@@ -310,8 +308,6 @@ def test_get_memory_history(mock_opensearch, mock_mem0_client, mock_mem0_service
             "created_at": "2024-03-20T10:00:00Z",
         }
     ]
-
-    # Configure mocks
     mock_mem0_service_client.get_memory_history.return_value = history_response
 
     # Call the memory function
@@ -319,18 +315,101 @@ def test_get_memory_history(mock_opensearch, mock_mem0_client, mock_mem0_service
 
     # Assertions
     assert result["status"] == "success"
-    assert isinstance(result["content"], list)
-    assert len(result["content"]) > 0
-    assert "text" in result["content"][0]
-    # Parse the JSON string in text
     history = json.loads(result["content"][0]["text"])
-    assert isinstance(history, list)
-    assert len(history) > 0
-    assert "id" in history[0]
     assert history[0]["id"] == "hist123"
 
 
-@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+def test_standalone_requires_identity_env_var(mock_tool):
+    """Test the standalone function errors when neither MEM0_USER_ID nor MEM0_AGENT_ID is set."""
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "list"},
+    }.get(key, default)
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = mem0_memory.mem0_memory(tool=mock_tool)
+        assert result["status"] == "error"
+        assert "MEM0_USER_ID or MEM0_AGENT_ID" in result["content"][0]["text"]
+
+
+def test_invalid_identity_env_var(mock_tool):
+    """Test that an invalid MEM0_USER_ID env var is rejected.
+
+    The agent cannot supply an identity, so it cannot reach this via the tool signature. An operator
+    can still misconfigure the environment variable, so validation runs on that value.
+    """
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "list"},
+    }.get(key, default)
+
+    invalid_identities = [
+        "user name",  # Space
+        "user@domain",  # @ symbol
+        "user/path",  # Forward slash
+        "user:name",  # Colon
+        "a" * 129,  # Too long (over 128 chars)
+        "",  # Empty
+        "   ",  # Whitespace only
+    ]
+
+    for invalid_identity in invalid_identities:
+        with patch.dict(os.environ, {"MEM0_USER_ID": invalid_identity}, clear=True):
+            result = mem0_memory.mem0_memory(tool=mock_tool)
+            assert result["status"] == "error", f"Invalid identity '{invalid_identity}' should be rejected"
+
+
+@patch.dict(os.environ, {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_get_denies_cross_tenant(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """Test get denies access to a memory owned by a different tenant."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    # Memory belongs to a different user
+    mock_mem0_service_client.get_memory.return_value = {
+        "id": "mem123",
+        "memory": "Secret content",
+        "user_id": "other_user",
+    }
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "get", "memory_id": "mem123"},
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    assert "Access denied" in result["content"][0]["text"]
+
+
+@patch.dict(
+    os.environ,
+    {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com", "BYPASS_TOOL_CONSENT": "true"},
+)
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_delete_denies_cross_tenant(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """Test delete denies removing a memory owned by a different tenant."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    # Memory belongs to a different user
+    mock_mem0_service_client.get_memory.return_value = {"id": "mem123", "user_id": "other_user"}
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "delete", "memory_id": "mem123"},
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    assert "Access denied" in result["content"][0]["text"]
+    mock_mem0_service_client.delete_memory.assert_not_called()
+
+
+@patch.dict(os.environ, {"MEM0_USER_ID": "test_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
 @patch("strands_tools.mem0_memory.Mem0ServiceClient")
 @patch("opensearchpy.OpenSearch")
 def test_invalid_action(mock_opensearch, mock_mem0_client, mock_tool):
@@ -346,35 +425,13 @@ def test_invalid_action(mock_opensearch, mock_mem0_client, mock_tool):
     assert "Invalid action" in str(result["content"][0]["text"])
 
 
-@patch.dict(os.environ, {})
-def test_missing_opensearch_host(mock_tool):
-    """Test missing OpenSearch host defaults to FAISS."""
-    mock_tool.get.side_effect = lambda key, default=None: {
-        "toolUseId": "test-id",
-        "input": {"action": "list", "user_id": "test-user"},
-    }.get(key, default)
-
-    real_import = builtins.__import__
-
-    def fail_faiss(name, *args, **kwargs):
-        if name == "faiss":
-            raise ImportError("No module named 'faiss'")
-        return real_import(name, *args, **kwargs)
-
-    with patch("builtins.__import__", side_effect=fail_faiss):
-        result = mem0_memory.mem0_memory(tool=mock_tool)
-        assert result["status"] == "error"
-        assert "The faiss-cpu package is required" in str(result["content"][0]["text"])
-
-
-@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch.dict(os.environ, {"MEM0_USER_ID": "test_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
 @patch("strands_tools.mem0_memory.Mem0ServiceClient")
 @patch("opensearchpy.OpenSearch")
 def test_action_specific_missing_params(mock_opensearch, mock_mem0_client, mock_tool):
     """Test missing action-specific parameters."""
     # Setup mock
-    mock_client = MagicMock()
-    mock_mem0_client.return_value = mock_client
+    mock_mem0_client.return_value = MagicMock()
 
     # Test missing content for store action
     mock_tool.get.side_effect = lambda key, default=None: {"toolUseId": "test-id", "input": {"action": "store"}}.get(
@@ -409,11 +466,32 @@ def test_action_specific_missing_params(mock_opensearch, mock_mem0_client, mock_
     assert "query is required for retrieve action" in str(retrieve_result["content"][0]["text"])
 
 
+@patch.dict(os.environ, {"MEM0_USER_ID": "test-user"})
+def test_missing_opensearch_host(mock_tool):
+    """Test missing OpenSearch host defaults to FAISS."""
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "list"},
+    }.get(key, default)
+
+    real_import = builtins.__import__
+
+    def fail_faiss(name, *args, **kwargs):
+        if name == "faiss":
+            raise ImportError("No module named 'faiss'")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fail_faiss):
+        result = mem0_memory.mem0_memory(tool=mock_tool)
+        assert result["status"] == "error"
+        assert "The faiss-cpu package is required" in str(result["content"][0]["text"])
+
+
 @patch("boto3.Session")
 @patch("strands_tools.mem0_memory.Mem0Memory")
 @patch("opensearchpy.OpenSearch")
 def test_mem0_service_client_init(mock_opensearch, mock_mem0_memory, mock_session):
-    """Test Mem0ServiceClient initialization."""
+    """Test Mem0ServiceClient initialization across backends."""
     # Mock session and credentials
     mock_credentials = MagicMock()
     mock_credentials.access_key = "test-access-key"
@@ -437,12 +515,7 @@ def test_mem0_service_client_init(mock_opensearch, mock_mem0_memory, mock_sessio
             Mem0ServiceClient()
 
     # Test with Neptune Analytics for both vector and graph
-    with patch.dict(
-        os.environ,
-        {
-            "NEPTUNE_ANALYTICS_GRAPH_IDENTIFIER": "g-5aaaaa1234",
-        },
-    ):
+    with patch.dict(os.environ, {"NEPTUNE_ANALYTICS_GRAPH_IDENTIFIER": "g-5aaaaa1234"}):
         client = Mem0ServiceClient()
         assert client.mem0 is not None
 
@@ -477,7 +550,7 @@ def test_mem0_service_client_init(mock_opensearch, mock_mem0_memory, mock_sessio
             assert platform_client.mem0 is not None
 
 
-@patch.dict(os.environ, {"MEM0_API_KEY": "test-api-key"})
+@patch.dict(os.environ, {"MEM0_USER_ID": "test_user", "MEM0_API_KEY": "test-api-key"})
 @patch("strands_tools.mem0_memory.MemoryClient")
 def test_mem0_platform_client(mock_memory_client, mock_tool):
     """Test Mem0 Platform client functionality."""
@@ -499,7 +572,6 @@ def test_mem0_platform_client(mock_memory_client, mock_tool):
         "input": {
             "action": "store",
             "content": "Test memory content",
-            "user_id": "test_user",
             "metadata": {"category": "test"},
         },
     }.get(key, default)
@@ -512,39 +584,118 @@ def test_mem0_platform_client(mock_memory_client, mock_tool):
     assert "Test memory content" in str(result["content"][0]["text"])
 
 
-@patch.dict(os.environ, {})
+@patch.dict(os.environ, {"MEM0_USER_ID": "test_user"})
 @patch("strands_tools.mem0_memory.Mem0Memory")
 def test_faiss_client(mock_mem0_memory, mock_tool):
     """Test FAISS client functionality."""
     # Inject a mock faiss module into sys.modules
     sys.modules["faiss"] = MagicMock()
-    # Setup mock client
-    mock_client = MagicMock()
-    # Return a real list of dicts, not MagicMock objects
-    mock_client.add.return_value = [
-        {
-            "event": "store",
-            "memory": "Test memory content",
-            "id": "mem123",
-            "created_at": "2024-03-20T10:00:00Z",
-        }
-    ]
-    mock_mem0_memory.from_config.return_value = mock_client
+    try:
+        # Setup mock client
+        mock_client = MagicMock()
+        # Return a real list of dicts, not MagicMock objects
+        mock_client.add.return_value = [
+            {
+                "event": "store",
+                "memory": "Test memory content",
+                "id": "mem123",
+                "created_at": "2024-03-20T10:00:00Z",
+            }
+        ]
+        mock_mem0_memory.from_config.return_value = mock_client
 
-    # Configure the mock_tool
+        # Configure the mock_tool
+        mock_tool.get.side_effect = lambda key, default=None: {
+            "toolUseId": "test-id",
+            "input": {
+                "action": "store",
+                "content": "Test memory content",
+                "metadata": {"category": "test"},
+            },
+        }.get(key, default)
+
+        # Call the memory function
+        result = mem0_memory.mem0_memory(tool=mock_tool)
+
+        # Assertions
+        assert result["status"] == "success"
+        assert "Test memory content" in str(result["content"][0]["text"])
+    finally:
+        del sys.modules["faiss"]
+
+
+# --- Mem0MemoryTool class (per-principal binding) ---
+
+
+def test_class_requires_identity():
+    """Constructing the class without a user_id or agent_id raises."""
+    with pytest.raises(ValueError, match="Either user_id or agent_id"):
+        Mem0MemoryTool()
+
+
+def test_class_rejects_invalid_identity():
+    """The class validates the bound identity at construction."""
+    with pytest.raises(ValueError, match="contains invalid characters"):
+        Mem0MemoryTool(user_id="user name")
+
+
+@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com", "BYPASS_TOOL_CONSENT": "true"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_class_binds_identity(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """The class uses its constructor identity, not any agent-supplied value."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+    mock_mem0_service_client.list_memories.return_value = {"results": []}
+
     mock_tool.get.side_effect = lambda key, default=None: {
         "toolUseId": "test-id",
-        "input": {
-            "action": "store",
-            "content": "Test memory content",
-            "user_id": "test_user",
-            "metadata": {"category": "test"},
-        },
+        "input": {"action": "list"},
     }.get(key, default)
 
-    # Call the memory function
-    result = mem0_memory.mem0_memory(tool=mock_tool)
+    tool = Mem0MemoryTool(user_id="user_alice")
+    result = tool.mem0_memory(tool=mock_tool)
 
-    # Assertions
     assert result["status"] == "success"
-    assert "Test memory content" in str(result["content"][0]["text"])
+    # Query used the bound identity
+    mock_mem0_service_client.list_memories.assert_called_once_with("user_alice", None)
+
+
+@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com", "BYPASS_TOOL_CONSENT": "true"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_class_record_uses_bound_identity(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """A record stored through the class is attributed to the bound identity."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+    mock_mem0_service_client.store_memory.return_value = [{"event": "store", "memory": "Bob's secret", "id": "mem123"}]
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "store", "content": "Bob's secret"},
+    }.get(key, default)
+
+    tool = Mem0MemoryTool(user_id="user_bob")
+    result = tool.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "success"
+    # The record was attributed to the bound identity
+    mock_mem0_service_client.store_memory.assert_called_once_with("Bob's secret", "user_bob", None, None)
+
+
+@patch.dict(os.environ, {"OPENSEARCH_HOST": "test.opensearch.amazonaws.com", "BYPASS_TOOL_CONSENT": "true"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_class_uses_agent_id(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """Binding an agent_id (instead of user_id) routes operations by agent_id."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+    mock_mem0_service_client.list_memories.return_value = {"results": []}
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "list"},
+    }.get(key, default)
+
+    tool = Mem0MemoryTool(agent_id="my_agent")
+    result = tool.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "success"
+    mock_mem0_service_client.list_memories.assert_called_once_with(None, "my_agent")

--- a/tests/test_mongodb_memory.py
+++ b/tests/test_mongodb_memory.py
@@ -2,6 +2,7 @@
 Tests for the mongodb_memory tool.
 """
 
+import inspect
 import json
 import os
 from unittest import mock
@@ -10,7 +11,24 @@ from unittest.mock import MagicMock
 import pytest
 from strands import Agent
 
-from src.strands_tools.mongodb_memory import mongodb_memory
+from src.strands_tools.mongodb_memory import MongoDBMemoryTool, mongodb_memory
+
+# The standalone function sources all connection and namespace configuration from the environment,
+# so tests provide it via these variables rather than as tool-call parameters.
+MONGODB_ENV_VARS = {
+    "MONGODB_ATLAS_CLUSTER_URI": "mongodb+srv://test:test@cluster.mongodb.net/",
+    "MONGODB_DATABASE_NAME": "test_db",
+    "MONGODB_COLLECTION_NAME": "test_collection",
+    "MONGODB_NAMESPACE": "test_namespace",
+    "AWS_REGION": "us-east-1",
+}
+
+
+@pytest.fixture(autouse=True)
+def set_mongodb_env_vars():
+    """Auto-set MongoDB environment variables for all tests."""
+    with mock.patch.dict(os.environ, MONGODB_ENV_VARS):
+        yield
 
 
 @pytest.fixture(autouse=True)
@@ -93,8 +111,8 @@ def agent(mock_mongodb_client, mock_bedrock_client):
 
 
 @pytest.fixture
-def config():
-    """Configuration parameters for testing."""
+def tool_config():
+    """Configuration for constructing a MongoDBMemoryTool in tests."""
     return {
         "cluster_uri": "mongodb+srv://test:test@cluster.mongodb.net/",
         "database_name": "test_db",
@@ -104,14 +122,47 @@ def config():
     }
 
 
+# --- Security Tests ---
+
+
+def test_credential_and_namespace_params_not_in_standalone_signature():
+    """IDOR guard: the standalone tool must not expose connection, credential, or namespace params.
+
+    Regression test for the IDOR where an LLM-supplied namespace/connection string could redirect
+    the memory layer at another tenant or cluster. These must be environment-only.
+    """
+    param_names = set(inspect.signature(mongodb_memory).parameters.keys())
+    for forbidden in [
+        "namespace",
+        "cluster_uri",
+        "database_name",
+        "collection_name",
+        "embedding_model",
+        "region",
+        "vector_index_name",
+    ]:
+        assert forbidden not in param_names, f"'{forbidden}' must not be an LLM-controllable tool parameter"
+
+
+def test_namespace_params_not_in_class_tool_signature():
+    """IDOR guard: MongoDBMemoryTool.mongodb_memory must not expose namespace/connection to the agent.
+
+    Namespace and connection are bound at construction; the LLM cannot select a different tenant key.
+    """
+    param_names = set(inspect.signature(MongoDBMemoryTool.mongodb_memory).parameters.keys())
+    assert "namespace" not in param_names
+    assert "cluster_uri" not in param_names
+
+
 def test_missing_required_params(mock_mongodb_client, mock_bedrock_client):
-    """Test tool with missing required parameters."""
+    """Test tool with missing required environment variables."""
     agent = Agent(tools=[mongodb_memory])
 
-    # Test missing cluster_uri
-    result = agent.tool.mongodb_memory(action="record", content="test")
-    assert result["status"] == "error"
-    assert "cluster_uri is required for MongoDB Memory Tool" in result["content"][0]["text"]
+    # Test missing cluster_uri (no env var)
+    with mock.patch.dict(os.environ, {}, clear=True):
+        result = agent.tool.mongodb_memory(action="record", content="test")
+        assert result["status"] == "error"
+        assert "cluster_uri is required for MongoDB Memory Tool" in result["content"][0]["text"]
 
 
 def test_connection_failure(mock_mongodb_client, mock_bedrock_client):
@@ -123,22 +174,20 @@ def test_connection_failure(mock_mongodb_client, mock_bedrock_client):
 
     mock_mongodb_client["client"].admin.command.side_effect = ConnectionFailure("Connection failed")
 
-    result = agent.tool.mongodb_memory(
-        action="record", content="test", cluster_uri="mongodb+srv://test:test@cluster.mongodb.net/"
-    )
+    result = agent.tool.mongodb_memory(action="record", content="test")
 
     assert result["status"] == "error"
     assert "Unable to connect to MongoDB cluster" in result["content"][0]["text"]
 
 
-def test_vector_index_creation(mock_mongodb_client, mock_bedrock_client, config):
+def test_vector_index_creation(mock_mongodb_client, mock_bedrock_client):
     """Test that vector search index is created with proper configuration."""
     agent = Agent(tools=[mongodb_memory])
 
     # Configure mock responses
     mock_mongodb_client["collection"].insert_one.return_value = MagicMock(inserted_id="test_id")
 
-    agent.tool.mongodb_memory(action="record", content="Test content", **config)
+    agent.tool.mongodb_memory(action="record", content="Test content")
 
     # Verify index creation was called for record (it shouldn't be)
     # Index creation only happens for retrieve operations
@@ -146,7 +195,7 @@ def test_vector_index_creation(mock_mongodb_client, mock_bedrock_client, config)
 
     # Test retrieve action which should create index
     mock_mongodb_client["collection"].aggregate.return_value = []
-    agent.tool.mongodb_memory(action="retrieve", query="test query", **config)
+    agent.tool.mongodb_memory(action="retrieve", query="test query")
 
     # Verify index creation was called
     mock_mongodb_client["collection"].create_search_index.assert_called_once()
@@ -160,7 +209,7 @@ def test_vector_index_creation(mock_mongodb_client, mock_bedrock_client, config)
     assert call_args["definition"]["mappings"]["fields"]["namespace"]["type"] == "string"
 
 
-def test_record_memory(mock_mongodb_client, mock_bedrock_client, config):
+def test_record_memory(mock_mongodb_client, mock_bedrock_client):
     """Test recording a memory."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -170,9 +219,7 @@ def test_record_memory(mock_mongodb_client, mock_bedrock_client, config):
     mock_mongodb_client["collection"].insert_one.return_value = mock_result
 
     # Call the tool
-    result = agent.tool.mongodb_memory(
-        action="record", content="Test memory content", metadata={"category": "test"}, **config
-    )
+    result = agent.tool.mongodb_memory(action="record", content="Test memory content", metadata={"category": "test"})
 
     # Verify success response
     assert result["status"] == "success"
@@ -191,7 +238,7 @@ def test_record_memory(mock_mongodb_client, mock_bedrock_client, config):
     mock_bedrock_client["bedrock"].invoke_model.assert_called_once()
 
 
-def test_retrieve_memories(mock_mongodb_client, mock_bedrock_client, config):
+def test_retrieve_memories(mock_mongodb_client, mock_bedrock_client):
     """Test retrieving memories with semantic search."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -207,7 +254,7 @@ def test_retrieve_memories(mock_mongodb_client, mock_bedrock_client, config):
     ]
 
     # Call the tool
-    result = agent.tool.mongodb_memory(action="retrieve", query="test query", max_results=5, **config)
+    result = agent.tool.mongodb_memory(action="retrieve", query="test query", max_results=5)
 
     # Verify success response
     assert result["status"] == "success"
@@ -229,7 +276,7 @@ def test_retrieve_memories(mock_mongodb_client, mock_bedrock_client, config):
     mock_bedrock_client["bedrock"].invoke_model.assert_called_once()
 
 
-def test_list_memories(mock_mongodb_client, mock_bedrock_client, config):
+def test_list_memories(mock_mongodb_client, mock_bedrock_client):
     """Test listing all memories."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -257,7 +304,7 @@ def test_list_memories(mock_mongodb_client, mock_bedrock_client, config):
     mock_mongodb_client["collection"].count_documents.return_value = 2
 
     # Call the tool
-    result = agent.tool.mongodb_memory(action="list", max_results=10, **config)
+    result = agent.tool.mongodb_memory(action="list", max_results=10)
 
     # Verify success response
     assert result["status"] == "success"
@@ -269,13 +316,13 @@ def test_list_memories(mock_mongodb_client, mock_bedrock_client, config):
     assert "memories" in response_data
     assert "total" in response_data
 
-    # Verify find was called with proper query
+    # Verify find was called with proper query (namespace from environment)
     mock_mongodb_client["collection"].find.assert_called_once()
     call_args = mock_mongodb_client["collection"].find.call_args[0]
     assert call_args[0] == {"namespace": "test_namespace"}
 
 
-def test_get_memory(mock_mongodb_client, mock_bedrock_client, config):
+def test_get_memory(mock_mongodb_client, mock_bedrock_client):
     """Test getting a specific memory by ID."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -289,7 +336,7 @@ def test_get_memory(mock_mongodb_client, mock_bedrock_client, config):
     }
 
     # Call the tool
-    result = agent.tool.mongodb_memory(action="get", memory_id="mem_123", **config)
+    result = agent.tool.mongodb_memory(action="get", memory_id="mem_123")
 
     # Verify success response
     assert result["status"] == "success"
@@ -307,7 +354,7 @@ def test_get_memory(mock_mongodb_client, mock_bedrock_client, config):
     assert call_args[0] == {"memory_id": "mem_123", "namespace": "test_namespace"}
 
 
-def test_delete_memory(mock_mongodb_client, mock_bedrock_client, config):
+def test_delete_memory(mock_mongodb_client, mock_bedrock_client):
     """Test deleting a memory."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -325,7 +372,7 @@ def test_delete_memory(mock_mongodb_client, mock_bedrock_client, config):
     mock_mongodb_client["collection"].delete_one.return_value = mock_delete_result
 
     # Call the tool
-    result = agent.tool.mongodb_memory(action="delete", memory_id="mem_123", **config)
+    result = agent.tool.mongodb_memory(action="delete", memory_id="mem_123")
 
     # Verify success response
     assert result["status"] == "success"
@@ -338,11 +385,11 @@ def test_delete_memory(mock_mongodb_client, mock_bedrock_client, config):
     assert call_args[0] == {"memory_id": "mem_123", "namespace": "test_namespace"}
 
 
-def test_unsupported_action(mock_mongodb_client, mock_bedrock_client, config):
+def test_unsupported_action(mock_mongodb_client, mock_bedrock_client):
     """Test tool with an unsupported action."""
     agent = Agent(tools=[mongodb_memory])
 
-    result = agent.tool.mongodb_memory(action="unsupported_action", **config)
+    result = agent.tool.mongodb_memory(action="unsupported_action")
 
     # Verify error response
     assert result["status"] == "error"
@@ -351,12 +398,12 @@ def test_unsupported_action(mock_mongodb_client, mock_bedrock_client, config):
     assert "retrieve" in result["content"][0]["text"]
 
 
-def test_missing_required_parameters(mock_mongodb_client, mock_bedrock_client, config):
+def test_missing_required_parameters(mock_mongodb_client, mock_bedrock_client):
     """Test tool with missing required parameters."""
     agent = Agent(tools=[mongodb_memory])
 
     # Test record action without content
-    result = agent.tool.mongodb_memory(action="record", **config)
+    result = agent.tool.mongodb_memory(action="record")
 
     # Verify error response
     assert result["status"] == "error"
@@ -364,7 +411,7 @@ def test_missing_required_parameters(mock_mongodb_client, mock_bedrock_client, c
     assert "content" in result["content"][0]["text"]
 
     # Test retrieve action without query
-    result = agent.tool.mongodb_memory(action="retrieve", **config)
+    result = agent.tool.mongodb_memory(action="retrieve")
 
     # Verify error response
     assert result["status"] == "error"
@@ -372,7 +419,7 @@ def test_missing_required_parameters(mock_mongodb_client, mock_bedrock_client, c
     assert "query" in result["content"][0]["text"]
 
     # Test get action without memory_id
-    result = agent.tool.mongodb_memory(action="get", **config)
+    result = agent.tool.mongodb_memory(action="get")
 
     # Verify error response
     assert result["status"] == "error"
@@ -380,7 +427,7 @@ def test_missing_required_parameters(mock_mongodb_client, mock_bedrock_client, c
     assert "memory_id" in result["content"][0]["text"]
 
 
-def test_mongodb_api_error_handling(mock_mongodb_client, mock_bedrock_client, config):
+def test_mongodb_api_error_handling(mock_mongodb_client, mock_bedrock_client):
     """Test handling of MongoDB API errors."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -388,7 +435,7 @@ def test_mongodb_api_error_handling(mock_mongodb_client, mock_bedrock_client, co
     mock_mongodb_client["collection"].insert_one.side_effect = Exception("MongoDB error")
 
     # Call the tool
-    result = agent.tool.mongodb_memory(action="record", content="Test content", **config)
+    result = agent.tool.mongodb_memory(action="record", content="Test content")
 
     # Verify error response
     assert result["status"] == "error"
@@ -396,7 +443,7 @@ def test_mongodb_api_error_handling(mock_mongodb_client, mock_bedrock_client, co
     assert "MongoDB error" in result["content"][0]["text"]
 
 
-def test_bedrock_api_error_handling(mock_mongodb_client, mock_bedrock_client, config):
+def test_bedrock_api_error_handling(mock_mongodb_client, mock_bedrock_client):
     """Test handling of Bedrock API errors."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -404,7 +451,7 @@ def test_bedrock_api_error_handling(mock_mongodb_client, mock_bedrock_client, co
     mock_bedrock_client["bedrock"].invoke_model.side_effect = Exception("Bedrock error")
 
     # Call the tool
-    result = agent.tool.mongodb_memory(action="record", content="Test content", **config)
+    result = agent.tool.mongodb_memory(action="record", content="Test content")
 
     # Verify error response
     assert result["status"] == "error"
@@ -412,7 +459,7 @@ def test_bedrock_api_error_handling(mock_mongodb_client, mock_bedrock_client, co
     assert "Embedding generation failed" in result["content"][0]["text"]
 
 
-def test_memory_not_found(mock_mongodb_client, mock_bedrock_client, config):
+def test_memory_not_found(mock_mongodb_client, mock_bedrock_client):
     """Test handling when memory is not found."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -420,20 +467,20 @@ def test_memory_not_found(mock_mongodb_client, mock_bedrock_client, config):
     mock_mongodb_client["collection"].find_one.return_value = None
 
     # Call the tool
-    result = agent.tool.mongodb_memory(action="get", memory_id="nonexistent", **config)
+    result = agent.tool.mongodb_memory(action="get", memory_id="nonexistent")
 
     # Verify error response
     assert result["status"] == "error"
     assert "Memory nonexistent not found" in result["content"][0]["text"]
 
 
-def test_namespace_validation(mock_mongodb_client, mock_bedrock_client, config):
-    """Test that memories are properly filtered by namespace."""
+def test_namespace_filtering(mock_mongodb_client, mock_bedrock_client):
+    """Test that memories are properly filtered by the environment-configured namespace."""
     agent = Agent(tools=[mongodb_memory])
 
     mock_mongodb_client["collection"].find_one.return_value = None
 
-    result = agent.tool.mongodb_memory(action="get", memory_id="mem_123", **config)
+    result = agent.tool.mongodb_memory(action="get", memory_id="mem_123")
 
     # Verify error response
     assert result["status"] == "error"
@@ -444,7 +491,7 @@ def test_namespace_validation(mock_mongodb_client, mock_bedrock_client, config):
     assert call_args[0] == {"memory_id": "mem_123", "namespace": "test_namespace"}
 
 
-def test_pagination_support(mock_mongodb_client, mock_bedrock_client, config):
+def test_pagination_support(mock_mongodb_client, mock_bedrock_client):
     """Test pagination support in list and retrieve operations."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -466,7 +513,7 @@ def test_pagination_support(mock_mongodb_client, mock_bedrock_client, config):
     mock_mongodb_client["collection"].count_documents.return_value = 20  # More results available
 
     # Test list with pagination
-    agent.tool.mongodb_memory(action="list", max_results=5, next_token="10", **config)
+    agent.tool.mongodb_memory(action="list", max_results=5, next_token="10")
 
     # Verify skip was called with correct offset
     mock_cursor.skip.assert_called_with(10)
@@ -474,7 +521,7 @@ def test_pagination_support(mock_mongodb_client, mock_bedrock_client, config):
 
 
 def test_environment_variable_defaults(mock_mongodb_client, mock_bedrock_client):
-    """Test that environment variables are used for defaults."""
+    """Test that environment variables are used for configuration."""
     agent = Agent(tools=[mongodb_memory])
 
     with mock.patch.dict(
@@ -493,7 +540,7 @@ def test_environment_variable_defaults(mock_mongodb_client, mock_bedrock_client)
         mock_result.inserted_id = "test_id"
         mock_mongodb_client["collection"].insert_one.return_value = mock_result
 
-        # Call tool without explicit parameters (should use env vars)
+        # Call tool (config comes entirely from env vars)
         result = agent.tool.mongodb_memory(action="record", content="Test content")
 
         # Verify success (means env vars were used correctly)
@@ -504,41 +551,12 @@ def test_environment_variable_defaults(mock_mongodb_client, mock_bedrock_client)
         assert "json" in result["content"][1]
         response_data = result["content"][1]["json"]
         assert "memory_id" in response_data
+        # Namespace used was the environment-configured one
+        assert response_data["namespace"] == "env_namespace"
 
 
-def test_agent_tool_usage(mock_mongodb_client, mock_bedrock_client):
-    """Test using the mongodb_memory tool through agent.tool pattern."""
-    # Configure mock responses
-    mock_result = MagicMock()
-    mock_result.inserted_id = "test_id"
-    mock_mongodb_client["collection"].insert_one.return_value = mock_result
-
-    # Create agent with direct tool usage - this demonstrates the standard pattern
-    agent = Agent(tools=[mongodb_memory])
-
-    # Test calling the tool through agent.tool with configuration parameters
-    result = agent.tool.mongodb_memory(
-        action="record",
-        content="Test memory content",
-        cluster_uri="mongodb+srv://test:test@cluster.mongodb.net/",
-        database_name="test_db",
-        collection_name="test_collection",
-        namespace="test_namespace",
-    )
-
-    # Verify success response
-    assert result["status"] == "success"
-    assert "Memory stored successfully" in result["content"][0]["text"]
-
-    # Verify MongoDB insert was called
-    mock_mongodb_client["collection"].insert_one.assert_called_once()
-
-    # Verify embedding generation was called
-    mock_bedrock_client["bedrock"].invoke_model.assert_called_once()
-
-
-def test_custom_embedding_model(mock_mongodb_client, mock_bedrock_client, config):
-    """Test using custom embedding model."""
+def test_custom_embedding_model(mock_mongodb_client, mock_bedrock_client):
+    """Test using custom embedding model from the environment."""
     agent = Agent(tools=[mongodb_memory])
 
     # Configure mock responses
@@ -546,10 +564,9 @@ def test_custom_embedding_model(mock_mongodb_client, mock_bedrock_client, config
     mock_result.inserted_id = "test_id"
     mock_mongodb_client["collection"].insert_one.return_value = mock_result
 
-    # Call tool with custom embedding model
-    result = agent.tool.mongodb_memory(
-        action="record", content="Test memory content", embedding_model="amazon.titan-embed-text-v1:0", **config
-    )
+    # Call tool with custom embedding model via env var
+    with mock.patch.dict(os.environ, {"MONGODB_EMBEDDING_MODEL": "amazon.titan-embed-text-v1:0"}):
+        result = agent.tool.mongodb_memory(action="record", content="Test memory content")
 
     # Verify success response
     assert result["status"] == "success"
@@ -561,81 +578,7 @@ def test_custom_embedding_model(mock_mongodb_client, mock_bedrock_client, config
     assert call_args[1]["modelId"] == "amazon.titan-embed-text-v1:0"
 
 
-def test_multiple_namespaces(mock_mongodb_client, mock_bedrock_client, config):
-    """Test using different namespaces for data isolation."""
-    agent = Agent(tools=[mongodb_memory])
-
-    # Configure mock responses
-    mock_result = MagicMock()
-    mock_result.inserted_id = "test_id"
-    mock_mongodb_client["collection"].insert_one.return_value = mock_result
-
-    # Store memory in user namespace
-    result1 = agent.tool.mongodb_memory(
-        action="record",
-        content="Alice likes Italian food",
-        namespace="user_alice",
-        **{k: v for k, v in config.items() if k != "namespace"},
-    )
-
-    # Store memory in system namespace
-    result2 = agent.tool.mongodb_memory(
-        action="record",
-        content="System maintenance scheduled",
-        namespace="system_global",
-        **{k: v for k, v in config.items() if k != "namespace"},
-    )
-
-    # Verify both operations succeeded
-    assert result1["status"] == "success"
-    assert result2["status"] == "success"
-
-    # Verify both calls were made
-    assert mock_mongodb_client["collection"].insert_one.call_count == 2
-
-
-def test_configuration_dictionary_pattern(mock_mongodb_client, mock_bedrock_client):
-    """Test using configuration dictionary for cleaner code."""
-    agent = Agent(tools=[mongodb_memory])
-
-    # Configure mock responses
-    mock_result = MagicMock()
-    mock_result.inserted_id = "test_id"
-    mock_mongodb_client["collection"].insert_one.return_value = mock_result
-
-    mock_mongodb_client["collection"].aggregate.return_value = [
-        {
-            "memory_id": "mem_123",
-            "content": "Test content",
-            "timestamp": "2023-01-01T00:00:00Z",
-            "metadata": {},
-            "score": 0.95,
-        }
-    ]
-
-    # Create configuration dictionary
-    config = {
-        "cluster_uri": "mongodb+srv://test:test@cluster.mongodb.net/",
-        "database_name": "memories_db",
-        "collection_name": "memories",
-        "namespace": "user_123",
-        "region": "us-east-1",
-    }
-
-    # Store memory using config dictionary
-    result1 = agent.tool.mongodb_memory(action="record", content="User prefers vegetarian pizza", **config)
-
-    # Search memories using config dictionary
-    result2 = agent.tool.mongodb_memory(action="retrieve", query="food preferences", max_results=5, **config)
-
-    # Verify both operations succeeded
-    assert result1["status"] == "success"
-    assert result2["status"] == "success"
-    assert "Memory stored successfully" in result1["content"][0]["text"]
-    assert "Memories retrieved successfully" in result2["content"][0]["text"]
-
-
-def test_batch_operations(mock_mongodb_client, mock_bedrock_client, config):
+def test_batch_operations(mock_mongodb_client, mock_bedrock_client):
     """Test storing multiple related memories in batch."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -653,7 +596,6 @@ def test_batch_operations(mock_mongodb_client, mock_bedrock_client, config):
             action="record",
             content=content,
             metadata={"batch": "user_preferences", "category": "preferences"},
-            **config,
         )
         results.append(result)
 
@@ -666,7 +608,7 @@ def test_batch_operations(mock_mongodb_client, mock_bedrock_client, config):
     assert mock_mongodb_client["collection"].insert_one.call_count == len(memories)
 
 
-def test_error_handling_scenarios(mock_mongodb_client, mock_bedrock_client, config):
+def test_error_handling_scenarios(mock_mongodb_client, mock_bedrock_client):
     """Test comprehensive error handling scenarios."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -674,7 +616,7 @@ def test_error_handling_scenarios(mock_mongodb_client, mock_bedrock_client, conf
     from pymongo.errors import ConnectionFailure
 
     mock_mongodb_client["client"].admin.command.side_effect = ConnectionFailure("Connection failed")
-    result = agent.tool.mongodb_memory(action="record", content="test", **config)
+    result = agent.tool.mongodb_memory(action="record", content="test")
     assert result["status"] == "error"
     assert "Unable to connect to MongoDB cluster" in result["content"][0]["text"]
 
@@ -684,7 +626,7 @@ def test_error_handling_scenarios(mock_mongodb_client, mock_bedrock_client, conf
 
     # Test MongoDB API errors
     mock_mongodb_client["collection"].insert_one.side_effect = Exception("MongoDB connection failed")
-    result = agent.tool.mongodb_memory(action="record", content="test", **config)
+    result = agent.tool.mongodb_memory(action="record", content="test")
     assert result["status"] == "error"
     assert "API error" in result["content"][0]["text"]
 
@@ -693,12 +635,12 @@ def test_error_handling_scenarios(mock_mongodb_client, mock_bedrock_client, conf
 
     # Test Bedrock API errors
     mock_bedrock_client["bedrock"].invoke_model.side_effect = Exception("Bedrock access denied")
-    result = agent.tool.mongodb_memory(action="record", content="test", **config)
+    result = agent.tool.mongodb_memory(action="record", content="test")
     assert result["status"] == "error"
     assert "Embedding generation failed" in result["content"][0]["text"]
 
 
-def test_metadata_usage_scenarios(mock_mongodb_client, mock_bedrock_client, config):
+def test_metadata_usage_scenarios(mock_mongodb_client, mock_bedrock_client):
     """Test various metadata usage patterns."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -717,7 +659,7 @@ def test_metadata_usage_scenarios(mock_mongodb_client, mock_bedrock_client, conf
     }
 
     result = agent.tool.mongodb_memory(
-        action="record", content="Important project deadline", metadata=structured_metadata, **config
+        action="record", content="Important project deadline", metadata=structured_metadata
     )
 
     assert result["status"] == "success"
@@ -729,70 +671,15 @@ def test_metadata_usage_scenarios(mock_mongodb_client, mock_bedrock_client, conf
     assert call_args["metadata"] == structured_metadata
 
 
-def test_performance_scenarios(mock_mongodb_client, mock_bedrock_client, config):
-    """Test performance-related scenarios like pagination."""
-    agent = Agent(tools=[mongodb_memory])
-
-    # Configure mock find response with pagination
-    mock_cursor = MagicMock()
-    mock_cursor.sort.return_value = mock_cursor
-    mock_cursor.skip.return_value = mock_cursor
-    mock_cursor.limit.return_value = mock_cursor
-    mock_cursor.__iter__.return_value = [
-        {
-            "memory_id": f"mem_{i}",
-            "content": f"Test content {i}",
-            "timestamp": "2023-01-01T00:00:00Z",
-            "metadata": {},
-        }
-        for i in range(5)
-    ]
-
-    mock_mongodb_client["collection"].find.return_value = mock_cursor
-    mock_mongodb_client["collection"].count_documents.return_value = 25  # More results available
-
-    # Test pagination with next_token
-    result = agent.tool.mongodb_memory(action="list", max_results=5, next_token="10", **config)
-
-    assert result["status"] == "success"
-    assert "Memories listed successfully" in result["content"][0]["text"]
-
-    # Verify pagination parameters were used
-    mock_cursor.skip.assert_called_with(10)
-    mock_cursor.limit.assert_called_with(5)
-
-
-def test_security_scenarios(mock_mongodb_client, mock_bedrock_client):
-    """Test security-related scenarios like namespace isolation."""
-    agent = Agent(tools=[mongodb_memory])
-
-    # Configure mock find_one response to return None (not found)
-    # This simulates the new behavior where we query with both memory_id and namespace
-    mock_mongodb_client["collection"].find_one.return_value = None
-
-    # Test namespace validation
-    result = agent.tool.mongodb_memory(
-        action="get",
-        memory_id="mem_123",
-        cluster_uri="mongodb+srv://test:test@cluster.mongodb.net/",
-        database_name="test_db",
-        collection_name="test_collection",
-        namespace="correct_namespace",
-    )
-
-    assert result["status"] == "error"
-    assert "Memory mem_123 not found in namespace correct_namespace" in result["content"][0]["text"]
-
-
-def test_troubleshooting_scenarios(mock_mongodb_client, mock_bedrock_client, config):
+def test_troubleshooting_scenarios(mock_mongodb_client, mock_bedrock_client):
     """Test troubleshooting scenarios mentioned in documentation."""
     agent = Agent(tools=[mongodb_memory])
 
-    # Test index creation failure - now it should succeed with warning, not error
+    # Index creation failure is non-fatal: retrieve logs a warning and still succeeds.
     mock_mongodb_client["collection"].create_search_index.side_effect = Exception("Index creation failed")
     mock_mongodb_client["collection"].aggregate.return_value = []
-    result = agent.tool.mongodb_memory(action="retrieve", query="test", **config)
-    assert result["status"] == "success"  # Should succeed despite index creation failure
+    result = agent.tool.mongodb_memory(action="retrieve", query="test")
+    assert result["status"] == "success"
 
     # Reset side effect
     mock_mongodb_client["collection"].create_search_index.side_effect = None
@@ -801,57 +688,20 @@ def test_troubleshooting_scenarios(mock_mongodb_client, mock_bedrock_client, con
     from pymongo.errors import ConnectionFailure
 
     mock_mongodb_client["client"].admin.command.side_effect = ConnectionFailure("Authentication failed")
-    result = agent.tool.mongodb_memory(action="record", content="test", **config)
+    result = agent.tool.mongodb_memory(action="record", content="test")
     assert result["status"] == "error"
     assert "Unable to connect to MongoDB cluster" in result["content"][0]["text"]
 
 
-def test_nosql_injection_prevention(mock_mongodb_client, mock_bedrock_client, config):
-    """Test that NoSQL injection attempts are blocked."""
+def test_invalid_namespace_env_var(mock_mongodb_client, mock_bedrock_client):
+    """Test that an invalid MONGODB_NAMESPACE env var is rejected.
+
+    The agent cannot supply a namespace, so NoSQL operator injection cannot reach it via the tool
+    signature. An operator can still misconfigure the environment variable, so validation runs on
+    that value.
+    """
     agent = Agent(tools=[mongodb_memory])
 
-    # Test the specific PoC attack: namespace={"$ne": ""}
-    malicious_namespace = {"$ne": ""}
-
-    # Remove namespace from config to avoid conflict
-    test_config = {k: v for k, v in config.items() if k != "namespace"}
-
-    # Test with list action (most common attack vector)
-    result = agent.tool.mongodb_memory(action="list", namespace=malicious_namespace, **test_config)
-
-    # Should be blocked - either by Pydantic validation or our custom validation
-    assert result["status"] == "error"
-    error_text = result["content"][0]["text"]
-    assert "Invalid namespace" in error_text or "Input should be a valid string" in error_text, (
-        f"Expected validation error, got: {error_text}"
-    )
-
-    # Test other MongoDB operators
-    other_injection_attempts = [
-        {"$gt": ""},
-        {"$regex": ".*"},
-        {"$exists": True},
-        {"$in": ["tenant1", "tenant2"]},
-    ]
-
-    for injection_payload in other_injection_attempts:
-        result = agent.tool.mongodb_memory(action="list", namespace=injection_payload, **test_config)
-
-        assert result["status"] == "error", f"Injection {injection_payload} should be blocked"
-        error_text = result["content"][0]["text"]
-        assert "Invalid namespace" in error_text or "Input should be a valid string" in error_text, (
-            f"Expected validation error for {injection_payload}"
-        )
-
-
-def test_namespace_validation_strict_rules(mock_mongodb_client, mock_bedrock_client, config):
-    """Test strict namespace validation rules."""
-    agent = Agent(tools=[mongodb_memory])
-
-    # Remove namespace from config to avoid conflict
-    test_config = {k: v for k, v in config.items() if k != "namespace"}
-
-    # Test invalid characters (should be rejected)
     invalid_namespaces = [
         "user.name",  # Dots not allowed in strict mode
         "user@domain",  # @ symbol
@@ -865,14 +715,13 @@ def test_namespace_validation_strict_rules(mock_mongodb_client, mock_bedrock_cli
     ]
 
     for invalid_namespace in invalid_namespaces:
-        result = agent.tool.mongodb_memory(action="list", namespace=invalid_namespace, **test_config)
+        with mock.patch.dict(os.environ, {"MONGODB_NAMESPACE": invalid_namespace}):
+            result = agent.tool.mongodb_memory(action="list")
+            assert result["status"] == "error", f"Invalid namespace '{invalid_namespace}' should be rejected"
+            assert "Invalid namespace" in result["content"][0]["text"]
 
-        assert result["status"] == "error", f"Invalid namespace '{invalid_namespace}' should be rejected"
-        error_text = result["content"][0]["text"]
-        assert "Invalid namespace" in error_text, f"Expected validation error for '{invalid_namespace}'"
 
-
-def test_vector_search_pipeline_structure(mock_mongodb_client, mock_bedrock_client, config):
+def test_vector_search_pipeline_structure(mock_mongodb_client, mock_bedrock_client):
     """Test that the vector search pipeline is structured correctly."""
     agent = Agent(tools=[mongodb_memory])
 
@@ -888,7 +737,7 @@ def test_vector_search_pipeline_structure(mock_mongodb_client, mock_bedrock_clie
     ]
 
     # Call retrieve action
-    agent.tool.mongodb_memory(action="retrieve", query="test query", **config)
+    agent.tool.mongodb_memory(action="retrieve", query="test query")
 
     # Verify aggregate was called
     mock_mongodb_client["collection"].aggregate.assert_called()
@@ -913,3 +762,74 @@ def test_vector_search_pipeline_structure(mock_mongodb_client, mock_bedrock_clie
     vector_search = main_pipeline[0]["$vectorSearch"]
     assert vector_search["index"] == "vector_index"
     assert vector_search["path"] == "embedding"
+
+
+# --- MongoDBMemoryTool class (per-principal binding) ---
+
+
+def test_class_requires_cluster_uri(mock_mongodb_client, mock_bedrock_client):
+    """Constructing the class without a cluster URI raises."""
+    from src.strands_tools.mongodb_memory import MongoDBValidationError
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(MongoDBValidationError, match="cluster_uri is required"):
+            MongoDBMemoryTool()
+
+
+def test_class_rejects_invalid_namespace(mock_mongodb_client, mock_bedrock_client, tool_config):
+    """The class validates the bound namespace at construction."""
+    from src.strands_tools.mongodb_memory import MongoDBValidationError
+
+    bad_config = {**tool_config, "namespace": "user$name"}
+    with pytest.raises(MongoDBValidationError, match="Invalid namespace"):
+        MongoDBMemoryTool(**bad_config)
+
+
+def test_class_binds_namespace(mock_mongodb_client, mock_bedrock_client, tool_config):
+    """The class uses its constructor namespace, not any agent-supplied value."""
+    mock_mongodb_client["collection"].find_one.return_value = None
+
+    tool = MongoDBMemoryTool(**{**tool_config, "namespace": "user_alice"})
+    agent = Agent(tools=[tool.mongodb_memory])
+
+    result = agent.tool.mongodb_memory(action="get", memory_id="mem_123")
+
+    assert result["status"] == "error"
+    assert "not found in namespace user_alice" in result["content"][0]["text"]
+
+    # Query used the bound namespace
+    call_args = mock_mongodb_client["collection"].find_one.call_args[0]
+    assert call_args[0] == {"memory_id": "mem_123", "namespace": "user_alice"}
+
+
+def test_class_record_uses_bound_namespace(mock_mongodb_client, mock_bedrock_client, tool_config):
+    """A record stored through the class lands in the bound namespace."""
+    mock_result = MagicMock()
+    mock_result.inserted_id = "test_id"
+    mock_mongodb_client["collection"].insert_one.return_value = mock_result
+
+    tool = MongoDBMemoryTool(**{**tool_config, "namespace": "user_bob"})
+    agent = Agent(tools=[tool.mongodb_memory])
+
+    result = agent.tool.mongodb_memory(action="record", content="Bob's secret")
+
+    assert result["status"] == "success"
+    assert result["content"][1]["json"]["namespace"] == "user_bob"
+
+    # The stored document carries the bound namespace
+    stored_doc = mock_mongodb_client["collection"].insert_one.call_args[0][0]
+    assert stored_doc["namespace"] == "user_bob"
+
+
+def test_class_namespace_falls_back_to_env(mock_mongodb_client, mock_bedrock_client):
+    """When namespace is not passed to the constructor, it falls back to MONGODB_NAMESPACE."""
+    mock_mongodb_client["collection"].find_one.return_value = None
+
+    with mock.patch.dict(os.environ, {"MONGODB_NAMESPACE": "env_tenant"}):
+        tool = MongoDBMemoryTool(cluster_uri="mongodb+srv://test:test@cluster.mongodb.net/")
+    agent = Agent(tools=[tool.mongodb_memory])
+
+    agent.tool.mongodb_memory(action="get", memory_id="mem_123")
+
+    call_args = mock_mongodb_client["collection"].find_one.call_args[0]
+    assert call_args[0] == {"memory_id": "mem_123", "namespace": "env_tenant"}


### PR DESCRIPTION
## Description

The tenant-isolation key for stored memories was exposed as an LLM-controllable tool parameter, allowing a model (or prompt-injected content) to read, write, or delete another tenant's memories by supplying a different value. Some tools additionally exposed connection credentials, allowing the model to redirect the memory layer at an arbitrary cluster. This affected all three self-hosted memory tools:

- **`mongodb_memory`** / **`elasticsearch_memory`** — the LLM-facing `namespace` (sole tenant boundary) plus connection/credential params.
- **`mem0_memory`** — the LLM-facing `user_id` / `agent_id` (tenant boundary). Additionally, `get`/`delete`/`history` accepted a raw `memory_id` with no ownership check, so any memory ID was globally readable/deletable regardless of tenant.

### Code Updates

- Removes `namespace`, `index_name`, `cloud_id`, `es_url`, `api_key`, `cluster_uri`, `database_name`, `collection_name`, `embedding_model`, `region`, and `vector_index_name` from the LLM-facing `@tool` signatures of both `mongodb_memory` and `elasticsearch_memory`
- Binds namespace (the sole tenant-isolation key) at construction time in `MongoDBMemoryTool` and the new `ElasticsearchMemoryTool` class, with fail-fast validation
- Removes `user_id` / `agent_id` from the `mem0_memory` `TOOL_SPEC` input schema, and adds a new `Mem0MemoryTool` class that binds identity at construction time with fail-fast validation
- Adds ownership verification to `mem0_memory` `get`/`delete`/`history` so a raw `memory_id` cannot reach across tenants
- Standalone module-level functions now read all connection/namespace/identity config exclusively from environment variables (`mem0_memory` uses `MEM0_USER_ID` / `MEM0_AGENT_ID`)

## Breaking Changes

Any code passing `namespace`, `cluster_uri`, `database_name`, `collection_name`, `index_name`, `cloud_id`, `es_url`, `api_key`, `embedding_model`, `region`, or `vector_index_name` directly to the `mongodb_memory` / `elasticsearch_memory` tool functions will get a `TypeError`. For `mem0_memory`, `user_id` / `agent_id` are no longer accepted as tool inputs.

**Migration:**

- **Class-based (multi-tenant):**
  - `mongodb_memory` / `elasticsearch_memory`: add `namespace=f"user_{authenticated_user_id}"` to the constructor.
  - `mem0_memory`: construct `Mem0MemoryTool(user_id=f"user_{authenticated_user_id}")` (or `agent_id=...`).
  - Remove the tenant key from all tool call sites.
  - **Standalone (single-tenant):** Set the connection/identity environment variables and remove the deleted params from all call sites:
  - `mongodb_memory`: `MONGODB_NAMESPACE` (+ connection vars)
  - `elasticsearch_memory`: `ELASTICSEARCH_NAMESPACE` (+ connection vars)
  - `mem0_memory`: `MEM0_USER_ID` or `MEM0_AGENT_ID`

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
