### PR TITLE
feat: add MongoDB driver handshake metadata

### DIFF
--- a/src/strands_tools/mongodb_memory.py
+++ b/src/strands_tools/mongodb_memory.py
@@ -94,11 +94,21 @@ import boto3
 from pymongo import MongoClient
 from pymongo.collection import Collection
 from pymongo.cursor import Cursor
+from pymongo.driver_info import DriverInfo
 from pymongo.errors import ConnectionFailure
 from strands import tool
 
 # Set up logging
 logger = logging.getLogger(__name__)
+
+try:
+    from importlib.metadata import version as _get_version
+
+    _VERSION = _get_version("strands-agents-tools")
+except Exception:
+    _VERSION = None
+
+_DRIVER_INFO = DriverInfo(name="Strands-Tools", version=_VERSION)
 
 
 # Custom exceptions for better error handling
@@ -838,7 +848,7 @@ class MongoDBMemoryTool:
 
             # Initialize MongoDB client with secure error handling
             try:
-                client = MongoClient(self._cluster_uri, serverSelectionTimeoutMS=5000)
+                client = MongoClient(self._cluster_uri, serverSelectionTimeoutMS=5000, driver=_DRIVER_INFO)
                 # Test connection
                 client.admin.command("ping")
 
@@ -1068,7 +1078,7 @@ def mongodb_memory(
 
         # Initialize MongoDB client with secure error handling
         try:
-            client = MongoClient(cluster_uri, serverSelectionTimeoutMS=5000)
+            client = MongoClient(cluster_uri, serverSelectionTimeoutMS=5000, driver=_DRIVER_INFO)
             # Test connection
             client.admin.command("ping")
 

--- a/src/strands_tools/mongodb_memory.py
+++ b/src/strands_tools/mongodb_memory.py
@@ -108,7 +108,7 @@ try:
 except Exception:
     _VERSION = None
 
-_DRIVER_INFO = DriverInfo(name="Strands-Tools", version=_VERSION)
+_DRIVER_INFO = DriverInfo(name="Strands", version=_VERSION)
 
 
 # Custom exceptions for better error handling

--- a/tests/test_mongodb_memory.py
+++ b/tests/test_mongodb_memory.py
@@ -839,7 +839,7 @@ def test_driver_info_constant_name():
     """_DRIVER_INFO has the expected name."""
     from src.strands_tools.mongodb_memory import _DRIVER_INFO
 
-    assert _DRIVER_INFO.name == "Strands-Tools"
+    assert _DRIVER_INFO.name == "Strands"
 
 
 def test_standalone_monogclient_passes_driver_info(mock_mongodb_client):

--- a/tests/test_mongodb_memory.py
+++ b/tests/test_mongodb_memory.py
@@ -833,3 +833,35 @@ def test_class_namespace_falls_back_to_env(mock_mongodb_client, mock_bedrock_cli
 
     call_args = mock_mongodb_client["collection"].find_one.call_args[0]
     assert call_args[0] == {"memory_id": "mem_123", "namespace": "env_tenant"}
+
+
+def test_driver_info_constant_name():
+    """_DRIVER_INFO has the expected name."""
+    from src.strands_tools.mongodb_memory import _DRIVER_INFO
+
+    assert _DRIVER_INFO.name == "Strands-Tools"
+
+
+def test_standalone_monogclient_passes_driver_info(mock_mongodb_client):
+    """The standalone mongodb_memory function passes driver=_DRIVER_INFO to MongoClient."""
+    from src.strands_tools.mongodb_memory import _DRIVER_INFO
+
+    mongodb_memory(action="list")
+
+    _, kwargs = mock_mongodb_client["mongo_class"].call_args
+    assert kwargs.get("driver") is _DRIVER_INFO
+
+
+def test_class_tool_monogclient_passes_driver_info(mock_mongodb_client, mock_bedrock_client):
+    """MongoDBMemoryTool.mongodb_memory passes driver=_DRIVER_INFO to MongoClient."""
+    from src.strands_tools.mongodb_memory import _DRIVER_INFO
+
+    mock_mongodb_client["collection"].find.return_value.sort.return_value.skip.return_value.limit.return_value = []
+    mock_mongodb_client["collection"].count_documents.return_value = 0
+
+    tool = MongoDBMemoryTool(cluster_uri="mongodb+srv://test:test@cluster.mongodb.net/")
+    agent = Agent(tools=[tool.mongodb_memory])
+    agent.tool.mongodb_memory(action="list")
+
+    _, kwargs = mock_mongodb_client["mongo_class"].call_args
+    assert kwargs.get("driver") is _DRIVER_INFO


### PR DESCRIPTION
Adds `driver=DriverInfo(name="Strands", version=...)` to both `MongoClient` construction sites in `mongodb_memory.py`, so that MongoDB server-side telemetry (Atlas dashboards, `db.currentOp()`, `mongod` logs) can identify traffic from Strands Tools applications.

Changes:
* **`src/strands_tools/mongodb_memory.py`** — a module-level `_DRIVER_INFO` constant is defined using `DriverInfo` from `pymongo.driver_info`. The version is read at import time via `importlib.metadata` (falls back to `None` if unavailable, which is handled gracefully by PyMongo). The constant is passed as `driver=_DRIVER_INFO` at both `MongoClient(...)`
call sites: the `MongoDBMemoryTool` class method and the standalone `mongodb_memory` function.

This would produce a mongos/d log entry with details similar to the following:
> `{"t":{"$date":"2026-07-21T09:15:42.123+00:00"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn1","msg":"client metadata","attr":{"remote":"192.168.1.10:54321","client":"conn1","negotiatedCompressors":[],"doc":{"driver":{"name":"PyMongo|Strands","version":"4.9.2|0.1.0"},"os":{"type":"Darwin","name":"Darwin","architecture":"arm64","version":"26.5.2"},"platform":"CPython 3.10.3.final.0"}}}`

See the [MongoDB handshake specification](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md) for more info.