### PR TITLE
docs: note that tools are experimental and require an independent security review

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Strands Agents Tools is a community-driven project that provides a powerful set 
 - 📰 **RSS Feed Manager** - Subscribe, fetch, and process RSS feeds with content filtering and persistent storage
 - 🖱️ **Computer Tool** - Automate desktop actions including mouse movements, keyboard input, screenshots, and application management
 
+> [!IMPORTANT]
+> **The tools in this repository are experimental.** Many of them grant agents powerful capabilities — executing code, accessing the file system, calling AWS APIs, connecting to external servers, and automating browsers and desktops — which carry real security implications. Any production use should be preceded by your own independent security review; see the [Responsible AI guidance](https://strandsagents.com/docs/user-guide/safety-security/responsible-ai/) for best practices. Use of these tools is at your own risk.
+
 ## 📦 Installation
 
 ### Quick Install
@@ -1345,4 +1348,8 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 ## Security
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+The tools in this repository are experimental and are provided as-is. Any production use should be preceded by an independent security review of the specific tools you enable.
+
+For guidance on building and deploying agents safely, see [Responsible AI](https://strandsagents.com/docs/user-guide/safety-security/responsible-ai/) in the Strands Agents documentation.
+
+To report a security issue, see [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.


### PR DESCRIPTION
## Description

Adds a notice to the README stating that the tools in this repository are experimental, and that any production use should be preceded by an independent security review.

Two changes:

1. **A callout between Features and Installation** — placed so it reads immediately after the reader sees the breadth of capabilities on offer, and before they install anything. It names the capability classes that carry security weight (code execution, file system access, AWS APIs, external servers, browser/desktop automation) and points to the [Responsible AI guidance](https://strandsagents.com/docs/user-guide/safety-security/responsible-ai/).

2. **An expanded `## Security` section** — previously a single line pointing to CONTRIBUTING. It now states the experimental/independent-review position, links the Responsible AI page, and keeps the existing pointer for reporting vulnerabilities.

No functional changes; existing per-tool warnings (e.g. `mcp_client`) are untouched.

## Related Issues

N/A

## Documentation PR

N/A — the Responsible AI page this links to already exists in the docs.

## Type of Change

Documentation update

## Testing

Documentation-only change to `README.md`; no code paths are affected. Verified the linked Responsible AI URL resolves, and that the rendered Markdown (GitHub `[!IMPORTANT]` alert syntax, matching the callout style already used elsewhere in the docs) is well-formed.

- [ ] I ran `hatch run prepare` — not run; no Python source, tests, or dependencies are touched by this change.

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works — N/A for a documentation change
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature — N/A, no new feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.