### PR TITLE
fix: gate side-effecting AWS actions behind use_aws consent prompt

### DIFF
--- a/src/strands_tools/use_aws.py
+++ b/src/strands_tools/use_aws.py
@@ -111,6 +111,11 @@ MUTATIVE_OPERATIONS = [
     "cancel",
     "reboot",
     "accept",
+    "send",
+    "invoke",
+    "run",
+    "execute",
+    "publish",
 ]
 
 # Operations that return credentials or secrets and require user consent

--- a/tests/test_use_aws.py
+++ b/tests/test_use_aws.py
@@ -275,6 +275,49 @@ def test_use_aws_mutative_operation_confirm(
         assert result["status"] == "success"
 
 
+@pytest.mark.parametrize(
+    "service_name, operation_name",
+    [
+        ("ses", "send_email"),
+        ("sqs", "send_message"),
+        ("lambda", "invoke"),
+        ("ec2", "run_instances"),
+        ("rds-data", "execute_statement"),
+        ("sns", "publish"),
+    ],
+)
+@patch("strands_tools.use_aws.get_available_operations")
+@patch("strands_tools.use_aws.get_user_input")
+def test_use_aws_side_effecting_action_requires_consent(
+    mock_user_input,
+    mock_get_available_operations,
+    mock_boto3_client,
+    mock_available_services,
+    service_name,
+    operation_name,
+):
+    """Side-effecting action classes (send/invoke/run/execute/publish) require confirmation."""
+    mock_user_input.return_value = "y"
+    mock_get_available_operations.return_value = [operation_name]
+
+    with patch.dict("os.environ", {"BYPASS_TOOL_CONSENT": "false"}):
+        tool_use = {
+            "toolUseId": "test-tool-use-id",
+            "input": {
+                "service_name": service_name,
+                "operation_name": operation_name,
+                "parameters": {},
+                "region": "us-west-2",
+                "label": "Side-effecting Operation Test",
+            },
+        }
+
+        use_aws.use_aws(tool=tool_use)
+
+        # Verify the consent gate prompted the user before executing.
+        mock_user_input.assert_called_once()
+
+
 @patch("strands_tools.use_aws.get_user_input")
 def test_use_aws_mutative_operation_cancel(
     mock_user_input,


### PR DESCRIPTION
The `use_aws` consent gate (`MUTATIVE_OPERATIONS`) did not cover the `send`/`invoke`/`run`/`execute`/`publish` action classes, so operations such as `ses.send_email`, `lambda.invoke`, `ec2.run_instances`, `rds-data.execute_statement`, and `sns.publish` executed with no confirmation prompt.

## Changes
- Add `send`, `invoke`, `run`, `execute`, `publish` to `MUTATIVE_OPERATIONS` so these operations trigger the consent prompt (unless `BYPASS_TOOL_CONSENT=true`).
- Add a parametrized test covering one operation from each new action class.

The gate matches verbs as substrings and fails safe (a spurious prompt is harmless; a missed one is the vulnerability), consistent with the existing verbs.