### PR TITLE
ci(integ): opt in to allow-unsafe-pr-checkout on fork PR checkout

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -123,6 +123,16 @@ jobs:
           # pull_request_target pull the PR head from the forked repo.
           ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
           persist-credentials: false  # Don't persist credentials for subsequent actions
+          # Checking out fork code under pull_request_target is a "pwn request"
+          # risk, so checkout refuses it unless opted in. The opt-in is safe here
+          # only because of the gates above: authorization-check routes any author
+          # without write access to the `manual-approval` environment, which
+          # requires a maintainer to review the diff before this job starts, and
+          # every later push re-triggers the workflow so the approval cannot be
+          # bypassed by pushing after review. On the workflow_call path,
+          # validate-call-ref rejects fork-shaped refs outright.
+          # Removing either gate re-opens the vulnerability this flag suppresses.
+          allow-unsafe-pr-checkout: true
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary

`actions/checkout` v4.4.0 (released 2026-07-20, and what the floating `v4` tag now resolves to) added a guard that refuses to check out fork PR code from a `pull_request_target` workflow. Every `integration-test.yml` run since 2026-07-21 has failed at the checkout step with:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow. […] To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

This sets `allow-unsafe-pr-checkout: true` on that step, plus a comment explaining which existing gates make the opt-in safe.

## Why the opt-in is acceptable here

The guard protects against "pwn request": fork code executing with the base repo's secrets. This workflow already gates that, which is why the flag is the right fix rather than a workaround:

- `authorization-check` looks up the PR author's permission and routes anyone without `write`/`admin` to the `manual-approval` environment, which has `maintainers` as required reviewers — a maintainer must review the diff before the checkout job starts.
- Because `pull_request_target` fires on `synchronize`, a later push re-triggers the workflow and requires approval again, so review cannot be bypassed by pushing post-approval.
- On the `workflow_call` (release) path, `validate-call-ref` rejects fork-shaped refs outright.


## Test plan

- [x] Confirmed the failure cause in the logs of run for #543 (`allow-unsafe-pr-checkout: false` → guard error)
- [x] Verified `actions/checkout@v4` currently resolves to v4.4.0, which contains the guard
- [x] Confirmed `manual-approval` and `release-gate` environments have `maintainers` as required reviewers
- [x] Validated the workflow YAML parses and the input lands on the checkout step
- [ ] Integration tests reach and pass the checkout step on this PR (this PR is itself the test case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)