### PR TITLE
fix(calculator): reject cls= reroute in symbols()

### DIFF
--- a/src/strands_tools/calculator.py
+++ b/src/strands_tools/calculator.py
@@ -20,6 +20,11 @@ Security:
     name or numeric literal rather than through sympify (Symbol, symbols, Rational,
     Integer, Float); for example Symbol('x') and Rational('1/3') remain supported.
 
+    A string positional argument to those constructors is trusted only when the call
+    carries nothing but boolean assumption keywords (for example Symbol('x', positive=True)).
+    A keyword that reroutes parsing, most importantly symbols('...', cls=N), is rejected,
+    because cls=N makes symbols apply N (and therefore sympify) to the string.
+
 Key Features:
 1. Expression Evaluation:
    • Basic arithmetic operations (addition, multiplication, etc.)
@@ -292,6 +297,27 @@ _ALLOWED_AST_NODES = {
 _STRING_ARG_CONSTRUCTORS = frozenset({"Symbol", "symbols", "Rational", "Integer", "Float"})
 
 
+def _has_only_assumption_keywords(call: ast.Call) -> bool:
+    """Return True if every keyword on `call` is a boolean assumption flag.
+
+    The safe string constructors accept assumption keywords such as
+    `Symbol('x', positive=True)`, whose values are always boolean literals and never
+    change how the string argument is parsed. A keyword whose value is not a boolean
+    literal makes the call untrusted for the purpose of allowing string-literal
+    arguments. The important case is `symbols('...', cls=N)`: the `cls` keyword
+    reroutes `symbols` to apply an arbitrary constructor (for example `N`) to the
+    string, which re-parses it through sympify and escapes the restricted namespace.
+    `**kwargs` unpacking (`kw.arg is None`) can smuggle such a keyword in, so it is
+    treated as untrusted too.
+    """
+    for kw in call.keywords:
+        if kw.arg is None:
+            return False
+        if not (isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, bool)):
+            return False
+    return True
+
+
 def _validate_expression_ast(expr_str: str) -> None:
     """Reject expressions containing attribute access, subscripts, or other unsafe syntax.
 
@@ -318,6 +344,12 @@ def _validate_expression_ast(expr_str: str) -> None:
     allowed_string_nodes: set[int] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in _STRING_ARG_CONSTRUCTORS:
+            # A rerouting keyword such as cls=N turns symbols('...') into N('...'),
+            # which re-parses the string through sympify and escapes the sandbox. Only
+            # trust the positional string args when the call carries nothing but boolean
+            # assumption keywords (positive=True, real=True, ...).
+            if not _has_only_assumption_keywords(node):
+                continue
             for arg in node.args:
                 if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
                     allowed_string_nodes.add(id(arg))

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -11,6 +11,7 @@ from sympy import Integer, Symbol, exp, log
 
 # Function level imports from calculator module
 from src.strands_tools.calculator import (
+    _validate_expression_ast,
     apply_symbolic_simplifications,
     calculate_derivative,
     calculate_integral,
@@ -765,6 +766,50 @@ def test_ast_validation_rejects_non_positional_and_bytes_literals(payload):
     """Keyword-position strings and bytes literals stay rejected by the allowlist."""
     with pytest.raises(ValueError, match="Invalid mathematical expression"):
         parse_expression(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # cls=N reroutes symbols() to apply N() -> sympify() to the string, which is
+        # the reported sandbox-bypass RCE vector. The string positional arg must not
+        # be trusted when such a rerouting keyword is present.
+        "symbols(\"__import__('os').system('id')\",cls=N)",
+        "symbols('sqrt(16)', cls=N)",
+        "symbols('x', cls=simplify)",
+        "Symbol('x', cls=N)",
+        # ** unpacking could smuggle a cls= keyword in, so it is untrusted too.
+        "symbols('x', **{'cls': N})",
+    ],
+)
+def test_ast_validation_rejects_cls_reroute(payload):
+    """A rerouting keyword (cls=) on a string constructor rejects its string args."""
+    with pytest.raises(ValueError, match="Invalid mathematical expression"):
+        parse_expression(payload)
+
+
+def test_cls_reroute_does_not_execute():
+    """The symbols('...', cls=N) bypass must be blocked before any code runs."""
+    payload = "symbols(\"__import__('os').getpid()\",cls=N)"
+    with mock.patch("os.getpid") as mock_getpid:
+        with pytest.raises(ValueError, match="Invalid mathematical expression"):
+            parse_expression(payload)
+        mock_getpid.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        # Boolean assumption keywords never reroute parsing, so the string positional
+        # arg stays trusted by the AST validator (it is not rejected as a string literal).
+        "Symbol('x', positive=True)",
+        "Symbol('x', real=True)",
+        "symbols('x y', positive=True)",
+    ],
+)
+def test_string_constructor_assumption_keywords_pass_validation(expression):
+    """Assumption keywords keep the string positional arg trusted during validation."""
+    _validate_expression_ast(expression)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

The calculator tool validates every expression against an AST allowlist before evaluation. The validator trusted a string literal whenever it appeared as a positional argument to a safe string constructor (`Symbol`, `symbols`, `Rational`, `Integer`, `Float`), but it never inspected the call's keyword arguments.

`symbols()` accepts a keyword-only `cls=` argument that changes which constructor it applies to the parsed name. Passing `cls=N` turns `symbols("<expr>", cls=N)` into `N("<expr>")`, which re-parses the string through SymPy's `sympify`. `sympify` evaluates with full builtins, so a crafted string escapes the restricted namespace and runs arbitrary code on the host.

This expression passed validation and executed before the fix:

```
symbols("<payload>", cls=N)
```

## Fix

A string positional argument is now trusted only when every keyword on the call is a boolean assumption flag (for example `positive=True`, `real=True`) and there is no `**kwargs` unpacking. Any other keyword value, including `cls=<constructor>`, drops the call out of the trusted set, so its string literals are rejected with the existing validation error.

This closes the `cls=` route and any other keyword that could reroute string parsing into `sympify`, while keeping the documented usage working: `Symbol('x')`, `symbols('x y')`, `Rational('1/3')`, and assumption keywords like `Symbol('x', positive=True)`.

## Tests

- Reject the `cls=` reroute, including a mock that confirms no code executes.
- Confirm assumption keywords still pass validation.
- All existing calculator tests remain green.

## Note

The calculator tool is deprecated, but it is still shipped and executable in current releases, so the vulnerable code path remains reachable until users migrate off it. This patch protects those users; it is independent of the deprecation.
