### PR TITLE
fix(mem0): lazy-load OpenSearch dependency

### DIFF
--- a/src/strands_tools/mem0_memory.py
+++ b/src/strands_tools/mem0_memory.py
@@ -99,7 +99,6 @@ from typing import Any, Dict, List, Optional
 import boto3
 from mem0 import Memory as Mem0Memory
 from mem0 import MemoryClient
-from opensearchpy import AWSV4SignerAuth, RequestsHttpConnection
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -332,6 +331,16 @@ class Mem0ServiceClient:
         Returns:
             An initialized Mem0Memory instance configured for OpenSearch.
         """
+        try:
+            from opensearchpy import AWSV4SignerAuth, RequestsHttpConnection
+        except ModuleNotFoundError as error:
+            if error.name != "opensearchpy":
+                raise
+            raise ImportError(
+                "The opensearch-py package is required for the OpenSearch backend. "
+                "Install it with: pip install 'strands-agents-tools[mem0-memory]'"
+            ) from error
+
         # Add vector portion of the config
         config = config or {}
         config["vector_store"] = {

--- a/tests/test_mem0.py
+++ b/tests/test_mem0.py
@@ -10,7 +10,9 @@ identity is never an LLM-controllable tool parameter.
 import builtins
 import json
 import os
+import subprocess
 import sys
+import textwrap
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -485,6 +487,46 @@ def test_missing_opensearch_host(mock_tool):
         result = mem0_memory.mem0_memory(tool=mock_tool)
         assert result["status"] == "error"
         assert "The faiss-cpu package is required" in str(result["content"][0]["text"])
+
+
+def test_module_import_does_not_require_opensearch():
+    """FAISS users can import mem0_memory without the OpenSearch dependency."""
+    script = textwrap.dedent(
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def block_opensearch(name, *args, **kwargs):
+            if name == "opensearchpy" or name.startswith("opensearchpy."):
+                raise ModuleNotFoundError("No module named 'opensearchpy'", name="opensearchpy")
+            return real_import(name, *args, **kwargs)
+
+        builtins.__import__ = block_opensearch
+        from strands_tools.mem0_memory import Mem0ServiceClient
+
+        assert Mem0ServiceClient is not None
+        """
+    )
+
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_opensearch_backend_reports_missing_optional_dependency():
+    """The OpenSearch path explains how to install its optional dependency."""
+    client = object.__new__(Mem0ServiceClient)
+    real_import = builtins.__import__
+
+    def block_opensearch(name, *args, **kwargs):
+        if name == "opensearchpy" or name.startswith("opensearchpy."):
+            raise ModuleNotFoundError("No module named 'opensearchpy'", name="opensearchpy")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=block_opensearch):
+        with pytest.raises(ImportError, match="opensearch-py.*mem0-memory"):
+            client._append_opensearch_config()
 
 
 @patch("boto3.Session")


### PR DESCRIPTION
## Description

`strands_tools.mem0_memory` imported OpenSearch classes when the module was
loaded, so FAISS-only users could not import the tool unless `opensearch-py` was
installed. This moves those imports into the OpenSearch configuration path and
raises an actionable dependency error only when that backend is selected.

The change is limited to import timing. Backend selection, OpenSearch
configuration, authentication, and the existing `mem0-memory` extra are
unchanged.

## Related Issues

Fixes #227

## Documentation PR

Not applicable. The existing installation extra remains unchanged.

## Type of Change

Bug fix

## Testing

Added regressions that block `opensearchpy` and verify both the FAISS import
boundary and the OpenSearch missing-dependency message.

```bash
hatch test -i py=3.12 tests/test_mem0.py
hatch test -i py=3.12
hatch fmt --linter --check
ruff format --check src/strands_tools/mem0_memory.py tests/test_mem0.py
```

- [ ] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added necessary tests that prove the fix is effective
- [x] Documentation changes are not required because installation and public APIs are unchanged
- [x] A documentation example is not required for this dependency-boundary bug fix
- [x] My changes generate no new warnings
- [x] There are no dependent changes

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
