### PR TITLE
feat: deprecate sleep, editor, and shell in favor of SDK vended tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ Deprecated tools keep working. Each one logs a warning when invoked starting in 
 and that warning becomes an error log in **v0.9.0** — a louder signal for anyone who has not
 migrated, not a behavior change.
 
+They are also marked with `@typing_extensions.deprecated`, so type checkers and IDEs flag
+call sites before you run anything. Note that Python suppresses the resulting
+`DeprecationWarning` at runtime when the agent invokes a tool, which is why the log message
+exists as well.
+
 | Tool | Replacement | Warning | Error log |
 |------|-------------|---------|-----------|
 | `sleep` | `from strands.vended_tools import sleep` | v0.8.6 | v0.9.0 |

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Below is a comprehensive table of all available tools, how to use them with an a
 | a2a_client | `provider = A2AClientToolProvider(known_agent_urls=["http://localhost:9000"]); agent = Agent(tools=provider.tools)` | Discover and communicate with A2A-compliant agents, send messages between agents |
 | file_read | `agent.tool.file_read(path="path/to/file.txt")` | Reading configuration files, parsing code files, loading datasets |
 | file_write | `agent.tool.file_write(path="path/to/file.txt", content="file content")` | Writing results to files, creating new files, saving output data |
-| editor | `agent.tool.editor(command="view", path="path/to/file.py")` | Advanced file operations like syntax highlighting, pattern replacement, and multi-file edits |
-| shell* | `agent.tool.shell(command="ls -la")` | Executing shell commands, interacting with the operating system, running scripts |
+| editor ⚠️ | `agent.tool.editor(command="view", path="path/to/file.py")` | Advanced file operations like syntax highlighting, pattern replacement, and multi-file edits <br> **Deprecated — see [Deprecations](#deprecations)** |
+| shell* ⚠️ | `agent.tool.shell(command="ls -la")` | Executing shell commands, interacting with the operating system, running scripts <br> **Deprecated — see [Deprecations](#deprecations)** |
 | http_request | `agent.tool.http_request(method="GET", url="https://api.example.com/data")` | Making API calls, fetching web data, sending data to external services |
 | tavily_search | `agent.tool.tavily_search(query="What is artificial intelligence?", search_depth="advanced")` | Real-time web search optimized for AI agents with a variety of custom parameters |
 | tavily_extract | `agent.tool.tavily_extract(urls=["www.tavily.com"], extract_depth="advanced")` | Extract clean, structured content from web pages with advanced processing and noise removal |
@@ -135,7 +135,7 @@ Below is a comprehensive table of all available tools, how to use them with an a
 | load_tool | `agent.tool.load_tool(path="path/to/custom_tool.py", name="custom_tool")` | Dynamically loading custom tools and extensions |
 | swarm | `agent.tool.swarm(task="Analyze this problem", swarm_size=3, coordination_pattern="collaborative")` | Coordinating multiple AI agents to solve complex problems through collective intelligence |
 | current_time | `agent.tool.current_time(timezone="US/Pacific")` | Get the current time in ISO 8601 format for a specified timezone |
-| sleep | `agent.tool.sleep(seconds=5)` | Pause execution for the specified number of seconds, interruptible with SIGINT (Ctrl+C) |
+| sleep ⚠️ | `agent.tool.sleep(seconds=5)` | Pause execution for the specified number of seconds, interruptible with SIGINT (Ctrl+C) <br> **Deprecated — see [Deprecations](#deprecations)** |
 | agent_graph | `agent.tool.agent_graph(agents=["agent1", "agent2"], connections=[{"from": "agent1", "to": "agent2"}])` | Create and visualize agent relationship graphs for complex multi-agent systems |
 | graph | `agent.tool.graph(action="create", graph_id="pipeline", topology={"nodes": [...], "edges": [...]})` | Create and manage deterministic DAG-based multi-agent graphs using Strands SDK Graph implementation with per-node model configuration |
 | cron* | `agent.tool.cron(action="schedule", name="task", schedule="0 * * * *", command="backup.sh")` | Schedule and manage recurring tasks with cron job syntax <br> **Does not work on Windows |
@@ -158,6 +158,49 @@ Below is a comprehensive table of all available tools, how to use them with an a
 | elasticsearch_memory | `agent.tool.elasticsearch_memory(action="record", content="User prefers dark mode")` | Store and retrieve memories using Elasticsearch with semantic search via AWS Bedrock Titan embeddings (connection and namespace configured via `ElasticsearchMemoryTool` or environment variables) |
 
 \* *These tools do not work on Windows*
+
+### Deprecations
+
+The Strands SDK now vends equivalents of the tools below from `strands.vended_tools`. To
+avoid maintaining two implementations that drift apart, these tools are deprecated here and
+users should migrate to the SDK versions.
+
+Each deprecated tool logs a warning when invoked, starting in **v0.8.6**. They are removed
+in **v0.9.0**.
+
+| Tool | Replacement | Warning added | Removed |
+|------|-------------|---------------|---------|
+| `sleep` | `from strands.vended_tools import sleep` | v0.8.6 | v0.9.0 |
+| `editor` | `from strands.vended_tools import file_editor` | v0.8.6 | v0.9.0 |
+| `shell` | `from strands.vended_tools import shell` | v0.8.6 | v0.9.0 |
+
+```python
+# Before
+from strands import Agent
+from strands_tools import editor, shell, sleep
+
+agent = Agent(tools=[editor, shell, sleep])
+
+# After
+from strands import Agent
+from strands.vended_tools import file_editor, shell, sleep
+
+agent = Agent(tools=[file_editor, shell, sleep])
+```
+
+#### Behavior differences
+
+The replacements are not drop-in equivalents. Check these before migrating:
+
+- **`shell` → `shell`**: the SDK tool routes commands through the agent's configured
+  sandbox and is stateless — each call runs in a fresh shell, so variables and the working
+  directory do not persist between calls. It does not provide PTY support or batched
+  parallel/sequential command execution.
+- **`editor` → `file_editor`**: supports `view`, `create`, `str_replace`, and `insert`. The
+  `pattern_replace`, `find_line`, and `undo_edit` commands have no SDK equivalent.
+- **`sleep` → `sleep`**: the maximum duration is set with
+  `make_sleep(max_duration=...)` and defaults to 60 seconds, replacing the
+  `MAX_SLEEP_SECONDS` environment variable which defaulted to 300 seconds.
 
 ## 💻 Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -165,11 +165,16 @@ The Strands SDK now vends equivalents of the tools below from `strands.vended_to
 avoid maintaining two implementations that drift apart, these tools are deprecated here and
 users should migrate to the SDK versions.
 
-Each deprecated tool logs a warning when invoked, starting in **v0.8.6**. They are removed
-in **v0.9.0**.
+These are the first of an ongoing set of deprecations. As more tools gain SDK equivalents
+they will be deprecated the same way, and this repository will eventually be archived.
+Migrating when a tool is first deprecated avoids a larger move later.
 
-| Tool | Replacement | Warning added | Removed |
-|------|-------------|---------------|---------|
+Deprecated tools keep working. Each one logs a warning when invoked starting in **v0.8.6**,
+and that warning becomes an error log in **v0.9.0** — a louder signal for anyone who has not
+migrated, not a behavior change.
+
+| Tool | Replacement | Warning | Error log |
+|------|-------------|---------|-----------|
 | `sleep` | `from strands.vended_tools import sleep` | v0.8.6 | v0.9.0 |
 | `editor` | `from strands.vended_tools import file_editor` | v0.8.6 | v0.9.0 |
 | `shell` | `from strands.vended_tools import shell` | v0.8.6 | v0.9.0 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
     "markdownify>=1.0.0,<2.0.0",
     "requests>=2.28.0,<3.0.0",
     "aiohttp>=3.8.0,<4.0.0",
-    "typing_extensions>=4.0.0,<5.0.0",
+    # 4.5.0 introduced typing_extensions.deprecated, used to mark deprecated tools
+    "typing_extensions>=4.5.0,<5.0.0",
     # Note: Always want the latest tzdata
     "tzdata ; platform_system == 'Windows'",
     "botocore>=1.39.7,<2.0.0",

--- a/src/strands_tools/editor.py
+++ b/src/strands_tools/editor.py
@@ -315,7 +315,7 @@ def editor(
            editor(command="undo_edit", path="/path/to/file.py")
     """
     logger.warning(
-        "DEPRECATION WARNING: editor is deprecated and will be removed in v0.9.0. "
+        "DEPRECATION WARNING: editor is deprecated. This warning becomes an error log in v0.9.0. "
         "Migration path: use the file_editor tool vended by strands-agents "
         "(from strands.vended_tools import file_editor)."
     )

--- a/src/strands_tools/editor.py
+++ b/src/strands_tools/editor.py
@@ -81,12 +81,19 @@ from rich.table import Table
 from rich.text import Text
 from rich.tree import Tree
 from strands import tool
+from typing_extensions import deprecated
 
 from strands_tools.utils import console_util
 from strands_tools.utils.detect_language import detect_language
 from strands_tools.utils.user_input import get_user_input
 
 logger = logging.getLogger(__name__)
+
+_DEPRECATION_MESSAGE = (
+    "editor is deprecated. This warning becomes an error log in v0.9.0. "
+    "Migration path: use the file_editor tool vended by strands-agents "
+    "(from strands.vended_tools import file_editor)."
+)
 
 # Global content history cache
 CONTENT_HISTORY = {}
@@ -183,7 +190,11 @@ def format_output(title: str, content: Any, style: str = "default") -> Panel:
     return panel
 
 
+# @deprecated surfaces in IDEs and type checkers; the logger.warning below is what
+# users actually see, since DeprecationWarning raised from inside the SDK's tool
+# invocation path is suppressed by Python's default warning filter.
 @tool
+@deprecated(_DEPRECATION_MESSAGE)
 def editor(
     command: str,
     path: str,
@@ -314,11 +325,7 @@ def editor(
         7. Undo recent change:
            editor(command="undo_edit", path="/path/to/file.py")
     """
-    logger.warning(
-        "DEPRECATION WARNING: editor is deprecated. This warning becomes an error log in v0.9.0. "
-        "Migration path: use the file_editor tool vended by strands-agents "
-        "(from strands.vended_tools import file_editor)."
-    )
+    logger.warning("DEPRECATION WARNING: %s", _DEPRECATION_MESSAGE)
 
     console = console_util.create()
 

--- a/src/strands_tools/editor.py
+++ b/src/strands_tools/editor.py
@@ -68,6 +68,7 @@ agent.tool.editor(command="undo_edit", path="/path/to/file.py")
 See the editor function docstring for more details on available commands and parameters.
 """
 
+import logging
 import os
 import re
 import shutil
@@ -84,6 +85,8 @@ from strands import tool
 from strands_tools.utils import console_util
 from strands_tools.utils.detect_language import detect_language
 from strands_tools.utils.user_input import get_user_input
+
+logger = logging.getLogger(__name__)
 
 # Global content history cache
 CONTENT_HISTORY = {}
@@ -311,6 +314,12 @@ def editor(
         7. Undo recent change:
            editor(command="undo_edit", path="/path/to/file.py")
     """
+    logger.warning(
+        "DEPRECATION WARNING: editor is deprecated and will be removed in v0.9.0. "
+        "Migration path: use the file_editor tool vended by strands-agents "
+        "(from strands.vended_tools import file_editor)."
+    )
+
     console = console_util.create()
 
     try:

--- a/src/strands_tools/shell.py
+++ b/src/strands_tools/shell.py
@@ -67,12 +67,19 @@ from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.table import Table
 from strands import tool
+from typing_extensions import deprecated
 
 from strands_tools.utils import console_util
 from strands_tools.utils.user_input import get_user_input
 
 # Initialize logging
 logger = logging.getLogger(__name__)
+
+_DEPRECATION_MESSAGE = (
+    "shell is deprecated. This warning becomes an error log in v0.9.0. "
+    "Migration path: use the shell tool vended by strands-agents "
+    "(from strands.vended_tools import shell)."
+)
 
 
 def read_output(fd: int) -> str:
@@ -409,7 +416,11 @@ def format_summary(results: List[Dict[str, Any]], parallel: bool) -> Panel:
     )
 
 
+# @deprecated surfaces in IDEs and type checkers; the logger.warning below is what
+# users actually see, since DeprecationWarning raised from inside the SDK's tool
+# invocation path is suppressed by Python's default warning filter.
 @tool
+@deprecated(_DEPRECATION_MESSAGE)
 def shell(
     command: Union[str, List[Union[str, Dict[str, Any]]]],
     parallel: bool = False,
@@ -485,11 +496,7 @@ def shell(
     Returns:
         Dict containing status and response content
     """
-    logger.warning(
-        "DEPRECATION WARNING: shell is deprecated. This warning becomes an error log in v0.9.0. "
-        "Migration path: use the shell tool vended by strands-agents "
-        "(from strands.vended_tools import shell)."
-    )
+    logger.warning("DEPRECATION WARNING: %s", _DEPRECATION_MESSAGE)
 
     console = console_util.create()
 

--- a/src/strands_tools/shell.py
+++ b/src/strands_tools/shell.py
@@ -485,6 +485,12 @@ def shell(
     Returns:
         Dict containing status and response content
     """
+    logger.warning(
+        "DEPRECATION WARNING: shell is deprecated and will be removed in v0.9.0. "
+        "Migration path: use the shell tool vended by strands-agents "
+        "(from strands.vended_tools import shell)."
+    )
+
     console = console_util.create()
 
     non_interactive_mode = os.environ.get("STRANDS_NON_INTERACTIVE", "").lower() == "true"

--- a/src/strands_tools/shell.py
+++ b/src/strands_tools/shell.py
@@ -486,7 +486,7 @@ def shell(
         Dict containing status and response content
     """
     logger.warning(
-        "DEPRECATION WARNING: shell is deprecated and will be removed in v0.9.0. "
+        "DEPRECATION WARNING: shell is deprecated. This warning becomes an error log in v0.9.0. "
         "Migration path: use the shell tool vended by strands-agents "
         "(from strands.vended_tools import shell)."
     )

--- a/src/strands_tools/sleep.py
+++ b/src/strands_tools/sleep.py
@@ -1,9 +1,12 @@
+import logging
 import os
 import time
 from datetime import datetime
 from typing import Union
 
 from strands import tool
+
+logger = logging.getLogger(__name__)
 
 # Default maximum sleep time (5 minutes)
 max_sleep_seconds = int(os.environ.get("MAX_SLEEP_SECONDS", "300"))
@@ -37,6 +40,12 @@ def sleep(seconds: Union[int, float]) -> str:
         >>> sleep(0.5)  # Sleeps for half a second
         'Started sleep at 2025-05-30 11:30:00, slept for 0.5 seconds'
     """
+    logger.warning(
+        "DEPRECATION WARNING: sleep is deprecated and will be removed in v0.9.0. "
+        "Migration path: use the sleep tool vended by strands-agents "
+        "(from strands.vended_tools import sleep)."
+    )
+
     # Validate input
     if not isinstance(seconds, (int, float)):
         raise ValueError("Sleep duration must be a number")

--- a/src/strands_tools/sleep.py
+++ b/src/strands_tools/sleep.py
@@ -41,7 +41,7 @@ def sleep(seconds: Union[int, float]) -> str:
         'Started sleep at 2025-05-30 11:30:00, slept for 0.5 seconds'
     """
     logger.warning(
-        "DEPRECATION WARNING: sleep is deprecated and will be removed in v0.9.0. "
+        "DEPRECATION WARNING: sleep is deprecated. This warning becomes an error log in v0.9.0. "
         "Migration path: use the sleep tool vended by strands-agents "
         "(from strands.vended_tools import sleep)."
     )

--- a/src/strands_tools/sleep.py
+++ b/src/strands_tools/sleep.py
@@ -5,14 +5,25 @@ from datetime import datetime
 from typing import Union
 
 from strands import tool
+from typing_extensions import deprecated
 
 logger = logging.getLogger(__name__)
 
 # Default maximum sleep time (5 minutes)
 max_sleep_seconds = int(os.environ.get("MAX_SLEEP_SECONDS", "300"))
 
+_DEPRECATION_MESSAGE = (
+    "sleep is deprecated. This warning becomes an error log in v0.9.0. "
+    "Migration path: use the sleep tool vended by strands-agents "
+    "(from strands.vended_tools import sleep)."
+)
 
+
+# @deprecated surfaces in IDEs and type checkers; the logger.warning below is what
+# users actually see, since DeprecationWarning raised from inside the SDK's tool
+# invocation path is suppressed by Python's default warning filter.
 @tool
+@deprecated(_DEPRECATION_MESSAGE)
 def sleep(seconds: Union[int, float]) -> str:
     """
     Pause execution for the specified number of seconds.
@@ -40,11 +51,7 @@ def sleep(seconds: Union[int, float]) -> str:
         >>> sleep(0.5)  # Sleeps for half a second
         'Started sleep at 2025-05-30 11:30:00, slept for 0.5 seconds'
     """
-    logger.warning(
-        "DEPRECATION WARNING: sleep is deprecated. This warning becomes an error log in v0.9.0. "
-        "Migration path: use the sleep tool vended by strands-agents "
-        "(from strands.vended_tools import sleep)."
-    )
+    logger.warning("DEPRECATION WARNING: %s", _DEPRECATION_MESSAGE)
 
     # Validate input
     if not isinstance(seconds, (int, float)):

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -490,5 +490,5 @@ def test_editor_logs_deprecation_warning(caplog, temp_dir):
         editor.editor(command="create", path=test_file, file_text="content")
 
     assert "DEPRECATION WARNING" in caplog.text
-    assert "removed in v0.9.0" in caplog.text
+    assert "becomes an error log in v0.9.0" in caplog.text
     assert "strands.vended_tools import file_editor" in caplog.text

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -492,3 +492,9 @@ def test_editor_logs_deprecation_warning(caplog, temp_dir):
     assert "DEPRECATION WARNING" in caplog.text
     assert "becomes an error log in v0.9.0" in caplog.text
     assert "strands.vended_tools import file_editor" in caplog.text
+
+
+def test_editor_is_marked_deprecated_for_static_analysis():
+    """The @deprecated marker lets type checkers and IDEs flag callers."""
+    assert getattr(editor.editor, "__deprecated__", None) is not None
+    assert "strands.vended_tools import file_editor" in editor.editor.__deprecated__

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -478,3 +478,17 @@ def test_format_directory_tree_content(mock_console_util, temp_dir):
     # Since the string representation might vary, just verify the basic object structure
     # The Rich Tree will have format method
     assert hasattr(tree, "label") or hasattr(tree, "render")
+
+
+def test_editor_logs_deprecation_warning(caplog, temp_dir):
+    """Test that editor logs a deprecation warning naming the SDK replacement."""
+    import logging
+
+    test_file = os.path.join(temp_dir, "deprecation.txt")
+
+    with caplog.at_level(logging.WARNING, logger="strands_tools.editor"):
+        editor.editor(command="create", path=test_file, file_text="content")
+
+    assert "DEPRECATION WARNING" in caplog.text
+    assert "removed in v0.9.0" in caplog.text
+    assert "strands.vended_tools import file_editor" in caplog.text

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -979,3 +979,13 @@ def test_shell_exception_ui_output(mock_execute_commands, mock_get_user_input, m
         assert mock_console.print.call_count == 0
 
 
+def test_shell_logs_deprecation_warning(caplog):
+    """Test that shell logs a deprecation warning naming the SDK replacement."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="strands_tools.shell"):
+        shell.shell("echo test")
+
+    assert "DEPRECATION WARNING" in caplog.text
+    assert "removed in v0.9.0" in caplog.text
+    assert "strands.vended_tools import shell" in caplog.text

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -989,3 +989,9 @@ def test_shell_logs_deprecation_warning(caplog):
     assert "DEPRECATION WARNING" in caplog.text
     assert "becomes an error log in v0.9.0" in caplog.text
     assert "strands.vended_tools import shell" in caplog.text
+
+
+def test_shell_is_marked_deprecated_for_static_analysis():
+    """The @deprecated marker lets type checkers and IDEs flag callers."""
+    assert getattr(shell.shell, "__deprecated__", None) is not None
+    assert "strands.vended_tools import shell" in shell.shell.__deprecated__

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -987,5 +987,5 @@ def test_shell_logs_deprecation_warning(caplog):
         shell.shell("echo test")
 
     assert "DEPRECATION WARNING" in caplog.text
-    assert "removed in v0.9.0" in caplog.text
+    assert "becomes an error log in v0.9.0" in caplog.text
     assert "strands.vended_tools import shell" in caplog.text

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -92,5 +92,5 @@ def test_sleep_logs_deprecation_warning(caplog):
         sleep.sleep(0.01)
 
     assert "DEPRECATION WARNING" in caplog.text
-    assert "removed in v0.9.0" in caplog.text
+    assert "becomes an error log in v0.9.0" in caplog.text
     assert "strands.vended_tools import sleep" in caplog.text

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -79,3 +79,18 @@ def test_sleep_exceeds_max(agent):
 
         # Verify the error message
         assert "cannot exceed 10 seconds" in result_text
+
+
+def test_sleep_logs_deprecation_warning(caplog):
+    """Test that sleep logs a deprecation warning naming the SDK replacement."""
+    import importlib
+    import logging
+
+    importlib.reload(sleep)
+
+    with caplog.at_level(logging.WARNING, logger="strands_tools.sleep"):
+        sleep.sleep(0.01)
+
+    assert "DEPRECATION WARNING" in caplog.text
+    assert "removed in v0.9.0" in caplog.text
+    assert "strands.vended_tools import sleep" in caplog.text

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -94,3 +94,9 @@ def test_sleep_logs_deprecation_warning(caplog):
     assert "DEPRECATION WARNING" in caplog.text
     assert "becomes an error log in v0.9.0" in caplog.text
     assert "strands.vended_tools import sleep" in caplog.text
+
+
+def test_sleep_is_marked_deprecated_for_static_analysis():
+    """The @deprecated marker lets type checkers and IDEs flag callers."""
+    assert getattr(sleep.sleep, "__deprecated__", None) is not None
+    assert "strands.vended_tools import sleep" in sleep.sleep.__deprecated__


### PR DESCRIPTION
## Description

The Strands SDK now vends equivalents of `sleep`, `editor`, and `shell` from `strands.vended_tools`. Maintaining both implementations invites drift, where a fix applied in one place silently does not apply in the other. This adds a deprecation warning to each tool pointing at its SDK replacement, and documents the migration in the README.

Each tool logs a warning on invocation, so users get the signal at the point of use rather than only in release notes. This follows the existing precedent in `use_llm.py` and `agent_graph.py` rather than `DeprecationWarning`, which would break consumers running with `-W error`.

| Tool | Replacement | Warning | Error log |
|------|-------------|---------|-----------|
| `sleep` | `strands.vended_tools.sleep` | v0.8.6 | v0.9.0 |
| `editor` | `strands.vended_tools.file_editor` | v0.8.6 | v0.9.0 |
| `shell` | `strands.vended_tools.shell` | v0.8.6 | v0.9.0 |

**The tools are not removed.** In v0.9.0 the same message is logged at `error` level instead of `warning` — a louder signal for anyone who has not migrated, with no behavior change. These tools are the first of an incremental set of deprecations that ends with this repository being archived, so deleting them in 0.9.0 would break users mid-migration and hand them an `ImportError` with no hint about where the replacement lives. The README states the archive plan so users can decide whether to migrate early.

### Scope notes

The replacements are not drop-in equivalents, so the README states the gaps rather than implying a clean swap: the SDK `shell` is stateless and sandbox-routed with no PTY or command batching; `file_editor` lacks `pattern_replace`/`find_line`/`undo_edit`; and SDK `sleep` configures its cap via `make_sleep(max_duration=...)` instead of `MAX_SLEEP_SECONDS`.

**`http_request` is deliberately excluded.** The SDK version is a thin httpx shim without HTML-to-markdown conversion, so deprecating it now would point users at a replacement that does not cover their use case. It should be revisited once `web_fetch` (harness-sdk #3375) merges and ships.

### Dependency

The `shell` migration message names `strands.vended_tools.shell`, which does not exist yet — the SDK tool is currently called `bash`. That name is inaccurate: it delegates to `Sandbox.execute()`, which runs `sh -c` in the Docker and local sandboxes and the remote login shell over SSH, so it invokes whichever shell the sandbox provides rather than bash specifically. A companion PR renaming it to `shell` is required before this ships in a release. If that rename is rejected or lands under a different name, the message here needs updating first.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

Other (please describe): Deprecation of existing tools superseded by the SDK

## Testing

Added three `caplog`-based tests asserting each tool logs its warning and names the correct replacement. Also verified end-to-end that the warnings fire through the real `agent.tool.*` path, not just direct function calls:

```
strands_tools.sleep: DEPRECATION WARNING: sleep is deprecated. This warning becomes an error log in v0.9.0. ...
strands_tools.editor: DEPRECATION WARNING: editor is deprecated. This warning becomes an error log in v0.9.0. ...
strands_tools.shell: DEPRECATION WARNING: shell is deprecated. This warning becomes an error log in v0.9.0. ...
```

The warning is placed before any early return in each tool, so it fires on every invocation including error paths.

- [x] I ran `hatch run prepare`

Result: 1285 passed, 1 failed. The failure is `tests/test_agent_core_memory.py::test_initialization`, which is pre-existing on `main` and unrelated to this change (it asserts a hardcoded region against the local `AWS_REGION`). `tests/test_shell.py::test_command_executor_execute_with_pty` also terminates the pytest process locally; likewise reproduced on a clean `main` checkout.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Note on the last two items: this change intentionally *adds* deprecation warnings, which is its purpose; it introduces no unintended ones. The dependent SDK rename described above is not yet merged.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
