### PR TITLE
fix(mem0): make memory_id ownership check fail-closed 

### DIFF
--- a/src/strands_tools/mem0_memory.py
+++ b/src/strands_tools/mem0_memory.py
@@ -886,9 +886,10 @@ def _execute_mem0_memory(
                 if not tool_input.get("memory_id"):
                     raise ValueError("memory_id is required for delete action")
 
-                # Try to get memory info first for better context
+                # Verify ownership before showing any preview details
                 try:
                     memory = client.get_memory(tool_input["memory_id"])
+                    _verify_memory_ownership(memory, user_id, agent_id)
                     metadata = memory.get("metadata", {})
 
                     console.print(
@@ -901,8 +902,9 @@ def _execute_mem0_memory(
                             border_style="red",
                         )
                     )
+                except ValueError:
+                    raise
                 except Exception:
-                    # Fall back to basic info if we can't get memory details
                     console.print(
                         Panel(
                             f"Memory ID: {tool_input['memory_id']}",
@@ -916,11 +918,19 @@ def _execute_mem0_memory(
             if not tool_input.get("content"):
                 raise ValueError("content is required for store action")
 
+            metadata = tool_input.get("metadata")
+            if metadata and isinstance(metadata, dict):
+                metadata = {
+                    k: v
+                    for k, v in metadata.items()
+                    if k not in ("user_id", "agent_id", "run_id", "app_id", "org_id")
+                }
+
             results = client.store_memory(
                 tool_input["content"],
                 user_id,
                 agent_id,
-                tool_input.get("metadata"),
+                metadata,
             )
 
             # Normalize to list
@@ -1008,14 +1018,8 @@ def _execute_mem0_memory(
             if not tool_input.get("memory_id"):
                 raise ValueError("memory_id is required for delete action")
 
-            # Verify ownership before deleting
-            try:
-                memory = client.get_memory(tool_input["memory_id"])
-                _verify_memory_ownership(memory, user_id, agent_id)
-            except ValueError:
-                raise  # Re-raise ownership errors
-            except Exception:
-                pass  # If we can't fetch for verification, allow the delete (backend may enforce)
+            memory = client.get_memory(tool_input["memory_id"])
+            _verify_memory_ownership(memory, user_id, agent_id)
 
             client.delete_memory(tool_input["memory_id"])
             panel = format_delete_response(tool_input["memory_id"])
@@ -1030,14 +1034,8 @@ def _execute_mem0_memory(
             if not tool_input.get("memory_id"):
                 raise ValueError("memory_id is required for history action")
 
-            # Verify ownership before returning history
-            try:
-                memory = client.get_memory(tool_input["memory_id"])
-                _verify_memory_ownership(memory, user_id, agent_id)
-            except ValueError:
-                raise  # Re-raise ownership errors
-            except Exception:
-                pass  # If we can't fetch for verification, allow (backend may enforce)
+            memory = client.get_memory(tool_input["memory_id"])
+            _verify_memory_ownership(memory, user_id, agent_id)
 
             history = client.get_memory_history(tool_input["memory_id"])
             panel = format_history_response(history)
@@ -1062,9 +1060,7 @@ def _execute_mem0_memory(
 def _verify_memory_ownership(memory: Dict, user_id: Optional[str], agent_id: Optional[str]) -> None:
     """Verify that a retrieved memory belongs to the bound principal.
 
-    This is a defense-in-depth check for ``get``, ``delete``, and ``history``
-    operations which take a raw ``memory_id``. If the backend returns ownership
-    metadata, we validate it matches the bound principal.
+    Fail-closed: if ownership cannot be positively confirmed, access is denied.
 
     Args:
         memory: The memory record returned by the backend.
@@ -1072,20 +1068,30 @@ def _verify_memory_ownership(memory: Dict, user_id: Optional[str], agent_id: Opt
         agent_id: The bound agent_id (or None).
 
     Raises:
-        ValueError: If the memory belongs to a different principal.
+        ValueError: If ownership cannot be confirmed or the memory belongs to a different principal.
     """
     if not memory or not isinstance(memory, dict):
-        return
+        raise ValueError("Access denied")
+
+    if not user_id and not agent_id:
+        raise ValueError("Access denied")
 
     mem_user = memory.get("user_id")
     mem_agent = memory.get("agent_id")
 
-    # If backend doesn't return ownership info, we can't verify (rely on backend ACLs)
     if not mem_user and not mem_agent:
-        return
+        raise ValueError("Access denied")
 
-    # Check ownership
     if user_id and mem_user and mem_user != user_id:
-        raise ValueError("Access denied: memory belongs to a different user")
+        raise ValueError("Access denied")
     if agent_id and mem_agent and mem_agent != agent_id:
-        raise ValueError("Access denied: memory belongs to a different agent")
+        raise ValueError("Access denied")
+
+    # Fail-closed: at least one of the bound principal's IDs must positively match
+    matched = False
+    if user_id and mem_user and mem_user == user_id:
+        matched = True
+    if agent_id and mem_agent and mem_agent == agent_id:
+        matched = True
+    if not matched:
+        raise ValueError("Access denied")

--- a/tests/test_mem0.py
+++ b/tests/test_mem0.py
@@ -411,6 +411,282 @@ def test_delete_denies_cross_tenant(mock_opensearch, mock_mem0_client, mock_mem0
     mock_mem0_service_client.delete_memory.assert_not_called()
 
 
+@patch.dict(
+    os.environ,
+    {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"},
+)
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_delete_confirmation_preview_denies_cross_tenant(
+    mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool
+):
+    """Delete confirmation preview must not leak cross-tenant metadata.
+
+    When BYPASS_TOOL_CONSENT is not set, the delete path fetches the memory
+    for a preview dialog. This preview must enforce ownership before displaying
+    any metadata.
+    """
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    mock_mem0_service_client.get_memory.return_value = {
+        "id": "mem123",
+        "user_id": "other_user",
+        "metadata": {"secret_tag": "confidential"},
+    }
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "delete", "memory_id": "mem123"},
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    assert "Access denied" in result["content"][0]["text"]
+    mock_mem0_service_client.delete_memory.assert_not_called()
+
+
+@patch.dict(
+    os.environ,
+    {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"},
+)
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_history_denies_cross_tenant(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """Test history denies access to a memory owned by a different tenant."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    mock_mem0_service_client.get_memory.return_value = {"id": "mem123", "user_id": "other_user"}
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "history", "memory_id": "mem123"},
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    assert "Access denied" in result["content"][0]["text"]
+    mock_mem0_service_client.get_memory_history.assert_not_called()
+
+
+@patch.dict(os.environ, {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_get_denies_when_no_ownership_metadata(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """get must deny access when backend returns a memory with no user_id/agent_id."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    mock_mem0_service_client.get_memory.return_value = {"id": "mem123", "memory": "content"}
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "get", "memory_id": "mem123"},
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    assert "Access denied" in result["content"][0]["text"]
+
+
+@patch.dict(
+    os.environ,
+    {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com", "BYPASS_TOOL_CONSENT": "true"},
+)
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_delete_denies_when_no_ownership_metadata(
+    mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool
+):
+    """delete must deny when ownership cannot be verified due to missing metadata."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    mock_mem0_service_client.get_memory.return_value = {"id": "mem123", "memory": "content"}
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "delete", "memory_id": "mem123"},
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    assert "Access denied" in result["content"][0]["text"]
+    mock_mem0_service_client.delete_memory.assert_not_called()
+
+
+@patch.dict(os.environ, {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_history_denies_when_no_ownership_metadata(
+    mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool
+):
+    """history must deny when ownership cannot be verified due to missing metadata."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    mock_mem0_service_client.get_memory.return_value = {"id": "mem123", "memory": "content"}
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "history", "memory_id": "mem123"},
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    assert "Access denied" in result["content"][0]["text"]
+    mock_mem0_service_client.get_memory_history.assert_not_called()
+
+
+@patch.dict(
+    os.environ,
+    {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com", "BYPASS_TOOL_CONSENT": "true"},
+)
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_delete_denies_when_prefetch_raises(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """delete must NOT proceed if the ownership pre-check get_memory() raises."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    mock_mem0_service_client.get_memory.side_effect = ConnectionError("network timeout")
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "delete", "memory_id": "mem123"},
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    mock_mem0_service_client.delete_memory.assert_not_called()
+
+
+@patch.dict(os.environ, {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_history_denies_when_prefetch_raises(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """history must NOT proceed if the ownership pre-check get_memory() raises."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    mock_mem0_service_client.get_memory.side_effect = RuntimeError("backend unavailable")
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "history", "memory_id": "mem123"},
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    mock_mem0_service_client.get_memory_history.assert_not_called()
+
+
+@patch.dict(
+    os.environ,
+    {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com", "BYPASS_TOOL_CONSENT": "true"},
+)
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_store_strips_identity_keys_from_metadata(
+    mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool
+):
+    """store must strip identity keys from LLM-supplied metadata."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+    mock_mem0_service_client.store_memory.return_value = [
+        {"event": "store", "id": "mem1", "memory": "some content"}
+    ]
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {
+            "action": "store",
+            "content": "some content",
+            "metadata": {
+                "user_id": "injected_victim",
+                "agent_id": "injected_agent",
+                "org_id": "injected_org",
+                "safe_key": "safe_value",
+            },
+        },
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "success"
+    call_args = mock_mem0_service_client.store_memory.call_args
+    passed_metadata = call_args[0][3] if len(call_args[0]) > 3 else call_args[1].get("metadata")
+    assert "user_id" not in passed_metadata
+    assert "agent_id" not in passed_metadata
+    assert "org_id" not in passed_metadata
+    assert passed_metadata["safe_key"] == "safe_value"
+
+
+@patch.dict(os.environ, {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_get_denies_when_memory_is_none(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """get must deny when backend returns None for the memory."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    mock_mem0_service_client.get_memory.return_value = None
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "get", "memory_id": "mem123"},
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    assert "Access denied" in result["content"][0]["text"]
+
+
+@patch.dict(os.environ, {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_get_denies_when_memory_is_empty_dict(mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool):
+    """get must deny when backend returns empty dict."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    mock_mem0_service_client.get_memory.return_value = {}
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "get", "memory_id": "mem123"},
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "error"
+    assert "Access denied" in result["content"][0]["text"]
+
+
+@patch.dict(os.environ, {"MEM0_USER_ID": "bound_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
+@patch("strands_tools.mem0_memory.Mem0ServiceClient")
+@patch("opensearchpy.OpenSearch")
+def test_history_succeeds_when_ownership_matches(
+    mock_opensearch, mock_mem0_client, mock_mem0_service_client, mock_tool
+):
+    """Sanity check: history works when memory's user_id matches bound user."""
+    mock_mem0_client.return_value = mock_mem0_service_client
+
+    mock_mem0_service_client.get_memory.return_value = {"id": "mem123", "user_id": "bound_user"}
+    mock_mem0_service_client.get_memory_history.return_value = [
+        {"id": "hist1", "memory_id": "mem123", "event": "store", "new_memory": "content"}
+    ]
+
+    mock_tool.get.side_effect = lambda key, default=None: {
+        "toolUseId": "test-id",
+        "input": {"action": "history", "memory_id": "mem123"},
+    }.get(key, default)
+
+    result = mem0_memory.mem0_memory(tool=mock_tool)
+
+    assert result["status"] == "success"
+    mock_mem0_service_client.get_memory_history.assert_called_once_with("mem123")
+
+
 @patch.dict(os.environ, {"MEM0_USER_ID": "test_user", "OPENSEARCH_HOST": "test.opensearch.amazonaws.com"})
 @patch("strands_tools.mem0_memory.Mem0ServiceClient")
 @patch("opensearchpy.OpenSearch")


### PR DESCRIPTION
## Description

Makes the mem0_memory ownership check fail-closed for get/delete/history operations that take a raw `memory_id`. Previously the check silently allowed access when ownership couldn't be confirmed. Now at least one bound principal ID must positively match the memory record, or the operation is denied.

- Require positive ownership match in `_verify_memory_ownership`
- Remove `except Exception: pass` on delete/history pre-checks
- Move ownership check before delete confirmation preview
- Strip identity keys from LLM-controllable metadata
- Unify denial messages to a single "Access denied"

## Type of Change

Bug fix

## Testing

- 14 new unit tests covering cross-tenant denial, missing metadata, prefetch failures, and metadata sanitization
- All 36 tests pass (`pytest tests/test_mem0.py`)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.