### PR TITLE
ci: align dependabot config with harness-sdk conventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,10 @@
 #     churn on same-day releases. Majors get a long (30-day) window so a human
 #     can vet breaking changes before the PR lands.
 #   - groups: batch low-risk updates into grouped PRs. Dev tooling lands in one
-#     PR, minor/patch bumps in another. Major updates are intentionally left
-#     ungrouped so they arrive as individual, clearly-attributable PRs.
+#     PR, majors included, since a dev-tool major only touches CI and the
+#     blast radius is small; minor/patch bumps land in another. Major production updates
+#     are intentionally left ungrouped so they arrive as individual,
+#     clearly-attributable PRs.
 #   - schedule: poll weekly. The cooldown already delays PRs by days, so daily
 #     polling just adds noise without surfacing updates any sooner.
 #   - versioning-strategy: increase-if-necessary, which bumps the constraint

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,77 @@
+# Dependabot configuration.
+#
+# Shared conventions across every ecosystem below (aligned with
+# strands-agents/harness-sdk):
+#   - cooldown: hold new updates for a few days before opening a PR so we don't
+#     churn on same-day releases. Majors get a long (30-day) window so a human
+#     can vet breaking changes before the PR lands.
+#   - groups: batch low-risk updates into grouped PRs. Dev tooling lands in one
+#     PR, minor/patch bumps in another. Major updates are intentionally left
+#     ungrouped so they arrive as individual, clearly-attributable PRs.
+#   - schedule: poll weekly. The cooldown already delays PRs by days, so daily
+#     polling just adds noise without surfacing updates any sooner.
+#   - versioning-strategy: increase-if-necessary, which bumps the constraint
+#     floor at a major boundary instead of just widening the upper bound, so CI
+#     actually resolves and tests the new major rather than sitting on the old
+#     one.
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
+  # Python package at the repo root. Dev tooling and minor/patch bumps are
+  # batched; major bumps come individually and wait out the 30-day cooldown
+  # for review.
+  - package-ecosystem: 'pip'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'weekly'
     open-pull-requests-limit: 100
+    labels:
+      - 'dependencies'
+      - 'python'
     commit-message:
-      prefix: ci
+      prefix: 'ci(python)'
+    versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
-      dev-dependencies:
+      # Dev tooling in one PR, matched by name because Dependabot does not
+      # classify PEP 621 pyproject dependencies as development vs production,
+      # so dependency-type grouping never matches for pip.
+      development-dependencies:
+        applies-to: version-updates
         patterns:
-          - "pytest"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+          - 'commitizen'
+          - 'hatch'
+          - 'mypy'
+          - 'pre-commit'
+          - 'pytest*'
+          - 'responses'
+          - 'ruff'
+          - 'sphinx*'
+      # Everything else: minor + patch bumps in one PR. A dependency joins the
+      # first group it matches, so dev tooling above never lands here. Majors
+      # aren't matched by any group, so they get individual PRs, gated by the
+      # 30-day semver-major cooldown above for manual review.
+      production-minor:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+  # GitHub Actions workflow pins. Low volume, so no grouping; the cooldown
+  # still holds majors back for review before the bump PR opens.
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'weekly'
     open-pull-requests-limit: 100
     commit-message:
       prefix: ci
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
## Description

Aligns the Dependabot config with the conventions established in harness-sdk:

- **Weekly schedule with cooldown windows** instead of daily polling. New releases wait 3/7/30 days (patch/minor/major) before a PR opens, so we stop churning on same-day releases and majors get a review window.
- **`versioning-strategy: increase-if-necessary`** (previously unset here, unlike evals/harness-sdk) so a major bumps the constraint floor and CI actually resolves and tests the new major instead of only widening the upper bound.
- **Grouped updates**: dev tooling (commitizen, hatch, mypy, pre-commit, pytest*, responses, ruff, sphinx*) batches into one PR and remaining minor/patch bumps into another. Majors intentionally stay ungrouped so they arrive as individual, clearly-attributable PRs. Groups are pattern-based because Dependabot does not classify PEP 621 pyproject dependencies as development vs production, so `dependency-type` grouping never matches for pip.
- **Scoped commit prefix** `ci(python)` and `dependencies`/`python` labels, matching harness-sdk.
- Actions updates keep the plain `ci` prefix and gain the same cooldown.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Other: CI/dependency-management configuration

## Testing

YAML validated with a parser; config mirrors the scheme already running in harness-sdk and shell.

- [x] I ran `hatch run prepare` (not applicable, config-only change)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works