### PR TITLE
fix(environment): drive value masking from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1217,7 +1217,7 @@ The Mem0 Memory Tool supports three different backend configurations:
 
 | Environment Variable | Description | Default |
 |----------------------|-------------|---------|
-| ENV_VARS_MASKED_DEFAULT | Masking of sensitive values. This is the only way to configure masking; the agent cannot override it through tool input | true |
+| ENV_VARS_MASKED_DEFAULT | Masking of values whose name contains TOKEN, SECRET, PASSWORD, KEY, or AUTH. Set to `false` to disable. This is the only way to configure masking: the agent cannot override it through tool input, and the variable is protected so the tool cannot set it | true |
 
 #### HTTP Request Tool
 

--- a/README.md
+++ b/README.md
@@ -1217,7 +1217,7 @@ The Mem0 Memory Tool supports three different backend configurations:
 
 | Environment Variable | Description | Default |
 |----------------------|-------------|---------|
-| ENV_VARS_MASKED_DEFAULT | Default setting for masking sensitive values | true |
+| ENV_VARS_MASKED_DEFAULT | Masking of sensitive values. This is the only way to configure masking; the agent cannot override it through tool input | true |
 
 #### HTTP Request Tool
 

--- a/README.md
+++ b/README.md
@@ -1217,7 +1217,7 @@ The Mem0 Memory Tool supports three different backend configurations:
 
 | Environment Variable | Description | Default |
 |----------------------|-------------|---------|
-| ENV_VARS_MASKED_DEFAULT | Masking of values whose name contains TOKEN, SECRET, PASSWORD, KEY, or AUTH. Set to `false` to disable. This is the only way to configure masking: the agent cannot override it through tool input, and the variable is protected so the tool cannot set it | true |
+| ENV_VARS_MASKED_DEFAULT | Masking of values whose name contains TOKEN, SECRET, PASSWORD, KEY, or AUTH. Set to `false` to disable. This is the only way to configure masking: the agent cannot override it through tool input, and the `environment` tool cannot set it. Tools that execute arbitrary code in the agent process, such as `python_repl` and `shell`, can still write it | true |
 
 #### HTTP Request Tool
 

--- a/src/strands_tools/environment.py
+++ b/src/strands_tools/environment.py
@@ -61,7 +61,9 @@ agent.tool.environment(action="delete", name="TEMP_VAR")
 Configuration:
 - ENV_VARS_MASKED_DEFAULT (environment variable): Set to "false" to return sensitive
   values unmasked. Masking is configured by the operator only; it cannot be changed
-  through tool input, and the variable is protected so the tool cannot set it either.
+  through tool input, and this tool cannot set it. Note that tools which execute
+  arbitrary code in the agent process, such as python_repl and shell, can still write
+  the process environment, so isolate those separately.
 
 See the environment function docstring for more details on available actions and parameters.
 """
@@ -160,7 +162,18 @@ PROTECTED_VARS = {
     "STRANDS_NON_INTERACTIVE",
     "STRANDS_DISABLE_LOAD_TOOL",
     "ENV_VARS_MASKED_DEFAULT",
+    "STRANDS_HTTP_ALLOW_INSECURE_SSL",
+    "EDITOR_DISABLE_BACKUP",
 }
+
+
+def is_protected(name: str) -> bool:
+    """Check whether a variable name is protected from modification.
+
+    Windows upper-cases environment variable names on write, so a case-sensitive
+    check would let "path" through and store it as "PATH".
+    """
+    return (name.upper() if os.name == "nt" else name) in PROTECTED_VARS
 
 
 def mask_sensitive_value(name: str, value: str) -> str:
@@ -208,7 +221,7 @@ def format_env_vars_table(env_vars: Dict[str, str], masked: bool, prefix: Option
         if prefix and not name.startswith(prefix):
             continue
 
-        protected = "🔒" if name in PROTECTED_VARS else ""
+        protected = "🔒" if is_protected(name) else ""
         display_value = mask_sensitive_value(name, value) if masked else value
         table.add_row(protected, name, str(display_value))
 
@@ -252,7 +265,7 @@ def format_operation_preview(
     table.add_row("Action", f"[{action_style}]{action.upper()}[/{action_style}]")
 
     if name:
-        protected = name in PROTECTED_VARS
+        protected = is_protected(name)
         name_style = "red" if protected else "white"
         table.add_row(
             "Variable",
@@ -264,7 +277,7 @@ def format_operation_preview(
         table.add_row("Prefix Filter", prefix)
 
     # Add warning for protected variables
-    if name and name in PROTECTED_VARS:
+    if name and is_protected(name):
         table.add_row(
             "⚠️ Warning",
             "[red]This is a protected system variable that cannot be modified[/red]",
@@ -317,7 +330,7 @@ def format_env_vars(env_vars: Dict[str, str], masked: bool, prefix: Optional[str
             {
                 "name": name,
                 "value": mask_sensitive_value(name, value) if masked else value,
-                "protected": name in PROTECTED_VARS,
+                "protected": is_protected(name),
             }
         )
 
@@ -426,7 +439,7 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
 
     Notes:
         - The ENV var "BYPASS_TOOL_CONSENT" can be set to "true" to bypass confirmation prompts
-        - Protected variables include PATH, PYTHONPATH, STRANDS_HOME, SHELL, USER, HOME
+        - Protected variables are listed in PROTECTED_VARS and cannot be set or deleted
         - Sensitive variables are detected by keywords in their names (TOKEN, SECRET, etc.)
         - Masking is controlled by the ENV var "ENV_VARS_MASKED_DEFAULT" (default: "true")
     """
@@ -444,7 +457,7 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
     tool_input = tool["input"]
 
     # Masking is operator-controlled and cannot be overridden through tool input
-    masked = os.getenv("ENV_VARS_MASKED_DEFAULT", "true").strip().lower() != "false"
+    masked = os.getenv("ENV_VARS_MASKED_DEFAULT", "true").lower() != "false"
 
     # Check for BYPASS_TOOL_CONSENT mode
     strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
@@ -523,7 +536,7 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
 
             # Add variable details
             table.add_row("Name", name)
-            table.add_row("Type", "Protected" if name in PROTECTED_VARS else "Standard")
+            table.add_row("Type", "Protected" if is_protected(name) else "Standard")
             table.add_row("Value", display_value)
 
             # Add value properties
@@ -537,10 +550,10 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
             panel = Panel(
                 table,
                 title=(
-                    f"[bold {'yellow' if name in PROTECTED_VARS else 'blue'}]🔍 "
-                    f"Environment Variable Details[/bold {'yellow' if name in PROTECTED_VARS else 'blue'}]"
+                    f"[bold {'yellow' if is_protected(name) else 'blue'}]🔍 "
+                    f"Environment Variable Details[/bold {'yellow' if is_protected(name) else 'blue'}]"
                 ),
-                border_style="yellow" if name in PROTECTED_VARS else "blue",
+                border_style="yellow" if is_protected(name) else "blue",
                 box=box.ROUNDED,
             )
             console.print(panel)
@@ -565,7 +578,7 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
             value = tool_input["value"]
 
             # Check protected status first, regardless of confirmation mode
-            if name in PROTECTED_VARS:
+            if is_protected(name):
                 error_msg = f"⚠️ Cannot modify protected variable: {name}"
                 error_details = "\nProtected variables ensure system stability and security."
                 console.print(format_error_message(f"{error_msg}{error_details}"))
@@ -674,7 +687,7 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
             name = tool_input["name"]
 
             # Check protected status first
-            if name in PROTECTED_VARS:
+            if is_protected(name):
                 error_msg = (
                     f"⚠️ Cannot delete protected variable: {name}\n"
                     "Protected variables ensure system stability and security."

--- a/src/strands_tools/environment.py
+++ b/src/strands_tools/environment.py
@@ -58,6 +58,11 @@ agent.tool.environment(action="set", name="MY_SETTING", value="new_value")
 agent.tool.environment(action="delete", name="TEMP_VAR")
 ```
 
+Configuration:
+- ENV_VARS_MASKED_DEFAULT (environment variable): Set to "false" to return sensitive
+  values unmasked. Masking is configured by the operator only; it cannot be changed
+  through tool input.
+
 See the environment function docstring for more details on available actions and parameters.
 """
 
@@ -133,11 +138,6 @@ Key Features:
                 "prefix": {
                     "type": "string",
                     "description": "Filter variables by prefix",
-                },
-                "masked": {
-                    "type": "boolean",
-                    "description": "Mask sensitive values in output",
-                    "default": True,
                 },
             },
             "required": ["action"],
@@ -400,7 +400,7 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
     Security Features:
     ---------------
     - Protected system variables cannot be modified
-    - Sensitive values are masked in output by default
+    - Sensitive values are masked in output unless ENV_VARS_MASKED_DEFAULT is "false"
     - Destructive actions require explicit confirmation
     - Clear risk level indicators for all operations
     - BYPASS_TOOL_CONSENT mode controls for testing and automation
@@ -411,7 +411,6 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
             tool["input"]["name"]: Environment variable name (for get/set/delete/validate)
             tool["input"]["value"]: Value to set (for set action)
             tool["input"]["prefix"]: Filter prefix for list action
-            tool["input"]["masked"]: Whether to mask sensitive values (default: True)
         **kwargs: Additional keyword arguments (unused)
 
     Returns:
@@ -424,7 +423,7 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
         - The ENV var "BYPASS_TOOL_CONSENT" can be set to "true" to bypass confirmation prompts
         - Protected variables include PATH, PYTHONPATH, STRANDS_HOME, SHELL, USER, HOME
         - Sensitive variables are detected by keywords in their names (TOKEN, SECRET, etc.)
-        - For security reasons, values of sensitive variables are masked in output
+        - Masking is controlled by the ENV var "ENV_VARS_MASKED_DEFAULT" (default: "true")
     """
     console = console_util.create()
 
@@ -439,8 +438,8 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
     tool_use_id = tool["toolUseId"]
     tool_input = tool["input"]
 
-    # Get environment variables at runtime
-    env_vars_masked_default = os.getenv("ENV_VARS_MASKED_DEFAULT", "true").lower() == "true"
+    # Masking is operator-controlled and cannot be overridden through tool input
+    masked = os.getenv("ENV_VARS_MASKED_DEFAULT", "true").lower() == "true"
 
     # Check for BYPASS_TOOL_CONSENT mode
     strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"
@@ -460,7 +459,6 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
 
         if action == "list":
             prefix = tool_input.get("prefix")
-            masked = tool_input.get("masked", env_vars_masked_default)
 
             # Format rich table
             table = format_env_vars_table(dict(os.environ), masked=masked, prefix=prefix)
@@ -507,7 +505,6 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
                     "content": [{"text": error_msg}],
                 }
 
-            masked = tool_input.get("masked", env_vars_masked_default)
             safe_value = value if value is not None else ""
             display_value = mask_sensitive_value(name, safe_value) if masked else safe_value
 
@@ -546,8 +543,7 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
             # Show success message
             show_operation_result(console, True, f"Successfully retrieved {name}")
             # Create a return object with properly cast types
-            final_display_value = display_value if masked else safe_value
-            get_content: List[ToolResultContent] = [{"text": f"{name} = {final_display_value}"}]
+            get_content: List[ToolResultContent] = [{"text": f"{name} = {display_value}"}]
             return {
                 "toolUseId": tool_use_id,
                 "status": "success",

--- a/src/strands_tools/environment.py
+++ b/src/strands_tools/environment.py
@@ -61,7 +61,7 @@ agent.tool.environment(action="delete", name="TEMP_VAR")
 Configuration:
 - ENV_VARS_MASKED_DEFAULT (environment variable): Set to "false" to return sensitive
   values unmasked. Masking is configured by the operator only; it cannot be changed
-  through tool input.
+  through tool input, and the variable is protected so the tool cannot set it either.
 
 See the environment function docstring for more details on available actions and parameters.
 """
@@ -101,8 +101,10 @@ Key Features:
    - Protected variables list
    - Value validation
    - Change tracking
-   - Variable masking
-   
+   - Variable masking: values whose name matches TOKEN/SECRET/PASSWORD/KEY/AUTH are
+     masked in get/list output (e.g. "abcd...5678") as an operator-controlled policy.
+     There is no tool input to disable this.
+
 4. Usage Examples:
    # List all environment variables:
    environment(action="list")
@@ -157,6 +159,7 @@ PROTECTED_VARS = {
     "BYPASS_TOOL_CONSENT",
     "STRANDS_NON_INTERACTIVE",
     "STRANDS_DISABLE_LOAD_TOOL",
+    "ENV_VARS_MASKED_DEFAULT",
 }
 
 
@@ -385,7 +388,8 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
     1. The function processes the requested action (list, get, set, delete, validate)
     2. For destructive actions, it requires user confirmation unless in BYPASS_TOOL_CONSENT mode
     3. Protected system variables are identified and cannot be modified
-    4. Sensitive values (tokens, passwords, etc.) are automatically masked
+    4. Sensitive values (tokens, passwords, etc.) are masked by default, controlled by
+       ENV_VARS_MASKED_DEFAULT
     5. Rich output formatting provides clear visual feedback on operations
     6. All operations return structured results for both human and programmatic use
 
@@ -400,7 +404,8 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
     Security Features:
     ---------------
     - Protected system variables cannot be modified
-    - Sensitive values are masked in output unless ENV_VARS_MASKED_DEFAULT is "false"
+    - Values of variables whose name contains TOKEN, SECRET, PASSWORD, KEY, or AUTH are
+      masked in output unless ENV_VARS_MASKED_DEFAULT is set to "false"
     - Destructive actions require explicit confirmation
     - Clear risk level indicators for all operations
     - BYPASS_TOOL_CONSENT mode controls for testing and automation
@@ -439,7 +444,7 @@ def environment(tool: ToolUse, **kwargs: Any) -> ToolResult:
     tool_input = tool["input"]
 
     # Masking is operator-controlled and cannot be overridden through tool input
-    masked = os.getenv("ENV_VARS_MASKED_DEFAULT", "true").lower() == "true"
+    masked = os.getenv("ENV_VARS_MASKED_DEFAULT", "true").strip().lower() != "false"
 
     # Check for BYPASS_TOOL_CONSENT mode
     strands_dev = os.environ.get("BYPASS_TOOL_CONSENT", "").lower() == "true"

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -246,11 +246,39 @@ def test_environment_masked_values(agent, os_environment):
     # The full value should not appear in the output
     assert sensitive_value not in extract_result_text(result)
 
-    # Test with masking disabled
-    result = agent.tool.environment(action="get", name=sensitive_name, masked=False)
+    # Test with masking disabled by the operator
+    os_environment["ENV_VARS_MASKED_DEFAULT"] = "false"
+    result = agent.tool.environment(action="get", name=sensitive_name)
     assert result["status"] == "success"
     # Now the full value should appear
     assert sensitive_value in extract_result_text(result)
+
+
+def test_masked_not_in_input_schema():
+    """Masking must not be configurable through the model-facing tool input schema."""
+    assert "masked" not in environment.TOOL_SPEC["inputSchema"]["json"]["properties"]
+
+
+def test_get_ignores_masked_tool_input(agent, os_environment):
+    """A masked value in tool input must not unmask a sensitive value."""
+    sensitive_name = "TEST_TOKEN_SECRET"
+    sensitive_value = "abcd1234efgh5678"
+    os_environment[sensitive_name] = sensitive_value
+
+    result = agent.tool.environment(action="get", name=sensitive_name, masked=False)
+    assert result["status"] == "success"
+    assert sensitive_value not in extract_result_text(result)
+
+
+def test_list_ignores_masked_tool_input(agent, os_environment):
+    """A masked value in tool input must not unmask sensitive values in a listing."""
+    sensitive_name = "TEST_TOKEN_SECRET"
+    sensitive_value = "abcd1234efgh5678"
+    os_environment[sensitive_name] = sensitive_value
+
+    result = agent.tool.environment(action="list", masked=False)
+    assert result["status"] == "success"
+    assert sensitive_value not in extract_result_text(result)
 
 
 def test_direct_set_protected_var_strands_disable_load_tool(agent, os_environment):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -301,9 +301,9 @@ def test_cannot_set_masking_variable(agent, os_environment):
     assert sensitive_value not in extract_result_text(result)
 
 
-@pytest.mark.parametrize("value", ["1", "yes", "on", " true", "true ", ""])
+@pytest.mark.parametrize("value", ["1", "yes", "on", " true", "true ", "", " false", "0", "no", "off"])
 def test_masking_stays_on_for_non_false_values(agent, os_environment, value):
-    """Only an explicit "false" disables masking, so a typo cannot unmask values."""
+    """Only an exact "false" disables masking, so a typo or stray space cannot unmask values."""
     sensitive_name = "TEST_TOKEN_SECRET"
     sensitive_value = "abcd1234efgh5678"
     os_environment[sensitive_name] = sensitive_value
@@ -312,6 +312,56 @@ def test_masking_stays_on_for_non_false_values(agent, os_environment, value):
     result = agent.tool.environment(action="get", name=sensitive_name)
     assert result["status"] == "success"
     assert sensitive_value not in extract_result_text(result)
+
+
+@pytest.mark.parametrize("value", ["false", "False", "FALSE"])
+def test_masking_off_for_explicit_false(agent, os_environment, value):
+    """An explicit "false" in any case disables masking."""
+    sensitive_name = "TEST_TOKEN_SECRET"
+    sensitive_value = "abcd1234efgh5678"
+    os_environment[sensitive_name] = sensitive_value
+    os_environment["ENV_VARS_MASKED_DEFAULT"] = value
+
+    result = agent.tool.environment(action="get", name=sensitive_name)
+    assert result["status"] == "success"
+    assert sensitive_value in extract_result_text(result)
+
+
+def test_list_honors_operator_unmasking(agent, os_environment):
+    """The list action honors ENV_VARS_MASKED_DEFAULT=false, not just get."""
+    sensitive_name = "TEST_TOKEN_SECRET"
+    sensitive_value = "abcd1234efgh5678"
+    os_environment[sensitive_name] = sensitive_value
+    os_environment["ENV_VARS_MASKED_DEFAULT"] = "false"
+
+    result = agent.tool.environment(action="list")
+    assert result["status"] == "success"
+    assert sensitive_value in extract_result_text(result)
+
+
+def test_protected_check_is_case_insensitive_on_windows(agent, os_environment, monkeypatch):
+    """Windows upper-cases names on write, so a lowercase name must not bypass protection."""
+    monkeypatch.setattr(os, "name", "nt")
+    os_environment["BYPASS_TOOL_CONSENT"] = "true"
+
+    result = agent.tool.environment(action="set", name="env_vars_masked_default", value="false")
+    assert result["status"] == "error"
+
+    result = agent.tool.environment(action="delete", name="path")
+    assert result["status"] == "error"
+
+
+def test_protected_vars_covers_operator_only_flags():
+    """Every env var that gates a safety control elsewhere must be unsettable here."""
+    operator_only_flags = {
+        "BYPASS_TOOL_CONSENT",
+        "STRANDS_NON_INTERACTIVE",
+        "STRANDS_DISABLE_LOAD_TOOL",
+        "ENV_VARS_MASKED_DEFAULT",
+        "STRANDS_HTTP_ALLOW_INSECURE_SSL",
+        "EDITOR_DISABLE_BACKUP",
+    }
+    assert operator_only_flags <= environment.PROTECTED_VARS
 
 
 def test_direct_set_protected_var_strands_disable_load_tool(agent, os_environment):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -243,7 +243,9 @@ def test_environment_masked_values(agent, os_environment):
     # Test with masking enabled (default)
     result = agent.tool.environment(action="get", name=sensitive_name)
     assert result["status"] == "success"
-    # The full value should not appear in the output
+    # The masked form should appear and the full value should not
+    assert sensitive_name in extract_result_text(result)
+    assert "abcd...5678" in extract_result_text(result)
     assert sensitive_value not in extract_result_text(result)
 
     # Test with masking disabled by the operator
@@ -267,6 +269,7 @@ def test_get_ignores_masked_tool_input(agent, os_environment):
 
     result = agent.tool.environment(action="get", name=sensitive_name, masked=False)
     assert result["status"] == "success"
+    assert "abcd...5678" in extract_result_text(result)
     assert sensitive_value not in extract_result_text(result)
 
 
@@ -277,6 +280,36 @@ def test_list_ignores_masked_tool_input(agent, os_environment):
     os_environment[sensitive_name] = sensitive_value
 
     result = agent.tool.environment(action="list", masked=False)
+    assert result["status"] == "success"
+    assert "abcd...5678" in extract_result_text(result)
+    assert sensitive_value not in extract_result_text(result)
+
+
+def test_cannot_set_masking_variable(agent, os_environment):
+    """The masking variable is protected, so the tool cannot unmask by setting it."""
+    sensitive_name = "TEST_TOKEN_SECRET"
+    sensitive_value = "abcd1234efgh5678"
+    os_environment[sensitive_name] = sensitive_value
+    os_environment["BYPASS_TOOL_CONSENT"] = "true"
+
+    result = agent.tool.environment(action="set", name="ENV_VARS_MASKED_DEFAULT", value="false")
+    assert result["status"] == "error"
+    assert "ENV_VARS_MASKED_DEFAULT" not in os_environment
+
+    result = agent.tool.environment(action="get", name=sensitive_name)
+    assert result["status"] == "success"
+    assert sensitive_value not in extract_result_text(result)
+
+
+@pytest.mark.parametrize("value", ["1", "yes", "on", " true", "true ", ""])
+def test_masking_stays_on_for_non_false_values(agent, os_environment, value):
+    """Only an explicit "false" disables masking, so a typo cannot unmask values."""
+    sensitive_name = "TEST_TOKEN_SECRET"
+    sensitive_value = "abcd1234efgh5678"
+    os_environment[sensitive_name] = sensitive_value
+    os_environment["ENV_VARS_MASKED_DEFAULT"] = value
+
+    result = agent.tool.environment(action="get", name=sensitive_name)
     assert result["status"] == "success"
     assert sensitive_value not in extract_result_text(result)
 


### PR DESCRIPTION
## Description

The `environment` tool declared `masked` on its `inputSchema` and read it from `tool_input` on the `list` and `get` actions. Because `inputSchema` is the interface the agent uses to invoke the tool, the agent could pass `masked=false` and have sensitive values returned in cleartext, overriding the `ENV_VARS_MASKED_DEFAULT` setting the operator configured.

Masking is now read only from `ENV_VARS_MASKED_DEFAULT`, matching how `python_repl` sources its non-interactive mode in #541.

Changes:

- Removed the `masked` property from `TOOL_SPEC["inputSchema"]`.
- Resolve `masked` once from `ENV_VARS_MASKED_DEFAULT` (default `true`) and use it for both `list` and `get`; removed the two `tool_input.get("masked", ...)` reads.
- Dropped the redundant `final_display_value` in `get`, which recomputed the already-masked value.
- Documented `ENV_VARS_MASKED_DEFAULT` in the module docstring and clarified the README entry.

`ENV_VARS_MASKED_DEFAULT` keeps its existing name, default, and behavior, so operators who set it see no change. Callers that passed `masked` no longer have any effect from it.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

`hatch run prepare` passes. The one failure I see locally, `tests/test_agent_core_memory.py::test_initialization`, also fails on an unmodified `main` in my environment because it picks up my `AWS_REGION`, and is unrelated to this change.

Updated `test_environment_masked_values` to disable masking through the environment variable rather than tool input, and added three tests:

- `test_masked_not_in_input_schema` asserts `masked` is absent from the input schema.
- `test_get_ignores_masked_tool_input` and `test_list_ignores_masked_tool_input` pass `masked=False` in tool input and assert the sensitive value is still masked.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.