### PR TITLE
fix(retrieve): support distance score filtering

### DIFF
--- a/src/strands_tools/retrieve.py
+++ b/src/strands_tools/retrieve.py
@@ -144,12 +144,22 @@ Usage Examples:
                 "score": {
                     "type": "number",
                     "description": (
-                        "Minimum relevance score threshold (0.0-1.0). Results below this score will be filtered out. "
+                        "Score threshold (0.0-1.0). With scoreMetric='similarity', results below this score are "
+                        "filtered out. With scoreMetric='distance', results above this score are filtered out. "
                         "Default is 0.4."
                     ),
                     "default": 0.4,
                     "minimum": 0.0,
                     "maximum": 1.0,
+                },
+                "scoreMetric": {
+                    "type": "string",
+                    "description": (
+                        "How to interpret the score threshold. Use 'similarity' when higher scores are better, "
+                        "or 'distance' when lower scores are better. Default is 'similarity'."
+                    ),
+                    "enum": ["similarity", "distance"],
+                    "default": "similarity",
                 },
                 "profile_name": {
                     "type": "string",
@@ -187,22 +197,37 @@ Usage Examples:
 }
 
 
-def filter_results_by_score(results: List[Dict[str, Any]], min_score: float) -> List[Dict[str, Any]]:
+def filter_results_by_score(
+    results: List[Dict[str, Any]], min_score: float, score_metric: str = "similarity"
+) -> List[Dict[str, Any]]:
     """
-    Filter results based on minimum score threshold.
+    Filter results based on score threshold.
 
     This function takes the raw results from a knowledge base query and removes
-    any items that don't meet the minimum relevance score threshold.
+    any items that don't meet the configured score threshold.
 
     Args:
         results: List of retrieval results from Bedrock Knowledge Base
-        min_score: Minimum score threshold (0.0-1.0). Only results with scores
-            greater than or equal to this value will be returned.
+        min_score: Score threshold (0.0-1.0).
+        score_metric: Score interpretation. ``similarity`` keeps scores greater
+            than or equal to the threshold. ``distance`` keeps scores less than
+            or equal to the threshold.
 
     Returns:
-        List of filtered results that meet or exceed the score threshold
+        List of filtered results that meet the score threshold.
+
+    Raises:
+        ValueError: If score_metric is not supported.
     """
-    return [result for result in results if result.get("score", 0.0) >= min_score]
+    if score_metric == "similarity":
+        return [result for result in results if result.get("score", 0.0) >= min_score]
+    if score_metric == "distance":
+        return [result for result in results if result.get("score", float("inf")) <= min_score]
+    raise ValueError("scoreMetric must be either 'similarity' or 'distance'")
+
+
+def _score_threshold_operator(score_metric: str) -> str:
+    return "<=" if score_metric == "distance" else ">="
 
 
 # Mapping of RetrievalResultLocation types to their document identifier fields.
@@ -219,7 +244,9 @@ _LOCATION_FIELD_MAP = {
 }
 
 
-def format_results_for_display(results: List[Dict[str, Any]], enable_metadata: bool = False) -> str:
+def format_results_for_display(
+    results: List[Dict[str, Any]], enable_metadata: bool = False, score_metric: str = "similarity"
+) -> str:
     """
     Format retrieval results for readable display.
 
@@ -230,12 +257,15 @@ def format_results_for_display(results: List[Dict[str, Any]], enable_metadata: b
     Args:
         results: List of retrieval results from Bedrock Knowledge Base
         enable_metadata: Whether to include metadata in the formatted output (default: False)
+        score_metric: Score interpretation, either "similarity" or "distance" (default: "similarity")
 
     Returns:
         Formatted string containing the results in a readable format, including score,
         document ID, optional metadata, and content.
     """
     if not results:
+        if score_metric == "distance":
+            return "No results found at or below score threshold."
         return "No results found above score threshold."
 
     formatted = []
@@ -296,6 +326,7 @@ def retrieve(tool: ToolUse, **kwargs: Any) -> ToolResult:
             knowledgeBaseId: The ID of the knowledge base to query (default: from environment)
             region: AWS region where the knowledge base is located (default: us-west-2)
             score: Minimum relevance score threshold (default: 0.4)
+            scoreMetric: Score interpretation, either "similarity" or "distance" (default: "similarity")
             profile_name: Optional AWS profile name to use
             retrieveFilter: Optional filter to apply to the retrieval results
 
@@ -331,8 +362,16 @@ def retrieve(tool: ToolUse, **kwargs: Any) -> ToolResult:
         kb_id = tool_input.get("knowledgeBaseId", default_knowledge_base_id)
         region_name = tool_input.get("region", default_aws_region)
         min_score = tool_input.get("score", default_min_score)
+        score_metric = tool_input.get("scoreMetric", "similarity")
         enable_metadata = tool_input.get("enableMetadata", default_enable_metadata)
         retrieve_filter = tool_input.get("retrieveFilter")
+
+        if score_metric not in {"similarity", "distance"}:
+            return {
+                "toolUseId": tool_use_id,
+                "status": "error",
+                "content": [{"text": "scoreMetric must be either 'similarity' or 'distance'"}],
+            }
 
         # Initialize Bedrock client with optional profile name
         profile_name = tool_input.get("profile_name")
@@ -366,17 +405,23 @@ def retrieve(tool: ToolUse, **kwargs: Any) -> ToolResult:
 
         # Get and filter results
         all_results = response.get("retrievalResults", [])
-        filtered_results = filter_results_by_score(all_results, min_score)
+        filtered_results = filter_results_by_score(all_results, min_score, score_metric)
 
         # Format results for display with optional metadata
-        formatted_results = format_results_for_display(filtered_results, enable_metadata)
+        formatted_results = format_results_for_display(filtered_results, enable_metadata, score_metric)
+        score_operator = _score_threshold_operator(score_metric)
 
         # Return success with formatted results
         return {
             "toolUseId": tool_use_id,
             "status": "success",
             "content": [
-                {"text": f"Retrieved {len(filtered_results)} results with score >= {min_score}:\n{formatted_results}"}
+                {
+                    "text": (
+                        f"Retrieved {len(filtered_results)} results with score {score_operator} {min_score}:"
+                        f"\n{formatted_results}"
+                    )
+                }
             ],
         }
 

--- a/src/strands_tools/retrieve.py
+++ b/src/strands_tools/retrieve.py
@@ -146,7 +146,7 @@ Usage Examples:
                     "description": (
                         "Score threshold (0.0-1.0). With scoreMetric='similarity', results below this score are "
                         "filtered out. With scoreMetric='distance', results above this score are filtered out. "
-                        "Default is 0.4."
+                        "Defaults to 0.4 for similarity; distance results are not filtered when omitted."
                     ),
                     "default": 0.4,
                     "minimum": 0.0,
@@ -325,7 +325,7 @@ def retrieve(tool: ToolUse, **kwargs: Any) -> ToolResult:
             numberOfResults: Maximum number of results to return (default: 10)
             knowledgeBaseId: The ID of the knowledge base to query (default: from environment)
             region: AWS region where the knowledge base is located (default: us-west-2)
-            score: Minimum relevance score threshold (default: 0.4)
+            score: Score threshold (defaults to 0.4 for similarity; no default filtering for distance)
             scoreMetric: Score interpretation, either "similarity" or "distance" (default: "similarity")
             profile_name: Optional AWS profile name to use
             retrieveFilter: Optional filter to apply to the retrieval results
@@ -344,7 +344,7 @@ def retrieve(tool: ToolUse, **kwargs: Any) -> ToolResult:
     Notes:
         - The knowledge base ID can be set via the KNOWLEDGE_BASE_ID environment variable
         - The AWS region can be set via the AWS_REGION environment variable
-        - The minimum score threshold can be set via the MIN_SCORE environment variable
+        - The default similarity score threshold can be set via the MIN_SCORE environment variable
         - Results are automatically filtered based on the minimum score threshold
         - AWS credentials must be configured properly for this tool to work
     """
@@ -361,8 +361,9 @@ def retrieve(tool: ToolUse, **kwargs: Any) -> ToolResult:
         number_of_results = tool_input.get("numberOfResults", 10)
         kb_id = tool_input.get("knowledgeBaseId", default_knowledge_base_id)
         region_name = tool_input.get("region", default_aws_region)
-        min_score = tool_input.get("score", default_min_score)
         score_metric = tool_input.get("scoreMetric", "similarity")
+        default_score = default_min_score if score_metric == "similarity" else float("inf")
+        min_score = tool_input.get("score", default_score)
         enable_metadata = tool_input.get("enableMetadata", default_enable_metadata)
         retrieve_filter = tool_input.get("retrieveFilter")
 

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -470,6 +470,25 @@ def test_retrieve_distance_score_metric(mock_boto3_client):
     assert "doc-002" not in result["content"][0]["text"]
 
 
+@pytest.mark.parametrize("min_score", ["0.4", "0.7", "0.9"])
+def test_retrieve_distance_default_ignores_similarity_min_score(mock_boto3_client, min_score):
+    """Test MIN_SCORE does not become a distance ceiling."""
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {
+            "text": "test query",
+            "knowledgeBaseId": "test-kb-id",
+            "scoreMetric": "distance",
+        },
+    }
+
+    with mock.patch.dict(os.environ, {"MIN_SCORE": min_score}):
+        result = retrieve.retrieve(tool=tool_use)
+
+    assert result["status"] == "success"
+    assert "Retrieved 3 results with score <= inf" in result["content"][0]["text"]
+
+
 def test_retrieve_rejects_invalid_score_metric(mock_boto3_client):
     """Test retrieve rejects unsupported score metric values."""
     tool_use = {

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -94,6 +94,15 @@ def test_filter_results_by_score():
     assert filtered[0]["score"] == 0.9
     assert filtered[1]["score"] == 0.8
 
+    # Filter distance scores with threshold 0.5
+    filtered = retrieve.filter_results_by_score(test_results, 0.5, score_metric="distance")
+    assert len(filtered) == 2
+    assert filtered[0]["score"] == 0.5
+    assert filtered[1]["score"] == 0.3
+
+    with pytest.raises(ValueError, match="scoreMetric"):
+        retrieve.filter_results_by_score(test_results, 0.5, score_metric="unknown")
+
 
 def test_format_results_for_display():
     """Test the format_results_for_display function."""
@@ -438,6 +447,45 @@ def test_retrieve_custom_score_threshold(mock_boto3_client):
     assert "doc-001" in result["content"][0]["text"]
     # Medium score result (0.7) should not be included
     assert "doc-002" not in result["content"][0]["text"]
+
+
+def test_retrieve_distance_score_metric(mock_boto3_client):
+    """Test retrieve with distance scores, where lower is better."""
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {
+            "text": "test query",
+            "knowledgeBaseId": "test-kb-id",
+            "score": 0.4,
+            "scoreMetric": "distance",
+        },
+    }
+
+    result = retrieve.retrieve(tool=tool_use)
+
+    assert result["status"] == "success"
+    assert "Retrieved 1 results with score <= 0.4" in result["content"][0]["text"]
+    assert "doc-003" in result["content"][0]["text"]
+    assert "doc-001" not in result["content"][0]["text"]
+    assert "doc-002" not in result["content"][0]["text"]
+
+
+def test_retrieve_rejects_invalid_score_metric(mock_boto3_client):
+    """Test retrieve rejects unsupported score metric values."""
+    tool_use = {
+        "toolUseId": "test-tool-use-id",
+        "input": {
+            "text": "test query",
+            "knowledgeBaseId": "test-kb-id",
+            "scoreMetric": "unknown",
+        },
+    }
+
+    result = retrieve.retrieve(tool=tool_use)
+
+    assert result["status"] == "error"
+    assert "scoreMetric must be either 'similarity' or 'distance'" in result["content"][0]["text"]
+    mock_boto3_client.assert_not_called()
 
 
 def test_retrieve_via_agent(agent, mock_boto3_client):


### PR DESCRIPTION
Summary:
- Add a `scoreMetric` option to the retrieve tool so callers can choose similarity or distance score filtering.
- Keep the existing similarity behavior as the default while using `<=` for distance metrics.
- Add regression coverage for distance filtering and invalid score metric values.

Why:
- Some Bedrock Knowledge Base backends return distance scores where lower values are more relevant. The previous `>=` threshold dropped relevant low-distance results and kept worse high-distance results.

Validation:
- [x] `python -m compileall src\strands_tools\retrieve.py`
- [x] `python -m compileall tests\test_retrieve.py`
- [x] `python -m ruff check src\strands_tools\retrieve.py tests\test_retrieve.py`
- [x] `pytest tests\test_retrieve.py -q`

Notes for reviewers:
- Closes #417.
- The default remains `similarity`, so existing callers keep the previous threshold semantics.