### PR TITLE
fix(python_repl): drive non_interactive mode from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1030,6 +1030,7 @@ These variables affect multiple tools:
 | Environment Variable | Description | Default | Affected Tools |
 |----------------------|-------------|---------|---------------|
 | BYPASS_TOOL_CONSENT | Bypass consent for tool invocation, set to "true" to enable | false | All tools that require consent (e.g. shell, file_write, python_repl) |
+| STRANDS_NON_INTERACTIVE | Run tools without interactive prompts, set to "true" to suppress confirmation dialogs | false | Tools with a confirmation prompt (e.g. shell, python_repl) |
 | STRANDS_TOOL_CONSOLE_MODE | Enable rich UI for tools, set to "enabled" to enable | disabled | All tools that have optional rich UI |
 | AWS_REGION | Default AWS region for AWS operations | us-west-2 | use_aws, retrieve, generate_image, memory, nova_reels |
 | AWS_PROFILE | AWS profile name to use from ~/.aws/credentials | default | use_aws, retrieve |

--- a/src/strands_tools/python_repl.py
+++ b/src/strands_tools/python_repl.py
@@ -30,6 +30,13 @@ agent.tool.python_repl(code="input('Enter your name: ')", interactive=True)
 # Reset the REPL state if needed
 agent.tool.python_repl(code="print('Fresh start')", reset_state=True)
 ```
+
+Configuration:
+- STRANDS_NON_INTERACTIVE (environment variable): Set to "true" to run the tool
+  in a non-interactive mode, suppressing the user confirmation prompt before code
+  execution.
+- BYPASS_TOOL_CONSENT (environment variable): Set to "true" to bypass only the
+  user confirmation prompt, even in an otherwise interactive session.
 """
 
 import fcntl
@@ -611,8 +618,7 @@ def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
     # Check for development mode
     strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
 
-    # Check for non_interactive_mode parameter
-    non_interactive_mode = kwargs.get("non_interactive_mode", False)
+    non_interactive_mode = os.environ.get("STRANDS_NON_INTERACTIVE", "").lower() == "true"
 
     try:
         # Show code preview

--- a/tests/test_python_repl.py
+++ b/tests/test_python_repl.py
@@ -349,14 +349,15 @@ class TestPythonRepl:
             assert python_repl.repl_state.get_namespace()["dev_mode_test"] == 42
 
     def test_non_interactive_mode_bypass_confirmation(self, mock_console):
-        """Test that non_interactive_mode bypasses the confirmation dialog."""
+        """Test that STRANDS_NON_INTERACTIVE bypasses the confirmation dialog."""
         tool_use = {
             "toolUseId": "test-id",
             "input": {"code": "non_interactive_test = 'passed'", "interactive": False},
         }
 
-        # Pass non_interactive_mode as True
-        result = python_repl.python_repl(tool=tool_use, non_interactive_mode=True)
+        # Set STRANDS_NON_INTERACTIVE to bypass the confirmation prompt.
+        with patch.dict(os.environ, {"STRANDS_NON_INTERACTIVE": "true"}):
+            result = python_repl.python_repl(tool=tool_use)
 
         assert result["status"] == "success"
         assert python_repl.repl_state.get_namespace()["non_interactive_test"] == "passed"
@@ -436,27 +437,27 @@ class TestPythonRepl:
             },
         }
 
-        # First define the recursive function
-        # Pass non_interactive_mode=True to bypass confirmation
-        python_repl.python_repl(tool=tool_use, non_interactive_mode=True)
+        # Set STRANDS_NON_INTERACTIVE to bypass the confirmation prompt.
+        with patch.dict(os.environ, {"STRANDS_NON_INTERACTIVE": "true"}):
+            # First define the recursive function
+            python_repl.python_repl(tool=tool_use)
 
-        # Now trigger the recursion error
-        error_tool = {
-            "toolUseId": "error-id",
-            "input": {
-                "code": "recurse()",  # This will cause a recursion error
-                "interactive": False,
-            },
-        }
+            # Now trigger the recursion error
+            error_tool = {
+                "toolUseId": "error-id",
+                "input": {
+                    "code": "recurse()",  # This will cause a recursion error
+                    "interactive": False,
+                },
+            }
 
-        # Mock the clear_state method to verify it gets called
-        with patch.object(
-            python_repl.repl_state,
-            "clear_state",
-            wraps=python_repl.repl_state.clear_state,
-        ) as mock_clear:
-            # Pass non_interactive_mode=True to bypass confirmation
-            result = python_repl.python_repl(tool=error_tool, non_interactive_mode=True)
+            # Mock the clear_state method to verify it gets called
+            with patch.object(
+                python_repl.repl_state,
+                "clear_state",
+                wraps=python_repl.repl_state.clear_state,
+            ) as mock_clear:
+                result = python_repl.python_repl(tool=error_tool)
 
             # Verify clear_state was called
             mock_clear.assert_called_once()
@@ -477,7 +478,10 @@ class TestPythonRepl:
         }
 
         # Mock PtyManager to avoid actual PTY operations
-        with patch("strands_tools.python_repl.PtyManager") as mock_pty:
+        with (
+            patch("strands_tools.python_repl.PtyManager") as mock_pty,
+            patch.dict(os.environ, {"STRANDS_NON_INTERACTIVE": "true"}),
+        ):
             # Configure mocks
             mock_pty_instance = mock_pty.return_value
             mock_pty_instance.pid = 12345
@@ -487,8 +491,7 @@ class TestPythonRepl:
             with patch("os.waitpid") as mock_waitpid:
                 mock_waitpid.side_effect = [(12345, 0)]  # Return pid and exit status 0
 
-                # Pass non_interactive_mode=True to bypass confirmation
-                result = python_repl.python_repl(tool=tool_use, non_interactive_mode=True)
+                result = python_repl.python_repl(tool=tool_use)
 
                 # Verify PtyManager was used
                 mock_pty.assert_called_once()
@@ -511,7 +514,10 @@ class TestPythonRepl:
         }
 
         # Mock PtyManager to avoid actual PTY operations
-        with patch("strands_tools.python_repl.PtyManager") as mock_pty:
+        with (
+            patch("strands_tools.python_repl.PtyManager") as mock_pty,
+            patch.dict(os.environ, {"STRANDS_NON_INTERACTIVE": "true"}),
+        ):
             # Configure mocks
             mock_pty_instance = mock_pty.return_value
             mock_pty_instance.pid = 12345
@@ -521,8 +527,7 @@ class TestPythonRepl:
             with patch("os.waitpid") as mock_waitpid:
                 mock_waitpid.side_effect = [(12345, 1)]  # Return pid and non-zero exit status
 
-                # Pass non_interactive_mode=True to bypass confirmation
-                result = python_repl.python_repl(tool=tool_use, non_interactive_mode=True)
+                result = python_repl.python_repl(tool=tool_use)
 
                 # Verify PtyManager was used and stopped
                 mock_pty_instance.stop.assert_called_once()
@@ -542,15 +547,17 @@ class TestPythonRepl:
         }
 
         # Mock PtyManager
-        with patch("strands_tools.python_repl.PtyManager") as mock_pty:
+        with (
+            patch("strands_tools.python_repl.PtyManager") as mock_pty,
+            patch.dict(os.environ, {"STRANDS_NON_INTERACTIVE": "true"}),
+        ):
             mock_pty_instance = mock_pty.return_value
             mock_pty_instance.pid = 12345
             mock_pty_instance.get_output.return_value = "test output"
 
             # Mock os.waitpid to raise OSError
             with patch("os.waitpid", side_effect=OSError("No such process")):
-                # Pass non_interactive_mode=True to bypass confirmation
-                result = python_repl.python_repl(tool=tool_use, non_interactive_mode=True)
+                result = python_repl.python_repl(tool=tool_use)
 
                 # Verify PtyManager was stopped and cleaned up
                 mock_pty_instance.stop.assert_called_once()
@@ -570,8 +577,9 @@ class TestPythonRepl:
 )
 def test_agent_interface(agent, code, expected):
     """Test calling python_repl through the Agent interface."""
-    # Use non_interactive_mode to bypass confirmation
-    result = agent.tool.python_repl(code=code, interactive=False, non_interactive_mode=True)
+    # Set STRANDS_NON_INTERACTIVE to bypass the confirmation prompt.
+    with patch.dict(os.environ, {"STRANDS_NON_INTERACTIVE": "true"}):
+        result = agent.tool.python_repl(code=code, interactive=False)
 
     # Extract the response text
     if isinstance(result, dict) and "content" in result and isinstance(result["content"], list):


### PR DESCRIPTION
## Description

Reads the `python_repl` tool's `non_interactive_mode` flag exclusively from the `STRANDS_NON_INTERACTIVE` environment variable rather than from `kwargs`. This makes non-interactive mode an operator-controlled setting, consistent with how the `shell` tool resolves the same flag, and removes the ability for a caller to toggle it by forwarding a `non_interactive_mode` argument.

Changes:
- `python_repl` now derives `non_interactive_mode` from `os.environ["STRANDS_NON_INTERACTIVE"]` only.
- Documented `STRANDS_NON_INTERACTIVE` (and `BYPASS_TOOL_CONSENT`) in the module docstring's new `Configuration:` section.
- Updated tests to set the environment variable instead of passing the flag as a keyword argument.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

Ran the `python_repl` test suite (`pytest tests/test_python_repl.py`): 41 passed, 2 skipped. `ruff check` and `ruff format --check` are clean on the changed files.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.